### PR TITLE
Adds `npm run jest:coverage` so we can track test coverage

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,3 +1,4 @@
 node_modules
 build
 storybook-static
+coverage

--- a/package-lock.json
+++ b/package-lock.json
@@ -54,6 +54,7 @@
 				"eslint-plugin-wpcalypso": "4.1.0",
 				"immer": ">=9.0.6",
 				"jest-axe": "5.0.1",
+				"open-cli": "^7.0.1",
 				"optimize-css-assets-webpack-plugin": "^6.0.1",
 				"react-input-autosize": "^3.0.0",
 				"react-refresh": "^0.9.0",
@@ -5661,6 +5662,12 @@
 				"react": "^16.14.0 || ^17.0.0"
 			}
 		},
+		"node_modules/@tokenizer/token": {
+			"version": "0.3.0",
+			"resolved": "https://registry.npmjs.org/@tokenizer/token/-/token-0.3.0.tgz",
+			"integrity": "sha512-OvjF+z51L3ov0OyAU0duzsYuvO01PH7x4t6DJx+guahgTnBHkhJdG7soQeTSFLWN3efnHyibZ4Z8l2EuWwJN3A==",
+			"dev": true
+		},
 		"node_modules/@tootallnate/once": {
 			"version": "1.1.2",
 			"resolved": "https://registry.npmjs.org/@tootallnate/once/-/once-1.1.2.tgz",
@@ -5983,6 +5990,12 @@
 			"version": "3.0.5",
 			"resolved": "https://registry.npmjs.org/@types/minimatch/-/minimatch-3.0.5.tgz",
 			"integrity": "sha512-Klz949h02Gz2uZCMGwDUSDS1YBlTdDDgbWHi+81l29tQALUtvz4rAYi5uoVhE5Lagoq6DeqAUlbrHvW/mXDgdQ==",
+			"dev": true
+		},
+		"node_modules/@types/minimist": {
+			"version": "1.2.2",
+			"resolved": "https://registry.npmjs.org/@types/minimist/-/minimist-1.2.2.tgz",
+			"integrity": "sha512-jhuKLIRrhvCPLqwPcx6INqmKeiA5EWrsCOPhrlFSrbrmU4ZMPjj5Ul/oLCMDO98XRUIwVm78xICz4EPCektzeQ==",
 			"dev": true
 		},
 		"node_modules/@types/node": {
@@ -9528,6 +9541,48 @@
 				"node": ">=6"
 			}
 		},
+		"node_modules/camelcase-keys": {
+			"version": "7.0.1",
+			"resolved": "https://registry.npmjs.org/camelcase-keys/-/camelcase-keys-7.0.1.tgz",
+			"integrity": "sha512-P331lEls98pW8JLyodNWfzuz91BEDVA4VpW2/SwXnyv2K495tq1N777xzDbFgnEigfA7UIY0xa6PwR/H9jijjA==",
+			"dev": true,
+			"dependencies": {
+				"camelcase": "^6.2.0",
+				"map-obj": "^4.1.0",
+				"quick-lru": "^5.1.1",
+				"type-fest": "^1.2.1"
+			},
+			"engines": {
+				"node": ">=12"
+			},
+			"funding": {
+				"url": "https://github.com/sponsors/sindresorhus"
+			}
+		},
+		"node_modules/camelcase-keys/node_modules/camelcase": {
+			"version": "6.2.1",
+			"resolved": "https://registry.npmjs.org/camelcase/-/camelcase-6.2.1.tgz",
+			"integrity": "sha512-tVI4q5jjFV5CavAU8DXfza/TJcZutVKo/5Foskmsqcm0MsL91moHvwiGNnqaa2o6PF/7yT5ikDRcVcl8Rj6LCA==",
+			"dev": true,
+			"engines": {
+				"node": ">=10"
+			},
+			"funding": {
+				"url": "https://github.com/sponsors/sindresorhus"
+			}
+		},
+		"node_modules/camelcase-keys/node_modules/type-fest": {
+			"version": "1.4.0",
+			"resolved": "https://registry.npmjs.org/type-fest/-/type-fest-1.4.0.tgz",
+			"integrity": "sha512-yGSza74xk0UG8k+pLh5oeoYirvIiWo5t0/o3zHHAO2tRDiZcxWP7fywNlXhqb6/r6sWvwi+RsyQMWhVLe4BVuA==",
+			"dev": true,
+			"engines": {
+				"node": ">=10"
+			},
+			"funding": {
+				"url": "https://github.com/sponsors/sindresorhus"
+			}
+		},
 		"node_modules/can-use-dom": {
 			"version": "0.1.0",
 			"resolved": "https://registry.npmjs.org/can-use-dom/-/can-use-dom-0.1.0.tgz",
@@ -10994,6 +11049,28 @@
 				"node": ">=0.10.0"
 			}
 		},
+		"node_modules/decamelize-keys": {
+			"version": "1.1.0",
+			"resolved": "https://registry.npmjs.org/decamelize-keys/-/decamelize-keys-1.1.0.tgz",
+			"integrity": "sha1-0XGoeTMlKAfrPLYdwcFEXQeN8tk=",
+			"dev": true,
+			"dependencies": {
+				"decamelize": "^1.1.0",
+				"map-obj": "^1.0.0"
+			},
+			"engines": {
+				"node": ">=0.10.0"
+			}
+		},
+		"node_modules/decamelize-keys/node_modules/map-obj": {
+			"version": "1.0.1",
+			"resolved": "https://registry.npmjs.org/map-obj/-/map-obj-1.0.1.tgz",
+			"integrity": "sha1-2TPOuSBdgr3PSIb2dCvcK03qFG0=",
+			"dev": true,
+			"engines": {
+				"node": ">=0.10.0"
+			}
+		},
 		"node_modules/decimal.js": {
 			"version": "10.3.1",
 			"resolved": "https://registry.npmjs.org/decimal.js/-/decimal.js-10.3.1.tgz",
@@ -11180,6 +11257,15 @@
 			},
 			"bin": {
 				"which": "bin/which"
+			}
+		},
+		"node_modules/define-lazy-prop": {
+			"version": "2.0.0",
+			"resolved": "https://registry.npmjs.org/define-lazy-prop/-/define-lazy-prop-2.0.0.tgz",
+			"integrity": "sha512-Ds09qNh8yw3khSjiJjiUInaGX9xlqZDY7JVryGxdxV7NPeuqQfplOpQ66yJFZut3jLa5zOwkXw1g9EI2uKh4Og==",
+			"dev": true,
+			"engines": {
+				"node": ">=8"
 			}
 		},
 		"node_modules/define-properties": {
@@ -13815,6 +13901,23 @@
 				"rimraf": "bin.js"
 			}
 		},
+		"node_modules/file-type": {
+			"version": "16.5.3",
+			"resolved": "https://registry.npmjs.org/file-type/-/file-type-16.5.3.tgz",
+			"integrity": "sha512-uVsl7iFhHSOY4bEONLlTK47iAHtNsFHWP5YE4xJfZ4rnX7S1Q3wce09XgqSC7E/xh8Ncv/be1lNoyprlUH/x6A==",
+			"dev": true,
+			"dependencies": {
+				"readable-web-to-node-stream": "^3.0.0",
+				"strtok3": "^6.2.4",
+				"token-types": "^4.1.1"
+			},
+			"engines": {
+				"node": ">=10"
+			},
+			"funding": {
+				"url": "https://github.com/sindresorhus/file-type?sponsor=1"
+			}
+		},
 		"node_modules/file-uri-to-path": {
 			"version": "1.0.0",
 			"resolved": "https://registry.npmjs.org/file-uri-to-path/-/file-uri-to-path-1.0.0.tgz",
@@ -14545,6 +14648,18 @@
 				"node": ">=8.0.0"
 			}
 		},
+		"node_modules/get-stdin": {
+			"version": "9.0.0",
+			"resolved": "https://registry.npmjs.org/get-stdin/-/get-stdin-9.0.0.tgz",
+			"integrity": "sha512-dVKBjfWisLAicarI2Sf+JuBE/DghV4UzNAVe9yhEJuzeREd3JhOTE9cUaJTeSa77fsbQUK3pcOpJfM59+VKZaA==",
+			"dev": true,
+			"engines": {
+				"node": ">=12"
+			},
+			"funding": {
+				"url": "https://github.com/sponsors/sindresorhus"
+			}
+		},
 		"node_modules/get-stream": {
 			"version": "5.2.0",
 			"resolved": "https://registry.npmjs.org/get-stream/-/get-stream-5.2.0.tgz",
@@ -14826,6 +14941,15 @@
 			"resolved": "https://registry.npmjs.org/handle-thing/-/handle-thing-2.0.1.tgz",
 			"integrity": "sha512-9Qn4yBxelxoh2Ow62nP+Ka/kMnOXRi8BXnRaUwezLNhqelnN49xKz4F/dPP8OYLxLxq6JDtZb2i9XznUQbNPTg==",
 			"dev": true
+		},
+		"node_modules/hard-rejection": {
+			"version": "2.1.0",
+			"resolved": "https://registry.npmjs.org/hard-rejection/-/hard-rejection-2.1.0.tgz",
+			"integrity": "sha512-VIZB+ibDhx7ObhAe7OVtoEbuP4h/MuOTHJ+J8h/eBXotJYl0fBgR72xDFCKgIh22OJZIOVNxBMWuhAr10r8HdA==",
+			"dev": true,
+			"engines": {
+				"node": ">=6"
+			}
 		},
 		"node_modules/harmony-reflect": {
 			"version": "1.6.2",
@@ -19760,6 +19884,18 @@
 				"node": ">=0.10.0"
 			}
 		},
+		"node_modules/map-obj": {
+			"version": "4.3.0",
+			"resolved": "https://registry.npmjs.org/map-obj/-/map-obj-4.3.0.tgz",
+			"integrity": "sha512-hdN1wVrZbb29eBGiGjJbeP8JbKjq1urkHJ/LIP/NY48MZ1QVXUsQBV1G1zvYFHn1XE06cwjBsOI2K3Ulnj1YXQ==",
+			"dev": true,
+			"engines": {
+				"node": ">=8"
+			},
+			"funding": {
+				"url": "https://github.com/sponsors/sindresorhus"
+			}
+		},
 		"node_modules/map-or-similar": {
 			"version": "1.5.0",
 			"resolved": "https://registry.npmjs.org/map-or-similar/-/map-or-similar-1.5.0.tgz",
@@ -19840,6 +19976,273 @@
 				"errno": "^0.1.3",
 				"readable-stream": "^2.0.1"
 			}
