### PR TITLE
Close dropdown dialog on click

### DIFF
--- a/src/system/Dialog/Dialog.js
+++ b/src/system/Dialog/Dialog.js
@@ -16,8 +16,22 @@ const Dialog = ( { trigger, position = 'left', startOpen = false, content, disab
 	const [ isOpen, setIsOpen ] = useState( startOpen );
 	const dialogRef = useRef( null );
 
+	const isFunction = typeof content === 'function';
+
+	const hasDialog = component => {
+		if ( component?.type === Dialog ) {
+			return true;
+		}
+
+		if ( component?.props?.children ) {
+			return hasDialog( component.props.children );
+		}
+
+		return false;
+	};
+
 	const closeDialog = e => {
-		if ( props.variant !== 'modal' ) {
+		if ( ! props.variant && ! hasDialog( content ) && ! isFunction ) {
 			setIsOpen( false );
 		}
 
@@ -31,9 +45,6 @@ const Dialog = ( { trigger, position = 'left', startOpen = false, content, disab
 
 		return () => window.document.removeEventListener( 'click', closeDialog, true );
 	}, [] );
-
-	// if content is a function, pass in onClose
-	const isFunction = typeof content === 'function';
 
 	const handleOpen = ( event = null ) => {
 		const open = ! isOpen;

--- a/src/system/Dialog/Dialog.js
+++ b/src/system/Dialog/Dialog.js
@@ -17,6 +17,10 @@ const Dialog = ( { trigger, position = 'left', startOpen = false, content, disab
 	const dialogRef = useRef( null );
 
 	const closeDialog = e => {
+		if ( props.variant !== 'modal' ) {
+			setIsOpen( false );
+		}
+
 		if ( ! dialogRef.current.contains( e.target ) ) {
 			setIsOpen( false );
 		}
@@ -70,6 +74,7 @@ const Dialog = ( { trigger, position = 'left', startOpen = false, content, disab
 
 Dialog.propTypes = {
 	trigger: PropTypes.node,
+	variant: PropTypes.string,
 	disabled: PropTypes.bool,
 	position: PropTypes.string,
 	startOpen: PropTypes.bool,

--- a/src/system/Dialog/Dialog.stories.js
+++ b/src/system/Dialog/Dialog.stories.js
@@ -20,6 +20,8 @@ export default {
 
 const DropdownTrigger = <Button>Trigger Dropdown</Button>;
 const ModalTrigger = <Button sx={{ mr: 3 }}>Trigger Modal</Button>;
+const DialogAndModalTrigger = <Button sx={{ ml: 3 }}>Dropdown + Modal</Button>;
+const SidebarTrigger = <Button sx={{ ml: 3 }}>Sidebar</Button>;
 
 const DropdownContent = (
 	<div>
@@ -59,6 +61,29 @@ export const Default = () => (
 			trigger={DropdownTrigger}
 			content={DropdownContent}
 			sx={{ width: 200 }}
+		/>
+		<Dialog
+			position="right"
+			sx={ { width: 240 } }
+			trigger={ DialogAndModalTrigger }
+			content={
+				<div>
+					<div>
+						<DialogMenu>
+							<Dialog
+								variant="modal"
+								trigger={ <DialogMenuItem>Modal</DialogMenuItem> }
+								content={ ModalContent }
+							/>
+						</DialogMenu>
+					</div>
+				</div>
+			}
+		/>
+		<Dialog
+			variant="sidebar"
+			trigger={ SidebarTrigger }
+			content={ ModalContent }
 		/>
 	</Flex>
 );


### PR DESCRIPTION
## Description

This PR fixes the bug known as "dialog doesn't close when clicking."

Before:

https://user-images.githubusercontent.com/33168/151986966-362601b0-9db3-4662-ad6f-05ed98078392.mov





After:

https://user-images.githubusercontent.com/33168/151987787-4a393c69-003e-4df3-8c20-4e671f0dd888.mov

Ps: the `console.log( 'Profile Click!' )` from `<DialogMenuItem onClick={ () => console.log( 'Profile Click!' ) }>Profile</DialogMenuItem>` was removed from the `Dialog.stories.js` before committing. 





https://vipjira.atlassian.net/browse/CAFE-412

## Checklist

- [ ] This PR has good automated test coverage
- [ ] The storybook for the component has been updated

## Steps to Test

1. Pull down PR.
2. `npm run storybook`.
3. Go to Dialog > Default
4. Click on Trigger Dropdown
5. Click on Profile, and the dialog should close.
