### PR TITLE
Renames title attribute to label to allow title attributes into DOM

### DIFF
--- a/src/system/OptionRow/OptionRow.js
+++ b/src/system/OptionRow/OptionRow.js
@@ -16,7 +16,7 @@ const OptionRow = ({
 	image,
 	icon,
 	badge,
-	title,
+	label,
 	inline = false,
 	subTitle,
 	body,
@@ -91,7 +91,7 @@ const OptionRow = ({
 
 			<Box sx={{ flex: '1 1 auto' }}>
 				<Heading variant="h4" sx={{ mb: subTitle || body ? 1 : 0 }}>
-					{title}
+					{label}
 					{badge && <Badge sx={{ marginLeft: 2 }}>{badge}</Badge>}
 				</Heading>
 				{subTitle && <Text sx={{ mb: 1, color: 'muted' }}>{subTitle}</Text>}
@@ -106,7 +106,7 @@ OptionRow.propTypes = {
 	image: PropTypes.oneOfType([PropTypes.string, PropTypes.node]),
 	icon: PropTypes.node,
 	badge: PropTypes.string,
-	title: PropTypes.string,
+	label: PropTypes.string,
 	inline: PropTypes.bool,
 	subTitle: PropTypes.string,
 	body: PropTypes.string,

--- a/src/system/OptionRow/OptionRow.js
+++ b/src/system/OptionRow/OptionRow.js
@@ -106,7 +106,7 @@ OptionRow.propTypes = {
 	image: PropTypes.oneOfType([PropTypes.string, PropTypes.node]),
 	icon: PropTypes.node,
 	badge: PropTypes.string,
-	label: PropTypes.string,
+	label: PropTypes.node,
 	inline: PropTypes.bool,
 	subTitle: PropTypes.string,
 	body: PropTypes.string,

--- a/src/system/OptionRow/OptionRow.stories.js
+++ b/src/system/OptionRow/OptionRow.stories.js
@@ -22,13 +22,13 @@ export const Default = () => (
 	<Box sx={{ mx: -5 }}>
 		<OptionRow
 			image={image1}
-			title="Option Row"
+			label="Option Row"
 			subTitle="Mostly used to link off to other pages."
 			as="a"
 		/>
 		<OptionRow
 			image={image2}
-			title="Option Row"
+			label="Option Row"
 			subTitle="Mostly used to link off to other pages."
 			as="a"
 		/>


### PR DESCRIPTION
Breaking change:

This PR renames the `<OptionRow>` `title` attribute to use `label`. This change will allow when using the component users to pass the `title` attribute as a DOM attribute, providing ways of accessibility.

This PR also changes the `label` prop type to `node`. This change allows the user to pass a react element.
