### PR TITLE
Fix the clickable area from DialogTrigger component

### DIFF
--- a/src/system/Dialog/DialogTrigger.js
+++ b/src/system/Dialog/DialogTrigger.js
@@ -1,7 +1,9 @@
 /**
- * External dependencies
+ * Internal dependencies
  */
 
-const DialogTrigger = props => <div {...props} />;
+import { Box } from '../';
+
+const DialogTrigger = props => <Box sx={{ display: 'inline' }} {...props} />;
 
 export { DialogTrigger };


### PR DESCRIPTION
## Description

It Fixes the clickable area of the DialogTrigger. 

DialogTrigger wrapper is allowing the trigger element to have no boundaries when clicking. This small fix makes the trigger more flexible by using an inline approach in the DialogTrigger wrapper.

https://vipjira.atlassian.net/browse/PIE-2853
