### PR TITLE
Improves Notice component to handle alignment and dark mode

### DIFF
--- a/src/system/Notice/Notice.js
+++ b/src/system/Notice/Notice.js
@@ -1,68 +1,77 @@
 /**
  * External dependencies
  */
- import PropTypes from 'prop-types';
- import { MdError, MdWarning, MdCheckCircle, MdInfo } from 'react-icons/md';
- 
- /**
-  * Internal dependencies
-  */
- import { Box, Flex, Heading, Card } from '../';
- 
- const Notice = ( { variant = 'warning', inline = false, children, title, ...props } ) => {
-	 let color = 'yellow';
-	 let Icon = MdWarning;
- 
-	 switch ( variant ) {
-		 case 'info':
-			 color = 'blue';
-			 Icon = MdInfo;
-			 break;
-		 case 'alert':
-			 color = 'red';
-			 Icon = MdError;
-			 break;
-		 case 'success':
-			 color = 'green';
-			 Icon = MdCheckCircle;
-			 break;
-	 }
- 
-	 return (
-		 <Card
-			 sx={ {
-				 boxShadow: 'none',
-				 borderRadius: 2,
-				 bg: inline ? 'transparent' : `${ color }.0`,
-				 p: inline ? 0 : 3,
-				 a: {
-					 textDecoration: 'underline',
-					 border: 'none',
-				 },
-			 } }
-			 { ...props }
-		 >
-			 <Box>
-				 <Flex>
-					 <Icon sx={ { marginRight: 2, color: `${ color }.70`, mt: 1, flex: '0 0 auto' } }/>
-					 <Heading variant="h4" as="p" sx={ { color: `${ color }.70`, mb: 0 } }>{ title }</Heading>
-				 </Flex>
-				 { children &&
-					 <Box sx={ { mt: 1, ml: 23 } }>
-						 { children }
-					 </Box>
-				 }
-			 </Box>
- 
-		 </Card>
-	 );
- };
- 
- Notice.propTypes = {
-	 variant: PropTypes.string,
-	 title: PropTypes.string,
-	 inline: PropTypes.inline,
-	 children: PropTypes.array,
- };
- 
- export { Notice };
+import PropTypes from 'prop-types';
+import { MdError, MdWarning, MdCheckCircle, MdInfo } from 'react-icons/md';
+
+/**
+* Internal dependencies
+*/
+import { Box, Flex, Heading, Card } from '../';
+
+const Notice = ( { variant = 'warning', inline = false, children, title, ...props } ) => {
+	let color = 'yellow';
+	let Icon = MdWarning;
+
+	switch ( variant ) {
+		case 'info':
+			color = 'blue';
+			Icon = MdInfo;
+			break;
+		case 'alert':
+			color = 'red';
+			Icon = MdError;
+			break;
+		case 'success':
+			color = 'green';
+			Icon = MdCheckCircle;
+			break;
+	}
+
+	const NoticeIcon = ({ color }) => (
+		<Icon sx={ { marginRight: 2, color: `${ color }.70`, flex: '0 0 auto' } }/>
+	);
+
+	return (
+		<Card
+			sx={ {
+				boxShadow: 'none',
+				borderRadius: 2,
+				bg: inline ? 'transparent' : `${ color }.0`,
+				p: inline ? 0 : 3,
+				a: {
+					color: `${ color }.70`,
+					textDecoration: 'underline',
+					border: 'none',
+				},
+			} }
+			{ ...props }
+		>
+			<Flex sx={ {
+				alignItems: 'center',
+			} }>
+				<Flex sx={ {
+					alignItems: 'center',
+				} }>
+					<NoticeIcon color={color} />
+					{ title && <Heading variant="h4" as="p" sx={ { color: `${ color }.70`, mb: 0 } }>{ title }</Heading> }
+				</Flex>
+
+				{ children &&
+					<Box sx={ { ml: 23 } }>
+						{ children }
+					</Box>
+				}
+			</Flex>
+		</Card>
+	);
+};
+
+Notice.propTypes = {
+	variant: PropTypes.string,
+	title: PropTypes.string,
+	inline: PropTypes.inline,
+	children: PropTypes.array,
+};
+
+export { Notice };

