### PR TITLE
Fixes notice prop type

### DIFF
--- a/src/system/Notice/Notice.js
+++ b/src/system/Notice/Notice.js
@@ -70,7 +70,7 @@ Notice.propTypes = {
 	variant: PropTypes.string,
 	title: PropTypes.string,
 	inline: PropTypes.bool,
-	children: PropTypes.array,
+	children: PropTypes.node,
 };
 
 export { Notice };


### PR DESCRIPTION
# Description

Fixes `Notice` component `children` PropType. Under the development environment, it's throwing some errors.