+		},
+		"node_modules/meow": {
+			"version": "10.1.2",
+			"resolved": "https://registry.npmjs.org/meow/-/meow-10.1.2.tgz",
+			"integrity": "sha512-zbuAlN+V/sXlbGchNS9WTWjUzeamwMt/BApKCJi7B0QyZstZaMx0n4Unll/fg0njGtMdC9UP5SAscvOCLYdM+Q==",
+			"dev": true,
+			"dependencies": {
+				"@types/minimist": "^1.2.2",
+				"camelcase-keys": "^7.0.0",
+				"decamelize": "^5.0.0",
+				"decamelize-keys": "^1.1.0",
+				"hard-rejection": "^2.1.0",
+				"minimist-options": "4.1.0",
+				"normalize-package-data": "^3.0.2",
+				"read-pkg-up": "^8.0.0",
+				"redent": "^4.0.0",
+				"trim-newlines": "^4.0.2",
+				"type-fest": "^1.2.2",
+				"yargs-parser": "^20.2.9"
+			},
+			"engines": {
+				"node": "^12.20.0 || ^14.13.1 || >=16.0.0"
+			},
+			"funding": {
+				"url": "https://github.com/sponsors/sindresorhus"
+			}
+		},
+		"node_modules/meow/node_modules/decamelize": {
+			"version": "5.0.1",
+			"resolved": "https://registry.npmjs.org/decamelize/-/decamelize-5.0.1.tgz",
+			"integrity": "sha512-VfxadyCECXgQlkoEAjeghAr5gY3Hf+IKjKb+X8tGVDtveCjN+USwprd2q3QXBR9T1+x2DG0XZF5/w+7HAtSaXA==",
+			"dev": true,
+			"engines": {
+				"node": ">=10"
+			},
+			"funding": {
+				"url": "https://github.com/sponsors/sindresorhus"
+			}
+		},
+		"node_modules/meow/node_modules/find-up": {
+			"version": "5.0.0",
+			"resolved": "https://registry.npmjs.org/find-up/-/find-up-5.0.0.tgz",
+			"integrity": "sha512-78/PXT1wlLLDgTzDs7sjq9hzz0vXD+zn+7wypEe4fXQxCmdmqfGsEPQxmiCSQI3ajFV91bVSsvNtrJRiW6nGng==",
+			"dev": true,
+			"dependencies": {
+				"locate-path": "^6.0.0",
+				"path-exists": "^4.0.0"
+			},
+			"engines": {
+				"node": ">=10"
+			},
+			"funding": {
+				"url": "https://github.com/sponsors/sindresorhus"
+			}
+		},
+		"node_modules/meow/node_modules/hosted-git-info": {
+			"version": "4.0.2",
+			"resolved": "https://registry.npmjs.org/hosted-git-info/-/hosted-git-info-4.0.2.tgz",
+			"integrity": "sha512-c9OGXbZ3guC/xOlCg1Ci/VgWlwsqDv1yMQL1CWqXDL0hDjXuNcq0zuR4xqPSuasI3kqFDhqSyTjREz5gzq0fXg==",
+			"dev": true,
+			"dependencies": {
+				"lru-cache": "^6.0.0"
+			},
+			"engines": {
+				"node": ">=10"
+			}
+		},
+		"node_modules/meow/node_modules/indent-string": {
+			"version": "5.0.0",
+			"resolved": "https://registry.npmjs.org/indent-string/-/indent-string-5.0.0.tgz",
+			"integrity": "sha512-m6FAo/spmsW2Ab2fU35JTYwtOKa2yAwXSwgjSv1TJzh4Mh7mC3lzAOVLBprb72XsTrgkEIsl7YrFNAiDiRhIGg==",
+			"dev": true,
+			"engines": {
+				"node": ">=12"
+			},
+			"funding": {
+				"url": "https://github.com/sponsors/sindresorhus"
+			}
+		},
+		"node_modules/meow/node_modules/locate-path": {
+			"version": "6.0.0",
+			"resolved": "https://registry.npmjs.org/locate-path/-/locate-path-6.0.0.tgz",
+			"integrity": "sha512-iPZK6eYjbxRu3uB4/WZ3EsEIMJFMqAoopl3R+zuq0UjcAm/MO6KCweDgPfP3elTztoKP3KtnVHxTn2NHBSDVUw==",
+			"dev": true,
+			"dependencies": {
+				"p-locate": "^5.0.0"
+			},
+			"engines": {
+				"node": ">=10"
+			},
+			"funding": {
+				"url": "https://github.com/sponsors/sindresorhus"
+			}
+		},
+		"node_modules/meow/node_modules/lru-cache": {
+			"version": "6.0.0",
+			"resolved": "https://registry.npmjs.org/lru-cache/-/lru-cache-6.0.0.tgz",
+			"integrity": "sha512-Jo6dJ04CmSjuznwJSS3pUeWmd/H0ffTlkXXgwZi+eq1UCmqQwCh+eLsYOYCwY991i2Fah4h1BEMCx4qThGbsiA==",
+			"dev": true,
+			"dependencies": {
+				"yallist": "^4.0.0"
+			},
+			"engines": {
+				"node": ">=10"
+			}
+		},
+		"node_modules/meow/node_modules/normalize-package-data": {
+			"version": "3.0.3",
+			"resolved": "https://registry.npmjs.org/normalize-package-data/-/normalize-package-data-3.0.3.tgz",
+			"integrity": "sha512-p2W1sgqij3zMMyRC067Dg16bfzVH+w7hyegmpIvZ4JNjqtGOVAIvLmjBx3yP7YTe9vKJgkoNOPjwQGogDoMXFA==",
+			"dev": true,
+			"dependencies": {
+				"hosted-git-info": "^4.0.1",
+				"is-core-module": "^2.5.0",
+				"semver": "^7.3.4",
+				"validate-npm-package-license": "^3.0.1"
+			},
+			"engines": {
+				"node": ">=10"
+			}
+		},
+		"node_modules/meow/node_modules/p-limit": {
+			"version": "3.1.0",
+			"resolved": "https://registry.npmjs.org/p-limit/-/p-limit-3.1.0.tgz",
+			"integrity": "sha512-TYOanM3wGwNGsZN2cVTYPArw454xnXj5qmWF1bEoAc4+cU/ol7GVh7odevjp1FNHduHc3KZMcFduxU5Xc6uJRQ==",
+			"dev": true,
+			"dependencies": {
+				"yocto-queue": "^0.1.0"
+			},
+			"engines": {
+				"node": ">=10"
+			},
+			"funding": {
+				"url": "https://github.com/sponsors/sindresorhus"
+			}
+		},
+		"node_modules/meow/node_modules/p-locate": {
+			"version": "5.0.0",
+			"resolved": "https://registry.npmjs.org/p-locate/-/p-locate-5.0.0.tgz",
+			"integrity": "sha512-LaNjtRWUBY++zB5nE/NwcaoMylSPk+S+ZHNB1TzdbMJMny6dynpAGt7X/tl/QYq3TIeE6nxHppbo2LGymrG5Pw==",
+			"dev": true,
+			"dependencies": {
+				"p-limit": "^3.0.2"
+			},
+			"engines": {
+				"node": ">=10"
+			},
+			"funding": {
+				"url": "https://github.com/sponsors/sindresorhus"
+			}
+		},
+		"node_modules/meow/node_modules/parse-json": {
+			"version": "5.2.0",
+			"resolved": "https://registry.npmjs.org/parse-json/-/parse-json-5.2.0.tgz",
+			"integrity": "sha512-ayCKvm/phCGxOkYRSCM82iDwct8/EonSEgCSxWxD7ve6jHggsFl4fZVQBPRNgQoKiuV/odhFrGzQXZwbifC8Rg==",
+			"dev": true,
+			"dependencies": {
+				"@babel/code-frame": "^7.0.0",
+				"error-ex": "^1.3.1",
+				"json-parse-even-better-errors": "^2.3.0",
+				"lines-and-columns": "^1.1.6"
+			},
+			"engines": {
+				"node": ">=8"
+			},
+			"funding": {
+				"url": "https://github.com/sponsors/sindresorhus"
+			}
+		},
+		"node_modules/meow/node_modules/read-pkg": {
+			"version": "6.0.0",
+			"resolved": "https://registry.npmjs.org/read-pkg/-/read-pkg-6.0.0.tgz",
+			"integrity": "sha512-X1Fu3dPuk/8ZLsMhEj5f4wFAF0DWoK7qhGJvgaijocXxBmSToKfbFtqbxMO7bVjNA1dmE5huAzjXj/ey86iw9Q==",
+			"dev": true,
+			"dependencies": {
+				"@types/normalize-package-data": "^2.4.0",
+				"normalize-package-data": "^3.0.2",
+				"parse-json": "^5.2.0",
+				"type-fest": "^1.0.1"
+			},
+			"engines": {
+				"node": ">=12"
+			},
+			"funding": {
+				"url": "https://github.com/sponsors/sindresorhus"
+			}
+		},
+		"node_modules/meow/node_modules/read-pkg-up": {
+			"version": "8.0.0",
+			"resolved": "https://registry.npmjs.org/read-pkg-up/-/read-pkg-up-8.0.0.tgz",
+			"integrity": "sha512-snVCqPczksT0HS2EC+SxUndvSzn6LRCwpfSvLrIfR5BKDQQZMaI6jPRC9dYvYFDRAuFEAnkwww8kBBNE/3VvzQ==",
+			"dev": true,
+			"dependencies": {
+				"find-up": "^5.0.0",
+				"read-pkg": "^6.0.0",
+				"type-fest": "^1.0.1"
+			},
+			"engines": {
+				"node": ">=12"
+			},
+			"funding": {
+				"url": "https://github.com/sponsors/sindresorhus"
+			}
+		},
+		"node_modules/meow/node_modules/redent": {
+			"version": "4.0.0",
+			"resolved": "https://registry.npmjs.org/redent/-/redent-4.0.0.tgz",
+			"integrity": "sha512-tYkDkVVtYkSVhuQ4zBgfvciymHaeuel+zFKXShfDnFP5SyVEP7qo70Rf1jTOTCx3vGNAbnEi/xFkcfQVMIBWag==",
+			"dev": true,
+			"dependencies": {
+				"indent-string": "^5.0.0",
+				"strip-indent": "^4.0.0"
+			},
+			"engines": {
+				"node": ">=12"
+			},
+			"funding": {
+				"url": "https://github.com/sponsors/sindresorhus"
+			}
+		},
+		"node_modules/meow/node_modules/semver": {
+			"version": "7.3.5",
+			"resolved": "https://registry.npmjs.org/semver/-/semver-7.3.5.tgz",
+			"integrity": "sha512-PoeGJYh8HK4BTO/a9Tf6ZG3veo/A7ZVsYrSA6J8ny9nb3B1VrpkuN+z9OE5wfE5p6H4LchYZsegiQgbJD94ZFQ==",
+			"dev": true,
+			"dependencies": {
+				"lru-cache": "^6.0.0"
+			},
+			"bin": {
+				"semver": "bin/semver.js"
+			},
+			"engines": {
+				"node": ">=10"
+			}
+		},
+		"node_modules/meow/node_modules/strip-indent": {
+			"version": "4.0.0",
+			"resolved": "https://registry.npmjs.org/strip-indent/-/strip-indent-4.0.0.tgz",
+			"integrity": "sha512-mnVSV2l+Zv6BLpSD/8V87CW/y9EmmbYzGCIavsnsI6/nwn26DwffM/yztm30Z/I2DY9wdS3vXVCMnHDgZaVNoA==",
+			"dev": true,
+			"dependencies": {
+				"min-indent": "^1.0.1"
+			},
+			"engines": {
+				"node": ">=12"
+			},
+			"funding": {
+				"url": "https://github.com/sponsors/sindresorhus"
+			}
+		},
+		"node_modules/meow/node_modules/type-fest": {
+			"version": "1.4.0",
+			"resolved": "https://registry.npmjs.org/type-fest/-/type-fest-1.4.0.tgz",
+			"integrity": "sha512-yGSza74xk0UG8k+pLh5oeoYirvIiWo5t0/o3zHHAO2tRDiZcxWP7fywNlXhqb6/r6sWvwi+RsyQMWhVLe4BVuA==",
+			"dev": true,
+			"engines": {
+				"node": ">=10"
+			},
+			"funding": {
+				"url": "https://github.com/sponsors/sindresorhus"
+			}
+		},
+		"node_modules/meow/node_modules/yallist": {
+			"version": "4.0.0",
+			"resolved": "https://registry.npmjs.org/yallist/-/yallist-4.0.0.tgz",
+			"integrity": "sha512-3wdGidZyq5PB084XLES5TpOSRA3wjXAlIWMhum2kRcv/41Sn2emQ0dycQW4uZXLejwKvg6EsvbdlVL+FYEct7A==",
+			"dev": true
 		},
 		"node_modules/merge-deep": {
 			"version": "3.0.3",
@@ -20083,6 +20486,29 @@
 			"version": "1.2.5",
 			"resolved": "https://registry.npmjs.org/minimist/-/minimist-1.2.5.tgz",
 			"integrity": "sha512-FM9nNUYrRBAELZQT3xeZQ7fmMOBg6nWNmJKTcgsJeaLstP/UODVpGsr5OhXhhXg6f+qtJ8uiZ+PUxkDWcgIXLw=="
+		},
+		"node_modules/minimist-options": {
+			"version": "4.1.0",
+			"resolved": "https://registry.npmjs.org/minimist-options/-/minimist-options-4.1.0.tgz",
+			"integrity": "sha512-Q4r8ghd80yhO/0j1O3B2BjweX3fiHg9cdOwjJd2J76Q135c+NDxGCqdYKQ1SKBuFfgWbAUzBfvYjPUEeNgqN1A==",
+			"dev": true,
+			"dependencies": {
+				"arrify": "^1.0.1",
+				"is-plain-obj": "^1.1.0",
+				"kind-of": "^6.0.3"
+			},
+			"engines": {
+				"node": ">= 6"
+			}
+		},
+		"node_modules/minimist-options/node_modules/kind-of": {
+			"version": "6.0.3",
+			"resolved": "https://registry.npmjs.org/kind-of/-/kind-of-6.0.3.tgz",
+			"integrity": "sha512-dcS1ul+9tmeD95T+x28/ehLgd9mENa3LsvDTtzm3vyBEO7RPptvAD+t44WVXaUjTBRcrpFeFlC8WCruUR456hw==",
+			"dev": true,
+			"engines": {
+				"node": ">=0.10.0"
+			}
 		},
 		"node_modules/minipass": {
 			"version": "3.1.3",
@@ -20978,6 +21404,245 @@
 			},
 			"funding": {
 				"url": "https://github.com/sponsors/sindresorhus"
+			}
+		},
+		"node_modules/open-cli": {
+			"version": "7.0.1",
+			"resolved": "https://registry.npmjs.org/open-cli/-/open-cli-7.0.1.tgz",
+			"integrity": "sha512-w//Mb5nLGTu9aIAsAehgxV+CGEkd+P3CbdoTW8y2coQ/fmGXBSrea0i4RBqGnd9prSPX1akrBYc0e3NnWM4SPA==",
+			"dev": true,
+			"dependencies": {
+				"file-type": "^16.5.0",
+				"get-stdin": "^9.0.0",
+				"meow": "^10.0.1",
+				"open": "^8.2.0",
+				"tempy": "^1.0.1"
+			},
+			"bin": {
+				"open-cli": "cli.js"
+			},
+			"engines": {
+				"node": ">=14.13"
+			},
+			"funding": {
+				"url": "https://github.com/sponsors/sindresorhus"
+			}
+		},
+		"node_modules/open-cli/node_modules/@nodelib/fs.stat": {
+			"version": "2.0.5",
+			"resolved": "https://registry.npmjs.org/@nodelib/fs.stat/-/fs.stat-2.0.5.tgz",
+			"integrity": "sha512-RkhPPp2zrqDAQA/2jNhnztcPAlv64XdhIp7a7454A5ovI7Bukxgt7MX7udwAu3zg1DcpPU0rz3VV1SeaqvY4+A==",
+			"dev": true,
+			"engines": {
+				"node": ">= 8"
+			}
+		},
+		"node_modules/open-cli/node_modules/array-union": {
+			"version": "2.1.0",
+			"resolved": "https://registry.npmjs.org/array-union/-/array-union-2.1.0.tgz",
+			"integrity": "sha512-HGyxoOTYUyCM6stUe6EJgnd4EoewAI7zMdfqO+kGjnlZmBDz/cR5pf8r/cR4Wq60sL/p0IkcjUEEPwS3GFrIyw==",
+			"dev": true,
+			"engines": {
+				"node": ">=8"
+			}
+		},
+		"node_modules/open-cli/node_modules/crypto-random-string": {
+			"version": "2.0.0",
+			"resolved": "https://registry.npmjs.org/crypto-random-string/-/crypto-random-string-2.0.0.tgz",
+			"integrity": "sha512-v1plID3y9r/lPhviJ1wrXpLeyUIGAZ2SHNYTEapm7/8A9nLPoyvVp3RK/EPFqn5kEznyWgYZNsRtYYIWbuG8KA==",
+			"dev": true,
+			"engines": {
+				"node": ">=8"
+			}
+		},
+		"node_modules/open-cli/node_modules/del": {
+			"version": "6.0.0",
+			"resolved": "https://registry.npmjs.org/del/-/del-6.0.0.tgz",
+			"integrity": "sha512-1shh9DQ23L16oXSZKB2JxpL7iMy2E0S9d517ptA1P8iw0alkPtQcrKH7ru31rYtKwF499HkTu+DRzq3TCKDFRQ==",
+			"dev": true,
+			"dependencies": {
+				"globby": "^11.0.1",
+				"graceful-fs": "^4.2.4",
+				"is-glob": "^4.0.1",
+				"is-path-cwd": "^2.2.0",
+				"is-path-inside": "^3.0.2",
+				"p-map": "^4.0.0",
+				"rimraf": "^3.0.2",
+				"slash": "^3.0.0"
+			},
+			"engines": {
+				"node": ">=10"
+			},
+			"funding": {
+				"url": "https://github.com/sponsors/sindresorhus"
+			}
+		},
+		"node_modules/open-cli/node_modules/dir-glob": {
+			"version": "3.0.1",
+			"resolved": "https://registry.npmjs.org/dir-glob/-/dir-glob-3.0.1.tgz",
+			"integrity": "sha512-WkrWp9GR4KXfKGYzOLmTuGVi1UWFfws377n9cc55/tb6DuqyF6pcQ5AbiHEshaDpY9v6oaSr2XCDidGmMwdzIA==",
+			"dev": true,
+			"dependencies": {
+				"path-type": "^4.0.0"
+			},
+			"engines": {
+				"node": ">=8"
+			}
+		},
+		"node_modules/open-cli/node_modules/fast-glob": {
+			"version": "3.2.7",
+			"resolved": "https://registry.npmjs.org/fast-glob/-/fast-glob-3.2.7.tgz",
+			"integrity": "sha512-rYGMRwip6lUMvYD3BTScMwT1HtAs2d71SMv66Vrxs0IekGZEjhM0pcMfjQPnknBt2zeCwQMEupiN02ZP4DiT1Q==",
+			"dev": true,
+			"dependencies": {
+				"@nodelib/fs.stat": "^2.0.2",
+				"@nodelib/fs.walk": "^1.2.3",
+				"glob-parent": "^5.1.2",
+				"merge2": "^1.3.0",
+				"micromatch": "^4.0.4"
+			},
+			"engines": {
+				"node": ">=8"
+			}
+		},
+		"node_modules/open-cli/node_modules/globby": {
+			"version": "11.0.4",
+			"resolved": "https://registry.npmjs.org/globby/-/globby-11.0.4.tgz",
+			"integrity": "sha512-9O4MVG9ioZJ08ffbcyVYyLOJLk5JQ688pJ4eMGLpdWLHq/Wr1D9BlriLQyL0E+jbkuePVZXYFj47QM/v093wHg==",
+			"dev": true,
+			"dependencies": {
+				"array-union": "^2.1.0",
+				"dir-glob": "^3.0.1",
+				"fast-glob": "^3.1.1",
+				"ignore": "^5.1.4",
+				"merge2": "^1.3.0",
+				"slash": "^3.0.0"
+			},
+			"engines": {
+				"node": ">=10"
+			},
+			"funding": {
+				"url": "https://github.com/sponsors/sindresorhus"
+			}
+		},
+		"node_modules/open-cli/node_modules/ignore": {
+			"version": "5.2.0",
+			"resolved": "https://registry.npmjs.org/ignore/-/ignore-5.2.0.tgz",
+			"integrity": "sha512-CmxgYGiEPCLhfLnpPp1MoRmifwEIOgjcHXxOBjv7mY96c+eWScsOP9c112ZyLdWHi0FxHjI+4uVhKYp/gcdRmQ==",
+			"dev": true,
+			"engines": {
+				"node": ">= 4"
+			}
+		},
+		"node_modules/open-cli/node_modules/is-path-inside": {
+			"version": "3.0.3",
+			"resolved": "https://registry.npmjs.org/is-path-inside/-/is-path-inside-3.0.3.tgz",
+			"integrity": "sha512-Fd4gABb+ycGAmKou8eMftCupSir5lRxqf4aD/vd0cD2qc4HL07OjCeuHMr8Ro4CoMaeCKDB0/ECBOVWjTwUvPQ==",
+			"dev": true,
+			"engines": {
+				"node": ">=8"
+			}
+		},
+		"node_modules/open-cli/node_modules/open": {
+			"version": "8.4.0",
+			"resolved": "https://registry.npmjs.org/open/-/open-8.4.0.tgz",
+			"integrity": "sha512-XgFPPM+B28FtCCgSb9I+s9szOC1vZRSwgWsRUA5ylIxRTgKozqjOCrVOqGsYABPYK5qnfqClxZTFBa8PKt2v6Q==",
+			"dev": true,
+			"dependencies": {
+				"define-lazy-prop": "^2.0.0",
+				"is-docker": "^2.1.1",
+				"is-wsl": "^2.2.0"
+			},
+			"engines": {
+				"node": ">=12"
+			},
+			"funding": {
+				"url": "https://github.com/sponsors/sindresorhus"
+			}
+		},
+		"node_modules/open-cli/node_modules/p-map": {
+			"version": "4.0.0",
+			"resolved": "https://registry.npmjs.org/p-map/-/p-map-4.0.0.tgz",
+			"integrity": "sha512-/bjOqmgETBYB5BoEeGVea8dmvHb2m9GLy1E9W43yeyfP6QQCZGFNa+XRceJEuDB6zqr+gKpIAmlLebMpykw/MQ==",
+			"dev": true,
+			"dependencies": {
+				"aggregate-error": "^3.0.0"
+			},
+			"engines": {
+				"node": ">=10"
+			},
+			"funding": {
+				"url": "https://github.com/sponsors/sindresorhus"
+			}
+		},
+		"node_modules/open-cli/node_modules/path-type": {
+			"version": "4.0.0",
+			"resolved": "https://registry.npmjs.org/path-type/-/path-type-4.0.0.tgz",
+			"integrity": "sha512-gDKb8aZMDeD/tZWs9P6+q0J9Mwkdl6xMV8TjnGP3qJVJ06bdMgkbBlLU8IdfOsIsFz2BW1rNVT3XuNEl8zPAvw==",
+			"dev": true,
+			"engines": {
+				"node": ">=8"
+			}
+		},
+		"node_modules/open-cli/node_modules/slash": {
+			"version": "3.0.0",
+			"resolved": "https://registry.npmjs.org/slash/-/slash-3.0.0.tgz",
+			"integrity": "sha512-g9Q1haeby36OSStwb4ntCGGGaKsaVSjQ68fBxoQcutl5fS1vuY18H3wSt3jFyFtrkx+Kz0V1G85A4MyAdDMi2Q==",
+			"dev": true,
+			"engines": {
+				"node": ">=8"
+			}
+		},
+		"node_modules/open-cli/node_modules/temp-dir": {
+			"version": "2.0.0",
+			"resolved": "https://registry.npmjs.org/temp-dir/-/temp-dir-2.0.0.tgz",
+			"integrity": "sha512-aoBAniQmmwtcKp/7BzsH8Cxzv8OL736p7v1ihGb5e9DJ9kTwGWHrQrVB5+lfVDzfGrdRzXch+ig7LHaY1JTOrg==",
+			"dev": true,
+			"engines": {
+				"node": ">=8"
+			}
+		},
+		"node_modules/open-cli/node_modules/tempy": {
+			"version": "1.0.1",
+			"resolved": "https://registry.npmjs.org/tempy/-/tempy-1.0.1.tgz",
+			"integrity": "sha512-biM9brNqxSc04Ee71hzFbryD11nX7VPhQQY32AdDmjFvodsRFz/3ufeoTZ6uYkRFfGo188tENcASNs3vTdsM0w==",
+			"dev": true,
+			"dependencies": {
+				"del": "^6.0.0",
+				"is-stream": "^2.0.0",
+				"temp-dir": "^2.0.0",
+				"type-fest": "^0.16.0",
+				"unique-string": "^2.0.0"
+			},
+			"engines": {
+				"node": ">=10"
+			},
+			"funding": {
+				"url": "https://github.com/sponsors/sindresorhus"
+			}
+		},
+		"node_modules/open-cli/node_modules/type-fest": {
+			"version": "0.16.0",
+			"resolved": "https://registry.npmjs.org/type-fest/-/type-fest-0.16.0.tgz",
+			"integrity": "sha512-eaBzG6MxNzEn9kiwvtre90cXaNLkmadMWa1zQMs3XORCXNbsH/OewwbxC5ia9dCxIxnTAsSxXJaa/p5y8DlvJg==",
+			"dev": true,
+			"engines": {
+				"node": ">=10"
+			},
+			"funding": {
+				"url": "https://github.com/sponsors/sindresorhus"
+			}
+		},
+		"node_modules/open-cli/node_modules/unique-string": {
+			"version": "2.0.0",
+			"resolved": "https://registry.npmjs.org/unique-string/-/unique-string-2.0.0.tgz",
+			"integrity": "sha512-uNaeirEPvpZWSgzwsPGtU2zVSTrn/8L5q/IexZmH0eH6SA73CmAA5U4GwORTxQAZs95TAXLNqeLoPPNO5gZfWg==",
+			"dev": true,
+			"dependencies": {
+				"crypto-random-string": "^2.0.0"
+			},
+			"engines": {
+				"node": ">=8"
 			}
 		},
 		"node_modules/opn": {
@@ -21948,6 +22613,19 @@
 			},
 			"engines": {
 				"node": ">=0.12"
+			}
+		},
+		"node_modules/peek-readable": {
+			"version": "4.0.2",
+			"resolved": "https://registry.npmjs.org/peek-readable/-/peek-readable-4.0.2.tgz",
+			"integrity": "sha512-9fMaz6zoxw9ypO1KZy5RDJgSupEtu0Q+g/OqqsVHX3rKGR8qehRLYzsFARZ4bVvdvfknKiXvuDbkMnO1g6cRpQ==",
+			"dev": true,
+			"engines": {
+				"node": ">=8"
+			},
+			"funding": {
+				"type": "github",
+				"url": "https://github.com/sponsors/Borewit"
 			}
 		},
 		"node_modules/performance-now": {
@@ -23808,6 +24486,18 @@
 					"url": "https://feross.org/support"
 				}
 			]
