### PR TITLE
Add/use portal to select

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -1,12 +1,12 @@
 {
 	"name": "@automattic/vip-design-system",
-	"version": "0.9.1",
+	"version": "0.9.2",
 	"lockfileVersion": 2,
 	"requires": true,
 	"packages": {
 		"": {
 			"name": "@automattic/vip-design-system",
-			"version": "0.9.1",
+			"version": "0.9.2",
 			"dependencies": {
 				"@radix-ui/react-checkbox": "^0.1.0",
 				"@radix-ui/react-radio-group": "^0.1.0",

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
 	"name": "@automattic/vip-design-system",
-	"version": "0.9.1",
+	"version": "0.9.2",
 	"main": "build/system/index.js",
 	"scripts": {
 		"build-storybook": "build-storybook",

--- a/src/system/Form/Input.js
+++ b/src/system/Form/Input.js
@@ -28,7 +28,7 @@ const Input = React.forwardRef( ( { variant, label, forLabel, hasError, required
 			required={ required }
 			sx={ {
 				border: '1px solid',
-				borderColor: 'grey.60',
+				borderColor: 'border',
 				backgroundColor: 'card',
 				borderRadius: 1,
 				lineHeight: 'inherit',
@@ -47,7 +47,7 @@ const Input = React.forwardRef( ( { variant, label, forLabel, hasError, required
 					bg: 'backgroundSecondary',
 				},
 				'&::placeholder': {
-					color: 'grey.30',
+					color: 'placeholder',
 				},
 			} }
 		/>

--- a/src/system/Form/Select.js
+++ b/src/system/Form/Select.js
@@ -3,19 +3,28 @@
 /**
  * External dependencies
  */
+import React from 'react';
 import PropTypes from 'prop-types';
 
 /**
-  * Internal dependencies
-  */
+ * Internal dependencies
+ */
 import { SearchSelect } from './SearchSelect';
 import { InlineSelect } from './InlineSelect';
 
-const Select = ( { isMulti = false, isInline, options, label, isSearch, ...props } ) => {
-	if ( isInline ) {
-		return <InlineSelect isMulti={ isMulti } label={ label } options={ options } { ...props } />;
+const Select = ( { isMulti = false, isInline, options, label, isSearch, usePortal, ...props } ) => {
+	const selectRef = React.useRef();
+	const portalProps = {};
+
+	if ( usePortal !== undefined ) {
+		portalProps.menuPortalTarget =
+			selectRef?.current?.querySelector( '.select__control' ).parentElement;
+		portalProps.styles = { menuPortal: base => ( { ...base, position: 'fixed' } ) };
 	}
-	return <SearchSelect isMulti={ isMulti } label={ label } options={ options } { ...props } />;
+
+	const Component = isInline ? InlineSelect : SearchSelect;
+
+	return <div ref={selectRef}><Component isMulti={isMulti} label={label} options={options} {...portalProps} {...props} /></div>;
 };
 
 Select.propTypes = {
@@ -24,6 +33,7 @@ Select.propTypes = {
 	isSearch: PropTypes.bool,
 	label: PropTypes.string,
 	options: PropTypes.array,
+	usePortal: PropTypes.bool,
 };
 
 export { Select };

--- a/src/system/Form/Select.stories.js
+++ b/src/system/Form/Select.stories.js
@@ -6,15 +6,7 @@ import { useState } from 'react';
 /**
  * Internal dependencies
  */
-import {
-	Box,
-	Dialog,
-	DialogMenu,
-	DialogMenuItem,
-	DialogDivider,
-	Select,
-	Button,
-} from '..';
+import { Box, Dialog, DialogMenu, DialogMenuItem, DialogDivider, Select, Button } from '..';
 
 export default {
 	title: 'Select',
@@ -44,43 +36,79 @@ const DropdownContent = (
 const DropdownTrigger = <Button variant="secondary">Trigger Dropdown</Button>;
 
 export const Multi = () => {
-	const [ value, setValue ] = useState( [ ] );
+	const [ value, setValue ] = useState( [] );
 
 	return (
-		<Box sx={ { mr: 2, width: 400 } }>
-			<Select label="Type" value={ value } isMulti placeholder="Select domains..." options={ options } onChange={ newValue => setValue( newValue ) } />
+		<Box sx={{ mr: 2, width: 400 }}>
+			<Select
+				label="Type"
+				value={value}
+				isMulti
+				placeholder="Select domains..."
+				options={options}
+				onChange={newValue => setValue( newValue )}
+			/>
+		</Box>
+	);
+};
+
+export const usePortal = () => {
+	const [ value, setValue ] = useState( [] );
+
+	return (
+		<Box sx={{ mr: 2, width: 400 }}>
+			<Select
+				label="Type"
+				value={value}
+				isMulti
+				placeholder="Select domains..."
+				usePortal
+				options={options}
+				onChange={newValue => setValue( newValue )}
+			/>
 		</Box>
 	);
 };
 
 export const Single = () => {
-	const [ value, setValue ] = useState( [ ] );
+	const [ value, setValue ] = useState( [] );
 
 	return (
-		<Box sx={ { mr: 2, width: 200 } }>
-			<Select label="User" value={ value } placeholder="Select a domain..." options={ options } onChange={ newValue => setValue( newValue ) } />
+		<Box sx={{ mr: 2, width: 200 }}>
+			<Select
+				label="User"
+				value={value}
+				placeholder="Select a domain..."
+				options={options}
+				onChange={newValue => setValue( newValue )}
+			/>
 		</Box>
 	);
 };
 
 export const Inline = () => {
-	const [ value, setValue ] = useState( [ ] );
+	const [ value, setValue ] = useState( [] );
 
 	return (
-		<Box sx={ { mr: 2, width: 200 } }>
-			<Select label="User" value={ value } isInline isMulti noneLabel="Everyone" placeholder="Filter by user..." options={ options } onChange={ newValue => setValue( newValue ) } />
+		<Box sx={{ mr: 2, width: 200 }}>
+			<Select
+				label="User"
+				value={value}
+				isInline
+				isMulti
+				noneLabel="Everyone"
+				placeholder="Filter by user..."
+				options={options}
+				onChange={newValue => setValue( newValue )}
+			/>
 		</Box>
 	);
 };
 
 export const DropdownMenu = () => {
 	return (
-		<Box sx={ { mr: 2, width: 200 } }>
-			<Dialog
-				trigger={DropdownTrigger}
-				content={DropdownContent}
-				sx={{ width: 200 }}
-			/>
+		<Box sx={{ mr: 2, width: 200 }}>
+			<Dialog trigger={DropdownTrigger} content={DropdownContent} sx={{ width: 200 }} />
 		</Box>
 	);
 };

--- a/src/system/theme/index.js
+++ b/src/system/theme/index.js
@@ -88,7 +88,7 @@ export default {
 		muted: light.grey[ '90' ],
 		link: light.brand[ '90' ],
 		card: '#fff',
-		border: light.grey[ '20' ],
+		border: light.grey[ '60' ],
 		hover: 'rgba(0,0,0,.02)',
 		lightenBackground: 'rgba(255,255,255,.5)',
 		darken: 'rgba(0,0,0,.05)',


### PR DESCRIPTION
## Description

Adds a `usePortal` prop to allow the usage of the `menuPortalTarget` easily from the UI. This is a recurrent issue that overlaps divs. See screenshot below

![Screen Shot 2022-03-16 at 22 35 42](https://user-images.githubusercontent.com/3402/158719058-fdb8fa5e-8ad9-47bb-be79-45ddc1b8f9f1.png)

![Screen Shot 2022-03-16 at 22 36 05](https://user-images.githubusercontent.com/3402/158719093-686ba2a1-54ad-4b27-84e4-b52dd17818a2.png)

This PR also fixes the placeholder color for the Input.

Preview: https://deploy-preview-52--vip-design-system-components.netlify.app/?path=/story/select--use-portal

## Checklist

- [ ] This PR has good automated test coverage
- [ ] The storybook for the component has been updated

## Steps to Test

1. Pull down PR.
2. `npm run build`.
3. Copy the vip-design-system/build contents into the vip-ui/node_modules/@automattic/vip-design-system/build folder
4. Start the vip-ui `npm run dev`
5. Go to http://localhost:3000/apps/2003/production/settings/backup-shipping
6. Check that all <Select> components are not overlapping the page and the styles are accurate