### PR TITLE
Add experimental data attributes to mapped elements

### DIFF
--- a/src/system/OptionRow/OptionRow.js
+++ b/src/system/OptionRow/OptionRow.js
@@ -24,6 +24,7 @@ const OptionRow = ( {
 	to,
 	small = false,
 	disabled = false,
+	order = null,
 	...props
 } ) => {
 	const mergedCard = disabled
@@ -53,6 +54,7 @@ const OptionRow = ( {
 			to={to}
 			columns={[ 1, 1, 'auto 1fr auto' ]}
 			gap={[ 3, 3, `${ small ? 3 : 4 }` ]}
+			data-order={ order || undefined }
 			{...props}
 			sx={{
 				alignItems: 'center',
@@ -119,6 +121,7 @@ OptionRow.propTypes = {
 	to: PropTypes.string,
 	small: PropTypes.bool,
 	disabled: PropTypes.bool,
+	order: PropTypes.number,
 };
 
 export { OptionRow };

--- a/src/system/OptionRow/OptionRow.stories.js
+++ b/src/system/OptionRow/OptionRow.stories.js
@@ -26,6 +26,7 @@ export const Default = () => (
 			label="Option Row"
 			subTitle="Mostly used to link off to other pages."
 			as="a"
+			order={ 2 }
 		/>
 	</Box>
 );

--- a/src/system/OptionRow/OptionRow.test.js
+++ b/src/system/OptionRow/OptionRow.test.js
@@ -1,0 +1,31 @@
+/**
+ * External dependencies
+ */
+import { render, screen } from '@testing-library/react';
+import { axe } from 'jest-axe';
+
+/**
+* Internal dependencies
+*/
+import { OptionRow } from './OptionRow';
+
+// eslint-disable-next-line max-len
+const image1 = "data:image/svg+xml,%3Csvg xmlns='http://www.w3.org/2000/svg' width='79' height='79' viewBox='0 0 79 79' fill='none' %3E%3Cpath d='M71.4 15.3L54.2 4.2C54 4 53.7 4 53.4 4H26.4C26.1 4 25.8 4.1 25.6 4.2L8.29997 15.3C7.89997 15.6 7.59998 16 7.59998 16.5V32.1V63C7.59998 63.5 7.89997 64 8.29997 64.2L25.5 75.3C25.5 75.3 25.6 75.3 25.6 75.4C25.6 75.4 25.7 75.4 25.7 75.5C25.9 75.6 26 75.6 26.2 75.6H53.2C53.4 75.6 53.5 75.6 53.7 75.5C53.8 75.5 53.8 75.5 53.8 75.4C53.8 75.4 53.9 75.4 53.9 75.3L71.4 64.2C71.5 64.1 71.7 64 71.8 63.8C71.8 63.8 71.8 63.7 71.9 63.7C72 63.6 72.1 63.4 72.1 63.2V63.1C72.1 63 72.1 62.9 72.1 62.8V32.1V16.5C72.1 16 71.8 15.6 71.4 15.3ZM24.9 71.4L10.6 62.2V34.8L24.9 44V71.4ZM51.9 72.6H27.8V44.7H51.9V72.6ZM69.1 31.3L52.9 41.7H26.8L10.6 31.3V17.3L26.8 6.9H52.9L69.1 17.3V31.3Z' fill='%23BD9D70' /%3E%3C/svg%3E";
+
+describe( '<OptionRow />', () => {
+	it( 'renders the OptionRow', async () => {
+		const { container } = render(
+			<OptionRow
+				image={image1}
+				label="Option Row"
+				subTitle="Mostly used to link off to other pages."
+				as="a"
+			/>
+		);
+
+		expect( screen.getByText( 'Mostly used to link off to other pages.' ) ).toBeInTheDocument();
+
+		// Check for accessibility issues
+		await expect( await axe( container ) ).toHaveNoViolations();
+	} );
+} );

--- a/src/system/OptionRow/OptionRow.test.js
+++ b/src/system/OptionRow/OptionRow.test.js
@@ -9,14 +9,10 @@ import { axe } from 'jest-axe';
 */
 import { OptionRow } from './OptionRow';
 
-// eslint-disable-next-line max-len
-const image1 = "data:image/svg+xml,%3Csvg xmlns='http://www.w3.org/2000/svg' width='79' height='79' viewBox='0 0 79 79' fill='none' %3E%3Cpath d='M71.4 15.3L54.2 4.2C54 4 53.7 4 53.4 4H26.4C26.1 4 25.8 4.1 25.6 4.2L8.29997 15.3C7.89997 15.6 7.59998 16 7.59998 16.5V32.1V63C7.59998 63.5 7.89997 64 8.29997 64.2L25.5 75.3C25.5 75.3 25.6 75.3 25.6 75.4C25.6 75.4 25.7 75.4 25.7 75.5C25.9 75.6 26 75.6 26.2 75.6H53.2C53.4 75.6 53.5 75.6 53.7 75.5C53.8 75.5 53.8 75.5 53.8 75.4C53.8 75.4 53.9 75.4 53.9 75.3L71.4 64.2C71.5 64.1 71.7 64 71.8 63.8C71.8 63.8 71.8 63.7 71.9 63.7C72 63.6 72.1 63.4 72.1 63.2V63.1C72.1 63 72.1 62.9 72.1 62.8V32.1V16.5C72.1 16 71.8 15.6 71.4 15.3ZM24.9 71.4L10.6 62.2V34.8L24.9 44V71.4ZM51.9 72.6H27.8V44.7H51.9V72.6ZM69.1 31.3L52.9 41.7H26.8L10.6 31.3V17.3L26.8 6.9H52.9L69.1 17.3V31.3Z' fill='%23BD9D70' /%3E%3C/svg%3E";
-
 describe( '<OptionRow />', () => {
 	it( 'renders the OptionRow', async () => {
 		const { container } = render(
 			<OptionRow
-				image={image1}
 				label="Option Row"
 				subTitle="Mostly used to link off to other pages."
 				as="a"

--- a/src/system/Tabs/TabItem.js
+++ b/src/system/Tabs/TabItem.js
@@ -15,6 +15,7 @@ const TabItem = ( { active = false, sx, ...props } ) => (
 		variant="h4"
 		as="button"
 		tabIndex="0"
+		data-active={ active || undefined }
 		sx={ {
 			cursor: 'pointer',
 			background: 'none',

--- a/src/system/Wizard/Wizard.js
+++ b/src/system/Wizard/Wizard.js
@@ -14,7 +14,7 @@ import { Box, WizardStep, Flex, WizardStepHorizontal } from '..';
 
 const Wizard = ( { steps, activeStep, variant, completed = [], ...props } ) => {
 	return (
-		<Box>
+		<Box className="vip-component-wizard">
 			{variant === 'horizontal' ? (
 				<Box>
 					<Flex
@@ -26,6 +26,7 @@ const Wizard = ( { steps, activeStep, variant, completed = [], ...props } ) => {
 						{steps.map( ( { title, subTitle }, index ) => (
 							<React.Fragment key={index}>
 								<WizardStepHorizontal
+									order={index + 1}
 									active={index === activeStep}
 									title={title}
 									subTitle={subTitle}
@@ -44,6 +45,7 @@ const Wizard = ( { steps, activeStep, variant, completed = [], ...props } ) => {
 						subTitle={subTitle}
 						complete={completed.includes( index )}
 						key={index}
+						order={index + 1}
 					>
 						{children}
 					</WizardStep>

--- a/src/system/Wizard/Wizard.js
+++ b/src/system/Wizard/Wizard.js
@@ -14,7 +14,7 @@ import { Box, WizardStep, Flex, WizardStepHorizontal } from '..';
 
 const Wizard = ( { steps, activeStep, variant, completed = [], ...props } ) => {
 	return (
-		<Box className="vip-component-wizard">
+		<Box>
 			{variant === 'horizontal' ? (
 				<Box>
 					<Flex

--- a/src/system/Wizard/WizardStep.js
+++ b/src/system/Wizard/WizardStep.js
@@ -11,7 +11,7 @@ import PropTypes from 'prop-types';
  */
 import { Card, Heading, Text } from '..';
 
-const WizardStep = ( { title, subTitle, complete = false, children, active } ) => {
+const WizardStep = ( { title, subTitle, complete = false, children, active, order } ) => {
 	let borderLeftColor = 'border';
 
 	if ( complete ) {
@@ -44,6 +44,8 @@ const WizardStep = ( { title, subTitle, complete = false, children, active } ) =
 				borderColor: active ? 'primary' : 'border',
 				borderLeftColor: borderLeftColor,
 			}}
+			data-step={ order }
+			data-active={ active || undefined }
 		>
 			<Heading
 				variant="h4"
@@ -69,7 +71,8 @@ WizardStep.propTypes = {
 	subTitle: PropTypes.node,
 	complete: PropTypes.bool,
 	active: PropTypes.bool,
-	children: PropTypes.node.isRequired,
+	children: PropTypes.node,
+	order: PropTypes.number.isRequired,
 };
 
 export { WizardStep };

--- a/src/system/Wizard/WizardStepHorizontal.js
+++ b/src/system/Wizard/WizardStepHorizontal.js
@@ -11,7 +11,7 @@ import PropTypes from 'prop-types';
  */
 import { Heading } from '..';
 
-const WizardStepHorizontal = ( { title, active } ) => {
+const WizardStepHorizontal = ( { title, active, order } ) => {
 	return (
 		<Heading
 			variant="h4"
@@ -21,6 +21,8 @@ const WizardStepHorizontal = ( { title, active } ) => {
 				alignItems: 'center',
 				color: active ? 'heading' : 'muted',
 			}}
+			data-step={ order }
+			data-active={ active || undefined }
 		>
 			<MdCheckCircle sx={{ mr: 2 }} />
 			{title}
@@ -32,6 +34,7 @@ WizardStepHorizontal.propTypes = {
 	title: PropTypes.node,
 	subTitle: PropTypes.node,
 	active: PropTypes.bool,
+	order: PropTypes.number.isRequired,
 };
 
 export { WizardStepHorizontal };


### PR DESCRIPTION
## Description

Adding some data attributes to some components, so it's easier for other tools like PENDO to match some elements on the screen.

## Checklist

- [x] This PR has good automated test coverage
- [x] The storybook for the component has been updated

## Steps to Test

1. Pull down PR.
2. `npm run storybook`.
3. Check that http://localhost:6006/?path=/story/wizard--default for each step you can find a `data-order` attribute and one `data-active`
4. Check that http://localhost:6006/?path=/story/optionrow--default in the second example, you can find a `data-order`
5. Check that http://localhost:6006/?path=/story/tabs--default contains `data-active` for the active tab
6. 