+		},
+		"node_modules/quick-lru": {
+			"version": "5.1.1",
+			"resolved": "https://registry.npmjs.org/quick-lru/-/quick-lru-5.1.1.tgz",
+			"integrity": "sha512-WuyALRjWPDGtt/wzJiadO5AXY+8hZ80hVpe6MyivgraREW751X3SbhRvG3eLKOYN+8VEvqLcf3wdnt44Z4S4SA==",
+			"dev": true,
+			"engines": {
+				"node": ">=10"
+			},
+			"funding": {
+				"url": "https://github.com/sponsors/sindresorhus"
+			}
 		},
 		"node_modules/raf": {
 			"version": "3.4.1",
@@ -26689,6 +27379,36 @@
 			"resolved": "https://registry.npmjs.org/isarray/-/isarray-1.0.0.tgz",
 			"integrity": "sha1-u5NdSFgsuhaMBoNJV6VKPgcSTxE="
 		},
+		"node_modules/readable-web-to-node-stream": {
+			"version": "3.0.2",
+			"resolved": "https://registry.npmjs.org/readable-web-to-node-stream/-/readable-web-to-node-stream-3.0.2.tgz",
+			"integrity": "sha512-ePeK6cc1EcKLEhJFt/AebMCLL+GgSKhuygrZ/GLaKZYEecIgIECf4UaUuaByiGtzckwR4ain9VzUh95T1exYGw==",
+			"dev": true,
+			"dependencies": {
+				"readable-stream": "^3.6.0"
+			},
+			"engines": {
+				"node": ">=8"
+			},
+			"funding": {
+				"type": "github",
+				"url": "https://github.com/sponsors/Borewit"
+			}
+		},
+		"node_modules/readable-web-to-node-stream/node_modules/readable-stream": {
+			"version": "3.6.0",
+			"resolved": "https://registry.npmjs.org/readable-stream/-/readable-stream-3.6.0.tgz",
+			"integrity": "sha512-BViHy7LKeTz4oNnkcLJ+lVSL6vpiFeX6/d3oSH8zCW7UxP2onchk+vTGB143xuFjHS3deTgkKoXXymXqymiIdA==",
+			"dev": true,
+			"dependencies": {
+				"inherits": "^2.0.3",
+				"string_decoder": "^1.1.1",
+				"util-deprecate": "^1.0.1"
+			},
+			"engines": {
+				"node": ">= 6"
+			}
+		},
 		"node_modules/readdirp": {
 			"version": "2.2.1",
 			"resolved": "https://registry.npmjs.org/readdirp/-/readdirp-2.2.1.tgz",
@@ -29102,6 +29822,23 @@
 				"url": "https://github.com/sponsors/sindresorhus"
 			}
 		},
