### PR TITLE
Fix border color for light theme

### DIFF
--- a/src/system/theme/index.js
+++ b/src/system/theme/index.js
@@ -88,7 +88,7 @@ export default {
 		muted: light.grey[ '90' ],
 		link: light.brand[ '90' ],
 		card: '#fff',
-		border: light.grey[ '60' ],
+		border: light.grey[ '20' ],
 		hover: 'rgba(0,0,0,.02)',
 		lightenBackground: 'rgba(255,255,255,.5)',
 		darken: 'rgba(0,0,0,.05)',


### PR DESCRIPTION
## Description

Fixes the regression bug with the light `border` color. 

<img width="2032" alt="Screen Shot 2022-03-17 at 17 17 05" src="https://user-images.githubusercontent.com/3402/158888171-8010bb90-a0c6-4a5f-bf8d-86c08c99a634.png">

<img width="1700" alt="Screen Shot 2022-03-17 at 17 17 16" src="https://user-images.githubusercontent.com/3402/158888194-64124287-b474-4ffa-a137-2a049a1a5193.png">

## Checklist

- [ ] This PR has good automated test coverage
- [ ] The storybook for the component has been updated

## Steps to Test

1. Pull down PR.
2. `npm run storybook`.
3. Open Storybook.
4. Border colors should be lighter
