### PR TITLE
Improve notice to support non-title props

### DIFF
--- a/src/system/Notice/Notice.js
+++ b/src/system/Notice/Notice.js
@@ -55,14 +55,12 @@ const Notice = ( { variant = 'warning', inline = false, children, title, sx = {}
 					alignItems: 'center',
 				} }>
 					<NoticeIcon color={color} />
-					{ title && <Heading variant="h4" as="p" sx={ { color: `${ color }.70`, mb: 0 } }>{ title }</Heading> }
 				</Flex>
 
-				{ children &&
-					<Box sx={ { ml: 23 } }>
-						{ children }
-					</Box>
-				}
+				<Box sx={ { ml: 23 } }>
+					{ title && <Heading variant="h4" as="p" sx={ { color: `${ color }.70`, mb: 0 } }>{ title }</Heading> }
+					{ children }
+				</Box>
 			</Flex>
 		</Card>
 	);

--- a/src/system/Notice/Notice.stories.js
+++ b/src/system/Notice/Notice.stories.js
@@ -25,5 +25,13 @@ export const Default = () => (
 		<Notice variant="success" sx={{ mb: 4 }}>
 			It looks like you&lsquo;re ready to share your <a href="#">application with the world.</a>
 		</Notice>
+
+		<Notice sx={{ mb: 4 }} title="This notice has only the title prop passed" />
+
+		<Notice variant="success" sx={{ mb: 4 }} title="You made it!">
+			<Text sx={{ mb: 0 }}>
+				This notice has a title and children
+			</Text>
+		</Notice>
 	</React.Fragment>
 );


### PR DESCRIPTION
# Description

Adding the correct fixes mentioned in the past PR #6 

<img width="746" alt="Screen Shot 2021-08-25 at 14 52 09" src="https://user-images.githubusercontent.com/3402/130840759-315b697b-dbed-4fd8-8ee9-e66ef3eaf912.png">