+		"node_modules/strtok3": {
+			"version": "6.2.4",
+			"resolved": "https://registry.npmjs.org/strtok3/-/strtok3-6.2.4.tgz",
+			"integrity": "sha512-GO8IcFF9GmFDvqduIspUBwCzCbqzegyVKIsSymcMgiZKeCfrN9SowtUoi8+b59WZMAjIzVZic/Ft97+pynR3Iw==",
+			"dev": true,
+			"dependencies": {
+				"@tokenizer/token": "^0.3.0",
+				"peek-readable": "^4.0.1"
+			},
+			"engines": {
+				"node": ">=10"
+			},
+			"funding": {
+				"type": "github",
+				"url": "https://github.com/sponsors/Borewit"
+			}
+		},
 		"node_modules/style-loader": {
 			"version": "1.3.0",
 			"resolved": "https://registry.npmjs.org/style-loader/-/style-loader-1.3.0.tgz",
@@ -29916,6 +30653,23 @@
 				"node": ">=0.6"
 			}
 		},
+		"node_modules/token-types": {
+			"version": "4.1.1",
+			"resolved": "https://registry.npmjs.org/token-types/-/token-types-4.1.1.tgz",
+			"integrity": "sha512-hD+QyuUAyI2spzsI0B7gf/jJ2ggR4RjkAo37j3StuePhApJUwcWDjnHDOFdIWYSwNR28H14hpwm4EI+V1Ted1w==",
+			"dev": true,
+			"dependencies": {
+				"@tokenizer/token": "^0.3.0",
+				"ieee754": "^1.2.1"
+			},
+			"engines": {
+				"node": ">=10"
+			},
+			"funding": {
+				"type": "github",
+				"url": "https://github.com/sponsors/Borewit"
+			}
+		},
 		"node_modules/tough-cookie": {
 			"version": "4.0.0",
 			"resolved": "https://registry.npmjs.org/tough-cookie/-/tough-cookie-4.0.0.tgz",
@@ -29940,6 +30694,18 @@
 			},
 			"engines": {
 				"node": ">=8"
+			}
+		},
+		"node_modules/trim-newlines": {
+			"version": "4.0.2",
+			"resolved": "https://registry.npmjs.org/trim-newlines/-/trim-newlines-4.0.2.tgz",
+			"integrity": "sha512-GJtWyq9InR/2HRiLZgpIKv+ufIKrVrvjQWEj7PxAXNc5dwbNJkqhAUoAGgzRmULAnoOM5EIpveYd3J2VeSAIew==",
+			"dev": true,
+			"engines": {
+				"node": ">=12"
+			},
+			"funding": {
+				"url": "https://github.com/sponsors/sindresorhus"
 			}
 		},
 		"node_modules/tryer": {
@@ -36524,6 +37290,12 @@
 				"@theme-ui/mdx": "0.10.0"
 			}
 		},
+		"@tokenizer/token": {
+			"version": "0.3.0",
+			"resolved": "https://registry.npmjs.org/@tokenizer/token/-/token-0.3.0.tgz",
+			"integrity": "sha512-OvjF+z51L3ov0OyAU0duzsYuvO01PH7x4t6DJx+guahgTnBHkhJdG7soQeTSFLWN3efnHyibZ4Z8l2EuWwJN3A==",
+			"dev": true
+		},
 		"@tootallnate/once": {
 			"version": "1.1.2",
 			"resolved": "https://registry.npmjs.org/@tootallnate/once/-/once-1.1.2.tgz",
@@ -36802,6 +37574,12 @@
 			"version": "3.0.5",
 			"resolved": "https://registry.npmjs.org/@types/minimatch/-/minimatch-3.0.5.tgz",
 			"integrity": "sha512-Klz949h02Gz2uZCMGwDUSDS1YBlTdDDgbWHi+81l29tQALUtvz4rAYi5uoVhE5Lagoq6DeqAUlbrHvW/mXDgdQ==",
+			"dev": true
+		},
+		"@types/minimist": {
+			"version": "1.2.2",
+			"resolved": "https://registry.npmjs.org/@types/minimist/-/minimist-1.2.2.tgz",
+			"integrity": "sha512-jhuKLIRrhvCPLqwPcx6INqmKeiA5EWrsCOPhrlFSrbrmU4ZMPjj5Ul/oLCMDO98XRUIwVm78xICz4EPCektzeQ==",
 			"dev": true
 		},
 		"@types/node": {
@@ -39724,6 +40502,32 @@
 			"integrity": "sha512-L28STB170nwWS63UjtlEOE3dldQApaJXZkOI1uMFfzf3rRuPegHaHesyee+YxQ+W6SvRDQV6UrdOdRiR153wJg==",
 			"dev": true
 		},
+		"camelcase-keys": {
+			"version": "7.0.1",
+			"resolved": "https://registry.npmjs.org/camelcase-keys/-/camelcase-keys-7.0.1.tgz",
+			"integrity": "sha512-P331lEls98pW8JLyodNWfzuz91BEDVA4VpW2/SwXnyv2K495tq1N777xzDbFgnEigfA7UIY0xa6PwR/H9jijjA==",
+			"dev": true,
+			"requires": {
+				"camelcase": "^6.2.0",
+				"map-obj": "^4.1.0",
+				"quick-lru": "^5.1.1",
+				"type-fest": "^1.2.1"
+			},
+			"dependencies": {
+				"camelcase": {
+					"version": "6.2.1",
+					"resolved": "https://registry.npmjs.org/camelcase/-/camelcase-6.2.1.tgz",
+					"integrity": "sha512-tVI4q5jjFV5CavAU8DXfza/TJcZutVKo/5Foskmsqcm0MsL91moHvwiGNnqaa2o6PF/7yT5ikDRcVcl8Rj6LCA==",
+					"dev": true
+				},
+				"type-fest": {
+					"version": "1.4.0",
+					"resolved": "https://registry.npmjs.org/type-fest/-/type-fest-1.4.0.tgz",
+					"integrity": "sha512-yGSza74xk0UG8k+pLh5oeoYirvIiWo5t0/o3zHHAO2tRDiZcxWP7fywNlXhqb6/r6sWvwi+RsyQMWhVLe4BVuA==",
+					"dev": true
+				}
+			}
+		},
 		"can-use-dom": {
 			"version": "0.1.0",
 			"resolved": "https://registry.npmjs.org/can-use-dom/-/can-use-dom-0.1.0.tgz",
@@ -40888,6 +41692,24 @@
 			"integrity": "sha1-9lNNFRSCabIDUue+4m9QH5oZEpA=",
 			"dev": true
 		},
+		"decamelize-keys": {
+			"version": "1.1.0",
+			"resolved": "https://registry.npmjs.org/decamelize-keys/-/decamelize-keys-1.1.0.tgz",
+			"integrity": "sha1-0XGoeTMlKAfrPLYdwcFEXQeN8tk=",
+			"dev": true,
+			"requires": {
+				"decamelize": "^1.1.0",
+				"map-obj": "^1.0.0"
+			},
+			"dependencies": {
+				"map-obj": {
+					"version": "1.0.1",
+					"resolved": "https://registry.npmjs.org/map-obj/-/map-obj-1.0.1.tgz",
+					"integrity": "sha1-2TPOuSBdgr3PSIb2dCvcK03qFG0=",
+					"dev": true
+				}
+			}
+		},
 		"decimal.js": {
 			"version": "10.3.1",
 			"resolved": "https://registry.npmjs.org/decimal.js/-/decimal.js-10.3.1.tgz",
@@ -41035,6 +41857,12 @@
 					}
 				}
 			}
