### PR TITLE
Fixes the InlineSelect component warning

### DIFF
--- a/src/system/Form/InlineSelect.js
+++ b/src/system/Form/InlineSelect.js
@@ -85,7 +85,11 @@ const InlineSelect = ( { label, value, options, noneLabel = 'All', ...props } ) 
 
 InlineSelect.propTypes = {
 	label: PropTypes.string,
-	value: PropTypes.array,
+	// https://react-select.com/props
+	value: PropTypes.oneOfType([
+		PropTypes.array,
+		PropTypes.object,
+	]),
 	options: PropTypes.array,
 	noneLabel: PropTypes.string,
 };


### PR DESCRIPTION
# Description

The `InlineSelect` component is throwing a `warning` when the prop `value` is something different than an array. According to `react-select`, the `value` prop can have different types.

Reference: https://react-select.com/props