### PR TITLE
Fix dropdown component errors

### DIFF
--- a/src/system/Form/SearchSelect.js
+++ b/src/system/Form/SearchSelect.js
@@ -12,6 +12,7 @@ import PropTypes from 'prop-types';
  */
 import { Flex, Text } from '..';
 
+// Option component
 export const Option = ( { label, isSelected, ...props } ) => (
 	<components.Option {...props}>
 		<Flex sx={{ alignItems: 'center' }}>
@@ -32,6 +33,7 @@ Option.propTypes = {
 	isSelected: PropTypes.bool,
 };
 
+// DropdownIndicator component
 export const DropdownIndicator = ( {
 	innerProps,
 	isFocused,
@@ -69,6 +71,7 @@ DropdownIndicator.propTypes = {
 	theme: PropTypes.object,
 };
 
+// ClearIndicator component
 const ClearIndicator = ( { innerProps: { ref, ...restInnerProps }, ...props } ) => (
 	<MdClose ref={ref} {...restInnerProps} {...props} sx={{ color: 'text', mr: 2 }} />
 );
@@ -77,6 +80,7 @@ ClearIndicator.propTypes = {
 	innerProps: PropTypes.object,
 };
 
+// Parent SearchSelect component
 const SearchSelect = props => (
 	<Select
 		{ ...props }

--- a/src/system/Form/SearchSelect.js
+++ b/src/system/Form/SearchSelect.js
@@ -51,6 +51,24 @@ export const DropdownIndicator = ( {
     ...props
 } ) => <MdExpandMore { ...props } sx={ { color: 'text', mr: 2 } } />;
 
+DropdownIndicator.propTypes = {
+	innerProps: PropTypes.object,
+	isFocused: PropTypes.bool,
+	isDisabled: PropTypes.bool,
+	clearValue: PropTypes.func,
+	cx: PropTypes.func,
+	getStyles: PropTypes.func,
+	getValue: PropTypes.func,
+	hasValue: PropTypes.bool,
+	isMulti: PropTypes.bool,
+	isRtl: PropTypes.bool,
+	options: PropTypes.array,
+	selectProps: PropTypes.object,
+	setValue: PropTypes.func,
+	selectOption: PropTypes.func,
+	theme: PropTypes.object,
+};
+
 const ClearIndicator = ( { innerProps: { ref, ...restInnerProps }, ...props } ) => (
 	<MdClose ref={ref} {...restInnerProps} {...props} sx={{ color: 'text', mr: 2 }} />
 );

--- a/src/system/Form/SearchSelect.js
+++ b/src/system/Form/SearchSelect.js
@@ -32,7 +32,24 @@ Option.propTypes = {
 	isSelected: PropTypes.bool,
 };
 
-export const DropdownIndicator = props => <MdExpandMore { ...props } sx={ { color: 'text', mr: 2 } } />;
+export const DropdownIndicator = ( {
+	innerProps,
+    isFocused,
+    isDisabled,
+    clearValue,
+    cx,
+    getStyles,
+    getValue,
+    hasValue,
+    isMulti,
+    isRtl,
+    options,
+	selectProps,
+    setValue,
+	selectOption,
+    theme,
+    ...props
+} ) => <MdExpandMore { ...props } sx={ { color: 'text', mr: 2 } } />;
 
 const ClearIndicator = ( { innerProps: { ref, ...restInnerProps }, ...props } ) => (
 	<MdClose ref={ref} {...restInnerProps} {...props} sx={{ color: 'text', mr: 2 }} />

--- a/src/system/Form/SearchSelect.js
+++ b/src/system/Form/SearchSelect.js
@@ -34,21 +34,21 @@ Option.propTypes = {
 
 export const DropdownIndicator = ( {
 	innerProps,
-    isFocused,
-    isDisabled,
-    clearValue,
-    cx,
-    getStyles,
-    getValue,
-    hasValue,
-    isMulti,
-    isRtl,
-    options,
+	isFocused,
+	isDisabled,
+	clearValue,
+	cx,
+	getStyles,
+	getValue,
+	hasValue,
+	isMulti,
+	isRtl,
+	options,
 	selectProps,
-    setValue,
+	setValue,
 	selectOption,
-    theme,
-    ...props
+	theme,
+	...props
 } ) => <MdExpandMore { ...props } sx={ { color: 'text', mr: 2 } } />;
 
 DropdownIndicator.propTypes = {

--- a/src/system/Form/Select.stories.js
+++ b/src/system/Form/Select.stories.js
@@ -105,6 +105,23 @@ export const Inline = () => {
 	);
 };
 
+export const AsyncSearch = () => {
+	const [ value, setValue ] = useState( [] );
+
+	return (
+		<Box sx={{ mr: 2, width: 200 }}>
+			<Select
+				isAsync
+				label={ 'Search...' }
+				value={ value }
+				placeholder={ 'Search...' }
+				options={ options }
+				onChange={ newValue => setValue( newValue ) }
+			/>
+		</Box>
+	);
+};
+
 export const DropdownMenu = () => {
 	return (
 		<Box sx={{ mr: 2, width: 200 }}>

--- a/src/system/Form/Select.stories.js
+++ b/src/system/Form/Select.stories.js
@@ -105,42 +105,6 @@ export const Inline = () => {
 	);
 };
 
-export const Async = () => {
-	let filteredOptions;
-	const [ value, setValue ] = useState();
-
-	// We need to return a formatted object for our async wrapper
-	const asyncOptions = search => {
-		if ( !! search ) {
-			filteredOptions = options.filter( ( { label: optionLabel } ) => {
-				const matching = optionLabel.toLowerCase().includes( search );
-
-				return matching;
-			} );
-		}
-
-		const selections = {
-			options: filteredOptions ? filteredOptions : options,
-			hasMore: true,
-		};
-
-		return selections;
-	};
-
-	return (
-		<Box sx={ { mr: 2, width: 200 } }>
-			<Select
-				isAsync
-				label="Search..."
-				value={ value }
-				placeholder="Search..."
-				loadOptions={ asyncOptions }
-				onChange={ newValue => setValue( newValue ) }
-			/>
-		</Box>
-	);
-};
-
 export const DropdownMenu = () => {
 	return (
 		<Box sx={{ mr: 2, width: 200 }}>

--- a/src/system/Form/Select.stories.js
+++ b/src/system/Form/Select.stories.js
@@ -105,17 +105,36 @@ export const Inline = () => {
 	);
 };
 
-export const AsyncSearch = () => {
-	const [ value, setValue ] = useState( [] );
+export const Async = () => {
+	let filteredOptions;
+	const [ value, setValue ] = useState();
+
+	// We need to return a formatted object for our async wrapper
+	const asyncOptions = search => {
+		if ( !! search ) {
+			filteredOptions = options.filter( ( { label: optionLabel } ) => {
+				const matching = optionLabel.toLowerCase().includes( search );
+
+				return matching;
+			} );
+		}
+
+		const selections = {
+			options: filteredOptions ? filteredOptions : options,
+			hasMore: true,
+		};
+
+		return selections;
+	};
 
 	return (
-		<Box sx={{ mr: 2, width: 200 }}>
+		<Box sx={ { mr: 2, width: 200 } }>
 			<Select
 				isAsync
-				label={ 'Search...' }
+				label="Search..."
 				value={ value }
-				placeholder={ 'Search...' }
-				options={ options }
+				placeholder="Search..."
+				loadOptions={ asyncOptions }
 				onChange={ newValue => setValue( newValue ) }
 			/>
 		</Box>


### PR DESCRIPTION
## Description

#51 was showing 13 errors/warnings in the console 😲 .

After some digging, it looks like this was due to some missing props that are required for the `DropdownIndicator` component. By explicitly passing them down, we won't pass them down via `props` to child components then eventually to the DOM.

## Checklist

- [ N/A ] This PR has good automated test coverage
- [ N/A ] The storybook for the component has been updated

## Steps to Test

1. Pull down PR.
1. `npm run test`
1. You shouldn't see these pesky errors:
<img width="582" alt="Screen Shot 2022-03-21 at 8 48 58 PM" src="https://user-images.githubusercontent.com/29221840/159413282-4bf2d497-e82e-4d2d-be44-60693ccef117.png">