+		},
+		"define-lazy-prop": {
+			"version": "2.0.0",
+			"resolved": "https://registry.npmjs.org/define-lazy-prop/-/define-lazy-prop-2.0.0.tgz",
+			"integrity": "sha512-Ds09qNh8yw3khSjiJjiUInaGX9xlqZDY7JVryGxdxV7NPeuqQfplOpQ66yJFZut3jLa5zOwkXw1g9EI2uKh4Og==",
+			"dev": true
 		},
 		"define-properties": {
 			"version": "1.1.3",
@@ -43094,6 +43922,17 @@
 				}
 			}
 		},
+		"file-type": {
+			"version": "16.5.3",
+			"resolved": "https://registry.npmjs.org/file-type/-/file-type-16.5.3.tgz",
+			"integrity": "sha512-uVsl7iFhHSOY4bEONLlTK47iAHtNsFHWP5YE4xJfZ4rnX7S1Q3wce09XgqSC7E/xh8Ncv/be1lNoyprlUH/x6A==",
+			"dev": true,
+			"requires": {
+				"readable-web-to-node-stream": "^3.0.0",
+				"strtok3": "^6.2.4",
+				"token-types": "^4.1.1"
+			}
+		},
 		"file-uri-to-path": {
 			"version": "1.0.0",
 			"resolved": "https://registry.npmjs.org/file-uri-to-path/-/file-uri-to-path-1.0.0.tgz",
@@ -43664,6 +44503,12 @@
 			"integrity": "sha512-pjzuKtY64GYfWizNAJ0fr9VqttZkNiK2iS430LtIHzjBEr6bX8Am2zm4sW4Ro5wjWW5cAlRL1qAMTcXbjNAO2Q==",
 			"dev": true
 		},
+		"get-stdin": {
+			"version": "9.0.0",
+			"resolved": "https://registry.npmjs.org/get-stdin/-/get-stdin-9.0.0.tgz",
+			"integrity": "sha512-dVKBjfWisLAicarI2Sf+JuBE/DghV4UzNAVe9yhEJuzeREd3JhOTE9cUaJTeSa77fsbQUK3pcOpJfM59+VKZaA==",
+			"dev": true
+		},
 		"get-stream": {
 			"version": "5.2.0",
 			"resolved": "https://registry.npmjs.org/get-stream/-/get-stream-5.2.0.tgz",
@@ -43884,6 +44729,12 @@
 			"version": "2.0.1",
 			"resolved": "https://registry.npmjs.org/handle-thing/-/handle-thing-2.0.1.tgz",
 			"integrity": "sha512-9Qn4yBxelxoh2Ow62nP+Ka/kMnOXRi8BXnRaUwezLNhqelnN49xKz4F/dPP8OYLxLxq6JDtZb2i9XznUQbNPTg==",
+			"dev": true
+		},
+		"hard-rejection": {
+			"version": "2.1.0",
+			"resolved": "https://registry.npmjs.org/hard-rejection/-/hard-rejection-2.1.0.tgz",
+			"integrity": "sha512-VIZB+ibDhx7ObhAe7OVtoEbuP4h/MuOTHJ+J8h/eBXotJYl0fBgR72xDFCKgIh22OJZIOVNxBMWuhAr10r8HdA==",
 			"dev": true
 		},
 		"harmony-reflect": {
@@ -47644,6 +48495,12 @@
 			"resolved": "https://registry.npmjs.org/map-cache/-/map-cache-0.2.2.tgz",
 			"integrity": "sha1-wyq9C9ZSXZsFFkW7TyasXcmKDb8="
 		},
+		"map-obj": {
+			"version": "4.3.0",
+			"resolved": "https://registry.npmjs.org/map-obj/-/map-obj-4.3.0.tgz",
+			"integrity": "sha512-hdN1wVrZbb29eBGiGjJbeP8JbKjq1urkHJ/LIP/NY48MZ1QVXUsQBV1G1zvYFHn1XE06cwjBsOI2K3Ulnj1YXQ==",
+			"dev": true
+		},
 		"map-or-similar": {
 			"version": "1.5.0",
 			"resolved": "https://registry.npmjs.org/map-or-similar/-/map-or-similar-1.5.0.tgz",
@@ -47711,6 +48568,182 @@
 			"requires": {
 				"errno": "^0.1.3",
 				"readable-stream": "^2.0.1"
+			}
+		},
+		"meow": {
+			"version": "10.1.2",
+			"resolved": "https://registry.npmjs.org/meow/-/meow-10.1.2.tgz",
+			"integrity": "sha512-zbuAlN+V/sXlbGchNS9WTWjUzeamwMt/BApKCJi7B0QyZstZaMx0n4Unll/fg0njGtMdC9UP5SAscvOCLYdM+Q==",
+			"dev": true,
+			"requires": {
+				"@types/minimist": "^1.2.2",
+				"camelcase-keys": "^7.0.0",
+				"decamelize": "^5.0.0",
+				"decamelize-keys": "^1.1.0",
+				"hard-rejection": "^2.1.0",
+				"minimist-options": "4.1.0",
+				"normalize-package-data": "^3.0.2",
+				"read-pkg-up": "^8.0.0",
+				"redent": "^4.0.0",
+				"trim-newlines": "^4.0.2",
+				"type-fest": "^1.2.2",
+				"yargs-parser": "^20.2.9"
+			},
+			"dependencies": {
+				"decamelize": {
+					"version": "5.0.1",
+					"resolved": "https://registry.npmjs.org/decamelize/-/decamelize-5.0.1.tgz",
+					"integrity": "sha512-VfxadyCECXgQlkoEAjeghAr5gY3Hf+IKjKb+X8tGVDtveCjN+USwprd2q3QXBR9T1+x2DG0XZF5/w+7HAtSaXA==",
+					"dev": true
+				},
+				"find-up": {
+					"version": "5.0.0",
+					"resolved": "https://registry.npmjs.org/find-up/-/find-up-5.0.0.tgz",
+					"integrity": "sha512-78/PXT1wlLLDgTzDs7sjq9hzz0vXD+zn+7wypEe4fXQxCmdmqfGsEPQxmiCSQI3ajFV91bVSsvNtrJRiW6nGng==",
+					"dev": true,
+					"requires": {
+						"locate-path": "^6.0.0",
+						"path-exists": "^4.0.0"
+					}
+				},
+				"hosted-git-info": {
+					"version": "4.0.2",
+					"resolved": "https://registry.npmjs.org/hosted-git-info/-/hosted-git-info-4.0.2.tgz",
+					"integrity": "sha512-c9OGXbZ3guC/xOlCg1Ci/VgWlwsqDv1yMQL1CWqXDL0hDjXuNcq0zuR4xqPSuasI3kqFDhqSyTjREz5gzq0fXg==",
+					"dev": true,
+					"requires": {
+						"lru-cache": "^6.0.0"
+					}
+				},
+				"indent-string": {
+					"version": "5.0.0",
+					"resolved": "https://registry.npmjs.org/indent-string/-/indent-string-5.0.0.tgz",
+					"integrity": "sha512-m6FAo/spmsW2Ab2fU35JTYwtOKa2yAwXSwgjSv1TJzh4Mh7mC3lzAOVLBprb72XsTrgkEIsl7YrFNAiDiRhIGg==",
+					"dev": true
+				},
+				"locate-path": {
+					"version": "6.0.0",
+					"resolved": "https://registry.npmjs.org/locate-path/-/locate-path-6.0.0.tgz",
+					"integrity": "sha512-iPZK6eYjbxRu3uB4/WZ3EsEIMJFMqAoopl3R+zuq0UjcAm/MO6KCweDgPfP3elTztoKP3KtnVHxTn2NHBSDVUw==",
+					"dev": true,
+					"requires": {
+						"p-locate": "^5.0.0"
+					}
+				},
+				"lru-cache": {
+					"version": "6.0.0",
+					"resolved": "https://registry.npmjs.org/lru-cache/-/lru-cache-6.0.0.tgz",
+					"integrity": "sha512-Jo6dJ04CmSjuznwJSS3pUeWmd/H0ffTlkXXgwZi+eq1UCmqQwCh+eLsYOYCwY991i2Fah4h1BEMCx4qThGbsiA==",
+					"dev": true,
+					"requires": {
+						"yallist": "^4.0.0"
+					}
+				},
+				"normalize-package-data": {
+					"version": "3.0.3",
+					"resolved": "https://registry.npmjs.org/normalize-package-data/-/normalize-package-data-3.0.3.tgz",
+					"integrity": "sha512-p2W1sgqij3zMMyRC067Dg16bfzVH+w7hyegmpIvZ4JNjqtGOVAIvLmjBx3yP7YTe9vKJgkoNOPjwQGogDoMXFA==",
+					"dev": true,
+					"requires": {
+						"hosted-git-info": "^4.0.1",
+						"is-core-module": "^2.5.0",
+						"semver": "^7.3.4",
+						"validate-npm-package-license": "^3.0.1"
+					}
+				},
+				"p-limit": {
+					"version": "3.1.0",
+					"resolved": "https://registry.npmjs.org/p-limit/-/p-limit-3.1.0.tgz",
+					"integrity": "sha512-TYOanM3wGwNGsZN2cVTYPArw454xnXj5qmWF1bEoAc4+cU/ol7GVh7odevjp1FNHduHc3KZMcFduxU5Xc6uJRQ==",
+					"dev": true,
+					"requires": {
+						"yocto-queue": "^0.1.0"
+					}
+				},
+				"p-locate": {
+					"version": "5.0.0",
+					"resolved": "https://registry.npmjs.org/p-locate/-/p-locate-5.0.0.tgz",
+					"integrity": "sha512-LaNjtRWUBY++zB5nE/NwcaoMylSPk+S+ZHNB1TzdbMJMny6dynpAGt7X/tl/QYq3TIeE6nxHppbo2LGymrG5Pw==",
+					"dev": true,
+					"requires": {
+						"p-limit": "^3.0.2"
+					}
+				},
+				"parse-json": {
+					"version": "5.2.0",
+					"resolved": "https://registry.npmjs.org/parse-json/-/parse-json-5.2.0.tgz",
+					"integrity": "sha512-ayCKvm/phCGxOkYRSCM82iDwct8/EonSEgCSxWxD7ve6jHggsFl4fZVQBPRNgQoKiuV/odhFrGzQXZwbifC8Rg==",
+					"dev": true,
+					"requires": {
+						"@babel/code-frame": "^7.0.0",
+						"error-ex": "^1.3.1",
+						"json-parse-even-better-errors": "^2.3.0",
+						"lines-and-columns": "^1.1.6"
+					}
+				},
+				"read-pkg": {
+					"version": "6.0.0",
+					"resolved": "https://registry.npmjs.org/read-pkg/-/read-pkg-6.0.0.tgz",
+					"integrity": "sha512-X1Fu3dPuk/8ZLsMhEj5f4wFAF0DWoK7qhGJvgaijocXxBmSToKfbFtqbxMO7bVjNA1dmE5huAzjXj/ey86iw9Q==",
+					"dev": true,
+					"requires": {
+						"@types/normalize-package-data": "^2.4.0",
+						"normalize-package-data": "^3.0.2",
+						"parse-json": "^5.2.0",
+						"type-fest": "^1.0.1"
+					}
+				},
+				"read-pkg-up": {
+					"version": "8.0.0",
+					"resolved": "https://registry.npmjs.org/read-pkg-up/-/read-pkg-up-8.0.0.tgz",
+					"integrity": "sha512-snVCqPczksT0HS2EC+SxUndvSzn6LRCwpfSvLrIfR5BKDQQZMaI6jPRC9dYvYFDRAuFEAnkwww8kBBNE/3VvzQ==",
+					"dev": true,
+					"requires": {
+						"find-up": "^5.0.0",
+						"read-pkg": "^6.0.0",
+						"type-fest": "^1.0.1"
+					}
+				},
+				"redent": {
+					"version": "4.0.0",
+					"resolved": "https://registry.npmjs.org/redent/-/redent-4.0.0.tgz",
+					"integrity": "sha512-tYkDkVVtYkSVhuQ4zBgfvciymHaeuel+zFKXShfDnFP5SyVEP7qo70Rf1jTOTCx3vGNAbnEi/xFkcfQVMIBWag==",
+					"dev": true,
+					"requires": {
+						"indent-string": "^5.0.0",
+						"strip-indent": "^4.0.0"
+					}
+				},
+				"semver": {
+					"version": "7.3.5",
+					"resolved": "https://registry.npmjs.org/semver/-/semver-7.3.5.tgz",
+					"integrity": "sha512-PoeGJYh8HK4BTO/a9Tf6ZG3veo/A7ZVsYrSA6J8ny9nb3B1VrpkuN+z9OE5wfE5p6H4LchYZsegiQgbJD94ZFQ==",
+					"dev": true,
+					"requires": {
+						"lru-cache": "^6.0.0"
+					}
+				},
+				"strip-indent": {
+					"version": "4.0.0",
+					"resolved": "https://registry.npmjs.org/strip-indent/-/strip-indent-4.0.0.tgz",
+					"integrity": "sha512-mnVSV2l+Zv6BLpSD/8V87CW/y9EmmbYzGCIavsnsI6/nwn26DwffM/yztm30Z/I2DY9wdS3vXVCMnHDgZaVNoA==",
+					"dev": true,
+					"requires": {
+						"min-indent": "^1.0.1"
+					}
+				},
+				"type-fest": {
+					"version": "1.4.0",
+					"resolved": "https://registry.npmjs.org/type-fest/-/type-fest-1.4.0.tgz",
+					"integrity": "sha512-yGSza74xk0UG8k+pLh5oeoYirvIiWo5t0/o3zHHAO2tRDiZcxWP7fywNlXhqb6/r6sWvwi+RsyQMWhVLe4BVuA==",
+					"dev": true
+				},
+				"yallist": {
+					"version": "4.0.0",
+					"resolved": "https://registry.npmjs.org/yallist/-/yallist-4.0.0.tgz",
+					"integrity": "sha512-3wdGidZyq5PB084XLES5TpOSRA3wjXAlIWMhum2kRcv/41Sn2emQ0dycQW4uZXLejwKvg6EsvbdlVL+FYEct7A==",
+					"dev": true
+				}
 			}
 		},
 		"merge-deep": {
@@ -47904,6 +48937,25 @@
 			"version": "1.2.5",
 			"resolved": "https://registry.npmjs.org/minimist/-/minimist-1.2.5.tgz",
 			"integrity": "sha512-FM9nNUYrRBAELZQT3xeZQ7fmMOBg6nWNmJKTcgsJeaLstP/UODVpGsr5OhXhhXg6f+qtJ8uiZ+PUxkDWcgIXLw=="
+		},
+		"minimist-options": {
+			"version": "4.1.0",
+			"resolved": "https://registry.npmjs.org/minimist-options/-/minimist-options-4.1.0.tgz",
+			"integrity": "sha512-Q4r8ghd80yhO/0j1O3B2BjweX3fiHg9cdOwjJd2J76Q135c+NDxGCqdYKQ1SKBuFfgWbAUzBfvYjPUEeNgqN1A==",
+			"dev": true,
+			"requires": {
+				"arrify": "^1.0.1",
+				"is-plain-obj": "^1.1.0",
+				"kind-of": "^6.0.3"
+			},
+			"dependencies": {
+				"kind-of": {
+					"version": "6.0.3",
+					"resolved": "https://registry.npmjs.org/kind-of/-/kind-of-6.0.3.tgz",
+					"integrity": "sha512-dcS1ul+9tmeD95T+x28/ehLgd9mENa3LsvDTtzm3vyBEO7RPptvAD+t44WVXaUjTBRcrpFeFlC8WCruUR456hw==",
+					"dev": true
+				}
+			}
 		},
 		"minipass": {
 			"version": "3.1.3",
@@ -48624,6 +49676,169 @@
 				"is-wsl": "^2.1.1"
 			}
 		},
