### PR TITLE
Fix inline select warning

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -1,12 +1,12 @@
 {
 	"name": "@automattic/vip-design-system",
-	"version": "0.5.1",
+	"version": "0.6.0",
 	"lockfileVersion": 2,
 	"requires": true,
 	"packages": {
 		"": {
 			"name": "@automattic/vip-design-system",
-			"version": "0.5.1",
+			"version": "0.6.0",
 			"dependencies": {
 				"babel-loader": "^8.2.2",
 				"framer-motion": "^3.9.1",

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
 	"name": "@automattic/vip-design-system",
-	"version": "0.5.1",
+	"version": "0.6.0",
 	"main": "build/system/index.js",
 	"scripts": {
 		"build-storybook": "build-storybook",

--- a/src/system/Form/InlineSelect.js
+++ b/src/system/Form/InlineSelect.js
@@ -85,7 +85,11 @@ const InlineSelect = ( { label, value, options, noneLabel = 'All', ...props } ) 
 
 InlineSelect.propTypes = {
 	label: PropTypes.string,
-	value: PropTypes.array,
+	// https://react-select.com/props
+	value: PropTypes.oneOfType([
+		PropTypes.array,
+		PropTypes.object,
+	]),
 	options: PropTypes.array,
 	noneLabel: PropTypes.string,
 };


### PR DESCRIPTION
# Description

The `InlineSelect` component is throwing a `warning` when the prop is something different than an array. According to `react-select`, the `value` prop can have different types.

Reference: https://react-select.com/props