--- a/src/system/Notice/Notice.stories.js
+++ b/src/system/Notice/Notice.stories.js
@@ -5,6 +5,7 @@
 /**
  * Internal dependencies
  */
+import React from 'react';
 import { Heading, Notice, Text } from '..';
 
 export default {
@@ -13,10 +14,16 @@ export default {
 };
 
 export const Default = () => (
-	<Notice variant="alert" sx={{ mb: 4 }}>
-		<Heading variant="h4">Your site is ready to launch!</Heading>
-		<Text sx={{ mb: 0 }}>
-			It looks like you&lsquo;re ready to share your application with the world.
-		</Text>
-	</Notice>
+	<React.Fragment>
+		<Notice variant="alert" sx={{ mb: 4 }}>
+			<Heading variant="h4">Your site is ready to launch!</Heading>
+			<Text sx={{ mb: 0 }}>
+				It looks like you&lsquo;re ready to share your application with the world.
+			</Text>
+		</Notice>
+
+		<Notice variant="success" sx={{ mb: 4 }}>
+			It looks like you&lsquo;re ready to share your <a href="#">application with the world.</a>
+		</Notice>
+	</React.Fragment>
 );


### PR DESCRIPTION
# Description

Fixing some inconsistencies with alignment. When the person passes only `children` to the notice component, it stills tries to render the `<Heading>` empty. This causes a bad alignment with the rest of the content.

In this improvement, I am fixing the bad alignment with or without `title` being passed. 

I am also adding color to anchor links with 70% of the intensity. Check the screenshots below to understand the changes.

## Link colored, and alignment without the `title` prop
<img width="864" alt="Screen Shot 2021-08-25 at 10 10 34" src="https://user-images.githubusercontent.com/3402/130796497-aa74140f-4e1e-40bb-a4af-29940a07d5c8.png">

```jsx
<Notice variant="success">
  { translate(
    'Sync Complete%(lastSync)s. {{a}}Visit environment{{/a}}.',
    {
      args: {
        lastSync,
      },
      components: {
        strong: <strong />,
        // eslint-disable-next-line jsx-a11y/anchor-has-content
        a: <a href={ 'https://' + domain } target="_blank" rel="noopener noreferrer" />,
      },
    }
  ) }
</Notice>
```

## Example with `title` prop passed and children

<img width="929" alt="Screen Shot 2021-08-25 at 10 21 21" src="https://user-images.githubusercontent.com/3402/130798122-7b9ea64c-b639-4d8c-b9ce-1e2b701995e0.png">

```jsx
<Notice variant="success" title="Sync Complete">
  { translate(
    'Sync Complete%(lastSync)s. {{a}}Visit environment{{/a}}.',
    {
      args: {
        lastSync,
      },
      components: {
        strong: <strong />,
        // eslint-disable-next-line jsx-a11y/anchor-has-content
        a: <a href={ 'https://' + domain } target="_blank" rel="noopener noreferrer" />,
      },
    }
  ) }
</Notice>
```

## Example with just the `title` prop

<img width="917" alt="Screen Shot 2021-08-25 at 10 22 44" src="https://user-images.githubusercontent.com/3402/130798305-df46745e-92a2-4af5-b21b-c7d58a26290a.png">

```jsx
<Notice variant="success" title={ translate(
  'Sync Complete%(lastSync)s. {{a}}Visit environment{{/a}}.',
  {
    args: {
      lastSync,
    },
    components: {
      strong: <strong />,
      // eslint-disable-next-line jsx-a11y/anchor-has-content
      a: <a href={ 'https://' + domain } target="_blank" rel="noopener noreferrer" />,
    },
  }
) } />
```