+		"open-cli": {
+			"version": "7.0.1",
+			"resolved": "https://registry.npmjs.org/open-cli/-/open-cli-7.0.1.tgz",
+			"integrity": "sha512-w//Mb5nLGTu9aIAsAehgxV+CGEkd+P3CbdoTW8y2coQ/fmGXBSrea0i4RBqGnd9prSPX1akrBYc0e3NnWM4SPA==",
+			"dev": true,
+			"requires": {
+				"file-type": "^16.5.0",
+				"get-stdin": "^9.0.0",
+				"meow": "^10.0.1",
+				"open": "^8.2.0",
+				"tempy": "^1.0.1"
+			},
+			"dependencies": {
+				"@nodelib/fs.stat": {
+					"version": "2.0.5",
+					"resolved": "https://registry.npmjs.org/@nodelib/fs.stat/-/fs.stat-2.0.5.tgz",
+					"integrity": "sha512-RkhPPp2zrqDAQA/2jNhnztcPAlv64XdhIp7a7454A5ovI7Bukxgt7MX7udwAu3zg1DcpPU0rz3VV1SeaqvY4+A==",
+					"dev": true
+				},
+				"array-union": {
+					"version": "2.1.0",
+					"resolved": "https://registry.npmjs.org/array-union/-/array-union-2.1.0.tgz",
+					"integrity": "sha512-HGyxoOTYUyCM6stUe6EJgnd4EoewAI7zMdfqO+kGjnlZmBDz/cR5pf8r/cR4Wq60sL/p0IkcjUEEPwS3GFrIyw==",
+					"dev": true
+				},
+				"crypto-random-string": {
+					"version": "2.0.0",
+					"resolved": "https://registry.npmjs.org/crypto-random-string/-/crypto-random-string-2.0.0.tgz",
+					"integrity": "sha512-v1plID3y9r/lPhviJ1wrXpLeyUIGAZ2SHNYTEapm7/8A9nLPoyvVp3RK/EPFqn5kEznyWgYZNsRtYYIWbuG8KA==",
+					"dev": true
+				},
+				"del": {
+					"version": "6.0.0",
+					"resolved": "https://registry.npmjs.org/del/-/del-6.0.0.tgz",
+					"integrity": "sha512-1shh9DQ23L16oXSZKB2JxpL7iMy2E0S9d517ptA1P8iw0alkPtQcrKH7ru31rYtKwF499HkTu+DRzq3TCKDFRQ==",
+					"dev": true,
+					"requires": {
+						"globby": "^11.0.1",
+						"graceful-fs": "^4.2.4",
+						"is-glob": "^4.0.1",
+						"is-path-cwd": "^2.2.0",
+						"is-path-inside": "^3.0.2",
+						"p-map": "^4.0.0",
+						"rimraf": "^3.0.2",
+						"slash": "^3.0.0"
+					}
+				},
+				"dir-glob": {
+					"version": "3.0.1",
+					"resolved": "https://registry.npmjs.org/dir-glob/-/dir-glob-3.0.1.tgz",
+					"integrity": "sha512-WkrWp9GR4KXfKGYzOLmTuGVi1UWFfws377n9cc55/tb6DuqyF6pcQ5AbiHEshaDpY9v6oaSr2XCDidGmMwdzIA==",
+					"dev": true,
+					"requires": {
+						"path-type": "^4.0.0"
+					}
+				},
+				"fast-glob": {
+					"version": "3.2.7",
+					"resolved": "https://registry.npmjs.org/fast-glob/-/fast-glob-3.2.7.tgz",
+					"integrity": "sha512-rYGMRwip6lUMvYD3BTScMwT1HtAs2d71SMv66Vrxs0IekGZEjhM0pcMfjQPnknBt2zeCwQMEupiN02ZP4DiT1Q==",
+					"dev": true,
+					"requires": {
+						"@nodelib/fs.stat": "^2.0.2",
+						"@nodelib/fs.walk": "^1.2.3",
+						"glob-parent": "^5.1.2",
+						"merge2": "^1.3.0",
+						"micromatch": "^4.0.4"
+					}
+				},
+				"globby": {
+					"version": "11.0.4",
+					"resolved": "https://registry.npmjs.org/globby/-/globby-11.0.4.tgz",
+					"integrity": "sha512-9O4MVG9ioZJ08ffbcyVYyLOJLk5JQ688pJ4eMGLpdWLHq/Wr1D9BlriLQyL0E+jbkuePVZXYFj47QM/v093wHg==",
+					"dev": true,
+					"requires": {
+						"array-union": "^2.1.0",
+						"dir-glob": "^3.0.1",
+						"fast-glob": "^3.1.1",
+						"ignore": "^5.1.4",
+						"merge2": "^1.3.0",
+						"slash": "^3.0.0"
+					}
+				},
+				"ignore": {
+					"version": "5.2.0",
+					"resolved": "https://registry.npmjs.org/ignore/-/ignore-5.2.0.tgz",
+					"integrity": "sha512-CmxgYGiEPCLhfLnpPp1MoRmifwEIOgjcHXxOBjv7mY96c+eWScsOP9c112ZyLdWHi0FxHjI+4uVhKYp/gcdRmQ==",
+					"dev": true
+				},
+				"is-path-inside": {
+					"version": "3.0.3",
+					"resolved": "https://registry.npmjs.org/is-path-inside/-/is-path-inside-3.0.3.tgz",
+					"integrity": "sha512-Fd4gABb+ycGAmKou8eMftCupSir5lRxqf4aD/vd0cD2qc4HL07OjCeuHMr8Ro4CoMaeCKDB0/ECBOVWjTwUvPQ==",
+					"dev": true
+				},
+				"open": {
+					"version": "8.4.0",
+					"resolved": "https://registry.npmjs.org/open/-/open-8.4.0.tgz",
+					"integrity": "sha512-XgFPPM+B28FtCCgSb9I+s9szOC1vZRSwgWsRUA5ylIxRTgKozqjOCrVOqGsYABPYK5qnfqClxZTFBa8PKt2v6Q==",
+					"dev": true,
+					"requires": {
+						"define-lazy-prop": "^2.0.0",
+						"is-docker": "^2.1.1",
+						"is-wsl": "^2.2.0"
+					}
+				},
+				"p-map": {
+					"version": "4.0.0",
+					"resolved": "https://registry.npmjs.org/p-map/-/p-map-4.0.0.tgz",
+					"integrity": "sha512-/bjOqmgETBYB5BoEeGVea8dmvHb2m9GLy1E9W43yeyfP6QQCZGFNa+XRceJEuDB6zqr+gKpIAmlLebMpykw/MQ==",
+					"dev": true,
+					"requires": {
+						"aggregate-error": "^3.0.0"
+					}
+				},
+				"path-type": {
+					"version": "4.0.0",
+					"resolved": "https://registry.npmjs.org/path-type/-/path-type-4.0.0.tgz",
+					"integrity": "sha512-gDKb8aZMDeD/tZWs9P6+q0J9Mwkdl6xMV8TjnGP3qJVJ06bdMgkbBlLU8IdfOsIsFz2BW1rNVT3XuNEl8zPAvw==",
+					"dev": true
+				},
+				"slash": {
+					"version": "3.0.0",
+					"resolved": "https://registry.npmjs.org/slash/-/slash-3.0.0.tgz",
+					"integrity": "sha512-g9Q1haeby36OSStwb4ntCGGGaKsaVSjQ68fBxoQcutl5fS1vuY18H3wSt3jFyFtrkx+Kz0V1G85A4MyAdDMi2Q==",
+					"dev": true
+				},
+				"temp-dir": {
+					"version": "2.0.0",
+					"resolved": "https://registry.npmjs.org/temp-dir/-/temp-dir-2.0.0.tgz",
+					"integrity": "sha512-aoBAniQmmwtcKp/7BzsH8Cxzv8OL736p7v1ihGb5e9DJ9kTwGWHrQrVB5+lfVDzfGrdRzXch+ig7LHaY1JTOrg==",
+					"dev": true
+				},
+				"tempy": {
+					"version": "1.0.1",
+					"resolved": "https://registry.npmjs.org/tempy/-/tempy-1.0.1.tgz",
+					"integrity": "sha512-biM9brNqxSc04Ee71hzFbryD11nX7VPhQQY32AdDmjFvodsRFz/3ufeoTZ6uYkRFfGo188tENcASNs3vTdsM0w==",
+					"dev": true,
+					"requires": {
+						"del": "^6.0.0",
+						"is-stream": "^2.0.0",
+						"temp-dir": "^2.0.0",
+						"type-fest": "^0.16.0",
+						"unique-string": "^2.0.0"
+					}
+				},
+				"type-fest": {
+					"version": "0.16.0",
+					"resolved": "https://registry.npmjs.org/type-fest/-/type-fest-0.16.0.tgz",
+					"integrity": "sha512-eaBzG6MxNzEn9kiwvtre90cXaNLkmadMWa1zQMs3XORCXNbsH/OewwbxC5ia9dCxIxnTAsSxXJaa/p5y8DlvJg==",
+					"dev": true
+				},
+				"unique-string": {
+					"version": "2.0.0",
+					"resolved": "https://registry.npmjs.org/unique-string/-/unique-string-2.0.0.tgz",
+					"integrity": "sha512-uNaeirEPvpZWSgzwsPGtU2zVSTrn/8L5q/IexZmH0eH6SA73CmAA5U4GwORTxQAZs95TAXLNqeLoPPNO5gZfWg==",
+					"dev": true,
+					"requires": {
+						"crypto-random-string": "^2.0.0"
+					}
+				}
+			}
+		},
 		"opn": {
 			"version": "5.5.0",
 			"resolved": "https://registry.npmjs.org/opn/-/opn-5.5.0.tgz",
@@ -49311,6 +50526,12 @@
 				"safe-buffer": "^5.0.1",
 				"sha.js": "^2.4.8"
 			}
