### PR TITLE
Add back the Timeline component

### DIFF
--- a/src/system/Timeline/index.js
+++ b/src/system/Timeline/index.js
@@ -1,0 +1,46 @@
+/** @jsxImportSource theme-ui */
+
+/**
+ * External dependencies
+ */
+import { Flex } from 'theme-ui';
+import { MdWatchLater } from 'react-icons/md';
+import PropTypes from 'prop-types';
+
+const VerticalLine = () => {
+	return (
+		<div
+			sx={ {
+				borderLeft: '2px solid',
+				borderColor: 'border',
+				height: 'calc( 50% - 16px )',
+				borderRadius: '2px',
+			} }>
+		</div>
+	);
+};
+
+const Timeline = ( { time, first = false, last = false, ...props } ) => (
+	<Flex { ...props }>
+		<Flex sx={ { flexDirection: 'column', justifyContent: 'space-evenly', alignItems: 'center' } }>
+			{ ! first && (
+				<VerticalLine />
+			) }
+			<MdWatchLater sx={ { color: 'border' } } size={ 18 }/>
+			{ ! last && (
+				<VerticalLine />
+			) }
+		</Flex>
+		<Flex sx={ { alignItems: 'center', ml: 2 } }>
+			<span>{ time }</span>
+		</Flex>
+	</Flex>
+);
+
+Timeline.propTypes = {
+	first: PropTypes.bool,
+	time: PropTypes.string,
+	last: PropTypes.bool,
+};
+
+export { Timeline };

--- a/src/system/index.js
+++ b/src/system/index.js
@@ -41,6 +41,7 @@ import { Spinner } from './Spinner';
 import { ResourceList, ResourceItem } from './ResourceList';
 import { Tooltip } from './Tooltip';
 import { Time } from './Time';
+import { Timeline } from './Timeline';
 import { Notification } from './Notification';
 import { OptionRow } from './OptionRow';
 import { Table, TableRow } from './Table';
@@ -93,6 +94,7 @@ export {
 	ToggleGroup,
 	TabItem,
 	Time,
+	Timeline,
 	Validation,
 	Wizard,
 	WizardStep,


### PR DESCRIPTION
## Description

Some recent changes #20 removed the `Timeline` component. Although `Time` is made for the new styles, some pages are not fully aligned with the North Star VIP design system.

We are putting back the `Timeline` component to keep consistency between some pages.

