### PR TITLE
PIE-3033 Hides image from screen readers

### DIFF
--- a/.github/workflows/nodejs.yaml
+++ b/.github/workflows/nodejs.yaml
@@ -21,7 +21,7 @@ jobs:
       uses: actions/setup-node@v1
       with:
         node-version: ${{ matrix.node-version }}
-    - run: npm install -g npm@latest
+    - run: npm install -g npm@7.24.2
     - run: npm install
     - run: npm run test
     - run: npm run build

--- a/src/system/Timeline/Timeline.js
+++ b/src/system/Timeline/Timeline.js
@@ -26,7 +26,7 @@ const Timeline = ( { time, first = false, last = false, ...props } ) => (
 			{ ! first && (
 				<VerticalLine />
 			) }
-			<MdWatchLater sx={ { color: 'border' } } size={ 18 }/>
+			<MdWatchLater aria-hidden sx={ { color: 'border' } } size={ 18 }/>
 			{ ! last && (
 				<VerticalLine />
 			) }


### PR DESCRIPTION
## Description

It's not useful for screen readers users to hear "image" when going through items of a timeline.

## Checklist

- [ ] This PR has good automated test coverage
- [ ] The storybook for the component has been updated

## Steps to Test

1. Pull down PR.
2. `npm run storybook`.
3. Open Storybook.
4. Go to the Timeline component
5. Enable screen reader (Cmd + F5 on Mac) and check if it reads out the image on the timeline.