+		},
+		"peek-readable": {
+			"version": "4.0.2",
+			"resolved": "https://registry.npmjs.org/peek-readable/-/peek-readable-4.0.2.tgz",
+			"integrity": "sha512-9fMaz6zoxw9ypO1KZy5RDJgSupEtu0Q+g/OqqsVHX3rKGR8qehRLYzsFARZ4bVvdvfknKiXvuDbkMnO1g6cRpQ==",
+			"dev": true
 		},
 		"performance-now": {
 			"version": "2.1.0",
@@ -50827,6 +52048,12 @@
 			"version": "1.2.3",
 			"resolved": "https://registry.npmjs.org/queue-microtask/-/queue-microtask-1.2.3.tgz",
 			"integrity": "sha512-NuaNSa6flKT5JaSYQzJok04JzTL1CA6aGhv5rfLW3PgqA+M2ChpZQnAC8h8i4ZFkBS8X5RqkDBHA7r4hej3K9A==",
+			"dev": true
+		},
+		"quick-lru": {
+			"version": "5.1.1",
+			"resolved": "https://registry.npmjs.org/quick-lru/-/quick-lru-5.1.1.tgz",
+			"integrity": "sha512-WuyALRjWPDGtt/wzJiadO5AXY+8hZ80hVpe6MyivgraREW751X3SbhRvG3eLKOYN+8VEvqLcf3wdnt44Z4S4SA==",
 			"dev": true
 		},
 		"raf": {
@@ -53003,6 +54230,28 @@
 				}
 			}
 		},
+		"readable-web-to-node-stream": {
+			"version": "3.0.2",
+			"resolved": "https://registry.npmjs.org/readable-web-to-node-stream/-/readable-web-to-node-stream-3.0.2.tgz",
+			"integrity": "sha512-ePeK6cc1EcKLEhJFt/AebMCLL+GgSKhuygrZ/GLaKZYEecIgIECf4UaUuaByiGtzckwR4ain9VzUh95T1exYGw==",
+			"dev": true,
+			"requires": {
+				"readable-stream": "^3.6.0"
+			},
+			"dependencies": {
+				"readable-stream": {
+					"version": "3.6.0",
+					"resolved": "https://registry.npmjs.org/readable-stream/-/readable-stream-3.6.0.tgz",
+					"integrity": "sha512-BViHy7LKeTz4oNnkcLJ+lVSL6vpiFeX6/d3oSH8zCW7UxP2onchk+vTGB143xuFjHS3deTgkKoXXymXqymiIdA==",
+					"dev": true,
+					"requires": {
+						"inherits": "^2.0.3",
+						"string_decoder": "^1.1.1",
+						"util-deprecate": "^1.0.1"
+					}
+				}
+			}
+		},
 		"readdirp": {
 			"version": "2.2.1",
 			"resolved": "https://registry.npmjs.org/readdirp/-/readdirp-2.2.1.tgz",
@@ -54968,6 +56217,16 @@
 			"integrity": "sha512-6fPc+R4ihwqP6N/aIv2f1gMH8lOVtWQHoqC4yK6oSDVVocumAsfCqjkXnqiYMhmMwS/mEHLp7Vehlt3ql6lEig==",
 			"dev": true
 		},
+		"strtok3": {
+			"version": "6.2.4",
+			"resolved": "https://registry.npmjs.org/strtok3/-/strtok3-6.2.4.tgz",
+			"integrity": "sha512-GO8IcFF9GmFDvqduIspUBwCzCbqzegyVKIsSymcMgiZKeCfrN9SowtUoi8+b59WZMAjIzVZic/Ft97+pynR3Iw==",
+			"dev": true,
+			"requires": {
+				"@tokenizer/token": "^0.3.0",
+				"peek-readable": "^4.0.1"
+			}
+		},
 		"style-loader": {
 			"version": "1.3.0",
 			"resolved": "https://registry.npmjs.org/style-loader/-/style-loader-1.3.0.tgz",
@@ -55627,6 +56886,16 @@
 			"integrity": "sha512-yaOH/Pk/VEhBWWTlhI+qXxDFXlejDGcQipMlyxda9nthulaxLZUNcUqFxokp0vcYnvteJln5FNQDRrxj3YcbVw==",
 			"dev": true
 		},
+		"token-types": {
+			"version": "4.1.1",
+			"resolved": "https://registry.npmjs.org/token-types/-/token-types-4.1.1.tgz",
+			"integrity": "sha512-hD+QyuUAyI2spzsI0B7gf/jJ2ggR4RjkAo37j3StuePhApJUwcWDjnHDOFdIWYSwNR28H14hpwm4EI+V1Ted1w==",
+			"dev": true,
+			"requires": {
+				"@tokenizer/token": "^0.3.0",
+				"ieee754": "^1.2.1"
+			}
+		},
 		"tough-cookie": {
 			"version": "4.0.0",
 			"resolved": "https://registry.npmjs.org/tough-cookie/-/tough-cookie-4.0.0.tgz",
@@ -55646,6 +56915,12 @@
 			"requires": {
 				"punycode": "^2.1.1"
 			}
+		},
+		"trim-newlines": {
+			"version": "4.0.2",
+			"resolved": "https://registry.npmjs.org/trim-newlines/-/trim-newlines-4.0.2.tgz",
+			"integrity": "sha512-GJtWyq9InR/2HRiLZgpIKv+ufIKrVrvjQWEj7PxAXNc5dwbNJkqhAUoAGgzRmULAnoOM5EIpveYd3J2VeSAIew==",
+			"dev": true
 		},
 		"tryer": {
 			"version": "1.0.1",

--- a/package.json
+++ b/package.json
@@ -35,11 +35,15 @@
 	},
 	"jest": {
 		"testURL": "http://localhost",
+		"roots": [
+			"<rootDir>/src",
+			"<rootDir>/test"
+		],
 		"setupFiles": [
-			"./test/setupTests.js"
+			"<rootDir>/test/setupTests.js"
 		],
 		"setupFilesAfterEnv": [
-			"./test/setupAfterEnv.js"
+			"<rootDir>/test/setupAfterEnv.js"
 		],
 		"transformIgnorePatterns": [
 			".*.stories.js$"

--- a/package.json
+++ b/package.json
@@ -7,6 +7,7 @@
 		"build": "cross-env NODE_ENV=production babel src --out-dir build",
 		"format": "eslint . --fix",
 		"jest": "NODE_ENV=test jest --detectOpenHandles",
+		"jest:coverage": "npm run jest && open-cli ./coverage/index.html",
 		"jest:watch": "npm run jest --watch",
 		"lint": "eslint . -f json | eslines --quiet",
 		"storybook": "start-storybook -p 6006",
@@ -34,6 +35,11 @@
 		"**/react-dom": "17.0.1"
 	},
 	"jest": {
+		"collectCoverage": true,
+		"coverageReporters": [
+			"json",
+			"html"
+		],
 		"testURL": "http://localhost",
 		"roots": [
 			"<rootDir>/src",
@@ -53,7 +59,6 @@
 		}
 	},
 	"devDependencies": {
-		"immer": ">=9.0.6",
 		"@axe-core/react": "4.3.2",
 		"@babel/cli": "^7.14.3",
 		"@babel/core": "7.14.0",
@@ -89,7 +94,9 @@
 		"eslint-plugin-no-async-foreach": "0.1.1",
 		"eslint-plugin-react": "7.25.3",
 		"eslint-plugin-wpcalypso": "4.1.0",
+		"immer": ">=9.0.6",
 		"jest-axe": "5.0.1",
+		"open-cli": "^7.0.1",
 		"optimize-css-assets-webpack-plugin": "^6.0.1",
 		"react-input-autosize": "^3.0.0",
 		"react-refresh": "^0.9.0",

--- a/src/system/Avatar/Avatar.test.js
+++ b/src/system/Avatar/Avatar.test.js
@@ -10,22 +10,21 @@ import { axe } from 'jest-axe';
 import { Avatar } from './Avatar';
 
 describe( '<Avatar />', () => {
-	it( 'renders the Avatar without an image', () => {
-		render( <Avatar name="John Doe" /> );
+	it( 'renders the Avatar without an image', async () => {
+		const { container } = render( <Avatar name="John Doe" /> );
 
 		expect( screen.getByText( 'J' ) ).toBeInTheDocument();
+
+		// Check for accessibility issues
+		await expect( await axe( container ) ).toHaveNoViolations();
 	} );
 
-	it( 'renders the Avatar with image', () => {
-		render( <Avatar name="John Doe" src="path/to/image" /> );
+	it( 'renders the Avatar with image', async () => {
+		const { container } = render( <Avatar name="John Doe" src="path/to/image" /> );
 
 		expect( screen.getByAltText( 'Avatar image from John Doe' ) ).toBeInTheDocument();
-	} );
 
-	it( 'should not have basic accessibility issues', async () => {
-		const { container } = render( <Avatar name="John Doe" src="path/to/image" /> );
-		const results = await axe( container );
-
-		expect( results ).toHaveNoViolations();
+		// Check for accessibility issues
+		await expect( await axe( container ) ).toHaveNoViolations();
 	} );
 } );

--- a/src/system/Badge/Badge.test.js
+++ b/src/system/Badge/Badge.test.js
@@ -1,0 +1,30 @@
+/**
+ * External dependencies
+ */
+import { render, screen } from '@testing-library/react';
+import { axe } from 'jest-axe';
+
+/**
+ * Internal dependencies
+ */
+import { Badge } from './Badge';
+
+describe( '<Badge />', () => {
+	it( 'renders the Badge component', async () => {
+		const { container } = render( <Badge>Badge text</Badge> );
+
+		expect( screen.getByText( 'Badge text' ) ).toBeInTheDocument();
+
+		// Check for accessibility issues
+		await expect( await axe( container ) ).toHaveNoViolations();
+	} );
+
+	it( 'renders the Badge component with a different variant', async () => {
+		const { container } = render( <Badge variant="primary">Badge text</Badge> );
+
+		expect( screen.getByText( 'Badge text' ) ).toBeInTheDocument();
+
+		// Check for accessibility issues
+		await expect( await axe( container ) ).toHaveNoViolations();
+	} );
+} );

--- a/src/system/BlankState/BlankState.js
+++ b/src/system/BlankState/BlankState.js
@@ -10,10 +10,17 @@ import PropTypes from 'prop-types';
  */
 import { Box, Heading, Text } from '..';
 
-const BlankState = ( { image, icon, title, body, cta } ) => {
+const BlankState = ( {
+	body,
+	cta,
+	icon,
+	image,
+	imageAlt = 'Image representing the blank state',
+	title,
+} ) => {
 	return (
 		<Box sx={{ textAlign: 'center', padding: 5 }}>
-			{icon ? icon : <img src={image} sx={{ mb: 3 }} alt="Icon representing the blank state" />}
+			{icon ? icon : <img src={image} sx={{ mb: 3 }} alt={imageAlt} />}
 			<Heading variant="h4">{title}</Heading>
 			<Text>{body}</Text>
 			<Box sx={{ mt: 3 }}>{cta}</Box>
@@ -22,11 +29,12 @@ const BlankState = ( { image, icon, title, body, cta } ) => {
 };
 
 BlankState.propTypes = {
-	image: PropTypes.oneOfType( [ PropTypes.object, PropTypes.string ] ),
-	icon: PropTypes.node,
-	title: PropTypes.node,
 	body: PropTypes.node,
 	cta: PropTypes.node,
+	icon: PropTypes.node,
+	image: PropTypes.oneOfType( [ PropTypes.object, PropTypes.string ] ),
+	imageAlt: PropTypes.string,
+	title: PropTypes.node,
 };
 
 export { BlankState };

--- a/src/system/BlankState/BlankState.test.js
+++ b/src/system/BlankState/BlankState.test.js
@@ -1,0 +1,58 @@
+/**
+ * External dependencies
+ */
+import { render, screen } from '@testing-library/react';
+import { axe } from 'jest-axe';
+import { MdContentCopy } from 'react-icons/md';
+
+/**
+ * Internal dependencies
+ */
+import { BlankState } from './BlankState';
+import { Link } from '../Link';
+
+// eslint-disable-next-line max-len
+const image = "data:image/svg+xml,%3Csvg xmlns='http://www.w3.org/2000/svg' width='79' height='79' viewBox='0 0 79 79' fill='none'%3E%3Cpath d='M66.3001 15.9C66.3001 15.9 66.3 15.8 66.2 15.8C66.1 15.7 66 15.5 65.9001 15.4C65.9001 15.4 65.9001 15.4 65.9001 15.3L44.4001 0.2C44.3001 0.0999998 44.2 0.0999994 44.1 0.0999994C44 0.0999994 44.0001 0 43.9001 0H43.3C43.2 0 43.1 0.0999994 43.1 0.0999994C43 0.0999994 42.9 0.2 42.8 0.2L28.2001 10.3C28.1 10.4 28.0001 10.5 27.9001 10.6C27.9001 10.6 27.9001 10.6 27.9001 10.7C27.8001 10.8 27.7001 11 27.7001 11.2C27.7001 11.2 27.7001 11.2 27.7001 11.3V31.1L13.9 40.8L13.7001 41C13.6001 41.1 13.6 41.1 13.6 41.2L13.5 41.3C13.5 41.4 13.4 41.5 13.4 41.5V41.6C13.4 41.7 13.3 41.8 13.3 42V62.2C13.3 62.4 13.3 62.6 13.4 62.7V62.8C13.5 62.9 13.6001 63.1 13.7001 63.2C13.7001 63.2 13.7 63.2 13.8 63.3L13.9 63.4L35.3 78.6H35.4001C35.4001 78.6 35.5 78.6 35.5 78.7H35.6C35.8 78.8 36 78.8 36.2001 78.8C36.3001 78.8 36.5 78.8 36.6 78.7H36.7001C36.8001 78.7 36.8001 78.7 36.9001 78.6C36.9001 78.6 37 78.6 37 78.5H37.1L66 58.3C66.1 58.2 66.2001 58.1 66.3001 58V15.9ZM34.6 74.5L16.1 61.3V44.7L34.6 57.8V74.5ZM36 55.3L17.2001 41.9L29 33.5L47.9001 46.9L36 55.3ZM49 44.1L30.5 31V14.4L49 27.5V44.1ZM50.5 24.9L31.6 11.5L43.5 3.2L62.4001 16.6L50.5 24.9Z' fill='%23BD9D70'/%3E%3C/svg%3E";
+
+const defaultProps = {
+	body: 'Sorry, there\'s nothing here yet.',
+	cta: <Link as="a">Explore add-ons →</Link>,
+	image,
+	imageAlt: 'This is the image alt',
+	title: 'Power up your application',
+};
+
+describe( '<BlankState />', () => {
+	it( 'renders the BlankState component', async () => {
+		const { container } = render( <BlankState { ...defaultProps } /> );
+
+		expect( screen.getByText( defaultProps.body ) ).toBeInTheDocument();
+		expect( screen.getByText( defaultProps.title ) ).toBeInTheDocument();
+		expect( screen.getByText( 'Explore add-ons →' ) ).toBeInTheDocument();
+		expect( screen.getByAltText( defaultProps.imageAlt ) ).toBeInTheDocument();
+
+		// Check for accessibility issues
+		await expect( await axe( container ) ).toHaveNoViolations();
+	} );
+
+	it( 'renders the BlankState component with default alt text for the given image', async () => {
+		const props = { ...defaultProps, imageAlt: undefined };
+		const { container } = render( <BlankState { ...props } /> );
+
+		expect( screen.getByAltText( 'Image representing the blank state' ) ).toBeInTheDocument();
+
+		// Check for accessibility issues
+		await expect( await axe( container ) ).toHaveNoViolations();
+	} );
+
+	it( 'renders the BlankState component with an icon', async () => {
+		const icon = <MdContentCopy title="this is an icon" />;
+		const props = { ...defaultProps, icon };
+		const { container } = render( <BlankState { ...props } /> );
+
+		expect( screen.getByTitle( 'this is an icon' ) ).toBeInTheDocument();
+
+		// Check for accessibility issues
+		await expect( await axe( container ) ).toHaveNoViolations();
+	} );
+} );

--- a/src/system/Card/Card.test.js
+++ b/src/system/Card/Card.test.js
@@ -1,0 +1,33 @@
+/**
+ * External dependencies
+ */
+import { render, screen, fireEvent, waitFor } from '@testing-library/react';
+import { axe } from 'jest-axe';
+import { MdContentCopy } from 'react-icons/md';
+
+/**
+ * Internal dependencies
+ */
+import { Card } from './Card';
+
+const defaultProps = {};
+
+describe( '<Card />', () => {
+	it( 'renders the Card component', async () => {
+		const { container } = render( <Card { ...defaultProps }>This is a Card</Card> );
+
+		expect( screen.getByText( 'This is a Card' ) ).toBeInTheDocument();
+
+		// Check for accessibility issues
+		await expect( await axe( container ) ).toHaveNoViolations();
+	} );
+
+	it( 'renders the Card component with a different variant', async () => {
+		const { container } = render( <Card variant="primary">Card text</Card> );
+
+		expect( screen.getByText( 'Card text' ) ).toBeInTheDocument();
+
+		// Check for accessibility issues
+		await expect( await axe( container ) ).toHaveNoViolations();
+	} );
+} );

--- a/src/system/Code/Code.js
+++ b/src/system/Code/Code.js
@@ -47,18 +47,21 @@ const Code = ( { prompt = false, showCopy = false, onCopy = null, ...props } ) =
 		>
 			{ codeDom }
 			{
-				<span
+				<button
+					aria-label="Copy"
 					sx={ {
-						position: 'absolute',
-						top: 0,
 						bg: 'grey.10',
-						right: 0,
-						paddingRight: 2,
-						paddingLeft: 2,
-						paddingTop: 1,
-						paddingBottom: 1,
 						borderTopRightRadius: 1,
+						borderWidth: 0,
+						color: 'muted',
 						opacity: 0.8,
+						paddingBottom: 1,
+						paddingLeft: 2,
+						paddingRight: 2,
+						paddingTop: 1,
+						position: 'absolute',
+						right: 0,
+						top: '-1px',
 						'&:hover': {
 							opacity: 1,
 							cursor: 'pointer',
@@ -75,7 +78,7 @@ const Code = ( { prompt = false, showCopy = false, onCopy = null, ...props } ) =
 					} }
 				>
 					{ copied ? 'Copied!' : <MdContentCopy /> }
-				</span>
+				</button>
 			}
 		</div>
 	);

--- a/src/system/Code/Code.stories.js
+++ b/src/system/Code/Code.stories.js
@@ -16,7 +16,9 @@ export default {
 export const Default = () => (
 	<React.Fragment>
 		<Code>Code</Code>
+		<br />
 		<Code showCopy={true}>Code with Icon</Code>
+		<br />
 		<Code showCopy={true} onCopy={
 			// eslint-disable-next-line no-console
 			() => console.info( 'Hello world' )

--- a/src/system/Code/Code.test.js
+++ b/src/system/Code/Code.test.js
@@ -1,0 +1,69 @@
+/**
+ * External dependencies
+ */
+import { render, screen, fireEvent, waitFor } from '@testing-library/react';
+import { axe } from 'jest-axe';
+import { MdContentCopy } from 'react-icons/md';
+
+/**
+ * Internal dependencies
+ */
+import { Code } from './Code';
+
+const defaultProps = {
+	showCopy: false,
+};
+
+// Mock navigator.clipboard because jsdom doesn't support it
+Object.defineProperty( window.navigator, 'clipboard', {
+	value: {
+		writeText: () => {},
+	},
+} );
+
+describe( '<Code />', () => {
+	it( 'renders the Code component', async () => {
+		const { container } = render( <Code { ...defaultProps }>This is a code</Code> );
+
+		expect( screen.getByText( 'This is a code' ) ).toBeInTheDocument();
+
+		// Check for accessibility issues
+		await expect( await axe( container ) ).toHaveNoViolations();
+	} );
+
+	// jsdom currently doesn't support pseudo-elements with getComputedStyle
+	it.skip( 'renders "$" in front of the code when in prompt mode', async () => {
+		const props = { ...defaultProps, prompt: true };
+		const { container } = render( <Code { ...props }>This is a code</Code> );
+		const codeElement = screen.getByText( 'This is a code' );
+
+		expect( window.getComputedStyle( codeElement, ':before' ).content ).toEqual( '$' );
+
+		// Check for accessibility issues
+		await expect( await axe( container ) ).toHaveNoViolations();
+	} );
+
+	it( 'renders the Code component with a copy button', async () => {
+		const props = { ...defaultProps, showCopy: true };
+		const { container } = render( <Code { ...props }>This is a code</Code> );
+
+		expect( screen.getByRole( 'button', { name: 'Copy' } ) ).toBeInTheDocument();
+
+		// Check for accessibility issues
+		await expect( await axe( container ) ).toHaveNoViolations();
+	} );
+
+	it( 'updates the the UI after clicking on "Copy"', async () => {
+		const props = { ...defaultProps, showCopy: true };
+		const { container } = render( <Code { ...props }>This is a code</Code> );
+
+		fireEvent.click( screen.getByRole( 'button', { name: 'Copy' } ) );
+
+		await waitFor( () => new Promise( res => setTimeout( res, 0 ) ) );
+
+		expect( screen.getByText( 'Copied!' ) ).toBeInTheDocument();
+
+		// Check for accessibility issues
+		await expect( await axe( container ) ).toHaveNoViolations();
+	} );
+} );


### PR DESCRIPTION
## Description

```
npm run jest:coverage
```

The command will run Jest tests, collect coverage, generate an HTML report and open it in a new browser window like this:

![Coverage](https://user-images.githubusercontent.com/156388/146807915-9866d2a4-f067-42c6-95a5-6e7c30860f7a.png)

![CoverageDetail](https://user-images.githubusercontent.com/156388/146808457-794e8271-f2cd-4198-aebd-8d346a90e069.png)

Allows tracking how much coverage we are getting with our current test efforts.

Please merge the following Pull Requests first:
- https://github.com/Automattic/vip-design-system/pull/38
- https://github.com/Automattic/vip-design-system/pull/39
- https://github.com/Automattic/vip-design-system/pull/40
- https://github.com/Automattic/vip-design-system/pull/41

## Checklist

- [x] This PR has good automated test coverage
- [ ] The storybook for the component has been updated

## Steps to Test

1. Pull down PR.
2. `npm run jest:coverage`.
