### PR TITLE
Add generic base class for all vip components

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -12,6 +12,7 @@
 				"@radix-ui/react-radio-group": "^0.1.0",
 				"@radix-ui/react-tooltip": "^0.1.0",
 				"babel-loader": "^8.2.2",
+				"classnames": "^2.3.1",
 				"framer-motion": "^3.9.1",
 				"react-icons": "^4.2.0",
 				"react-select": "^4.3.1",
@@ -9853,6 +9854,11 @@
 			"engines": {
 				"node": ">=0.10.0"
 			}
+		},
+		"node_modules/classnames": {
+			"version": "2.3.1",
+			"resolved": "https://registry.npmjs.org/classnames/-/classnames-2.3.1.tgz",
+			"integrity": "sha512-OlQdbZ7gLfGarSqxesMesDa5uz7KFbID8Kpq/SxIoNGDqY8lSYs0D+hhtBXhcdB3rcbXArFr7vlHheLk1voeNA=="
 		},
 		"node_modules/clean-css": {
 			"version": "4.2.3",
@@ -40804,6 +40810,11 @@
 				"isobject": "^3.0.0",
 				"static-extend": "^0.1.1"
 			}
+		},
+		"classnames": {
+			"version": "2.3.1",
+			"resolved": "https://registry.npmjs.org/classnames/-/classnames-2.3.1.tgz",
+			"integrity": "sha512-OlQdbZ7gLfGarSqxesMesDa5uz7KFbID8Kpq/SxIoNGDqY8lSYs0D+hhtBXhcdB3rcbXArFr7vlHheLk1voeNA=="
 		},
 		"clean-css": {
 			"version": "4.2.3",

--- a/package.json
+++ b/package.json
@@ -19,6 +19,7 @@
 		"@radix-ui/react-radio-group": "^0.1.0",
 		"@radix-ui/react-tooltip": "^0.1.0",
 		"babel-loader": "^8.2.2",
+		"classnames": "^2.3.1",
 		"framer-motion": "^3.9.1",
 		"react-icons": "^4.2.0",
 		"react-select": "^4.3.1",

--- a/src/system/Avatar/Avatar.js
+++ b/src/system/Avatar/Avatar.js
@@ -5,6 +5,7 @@
  */
 import PropTypes from 'prop-types';
 import { Image } from 'theme-ui';
+import classNames from 'classnames';
 
 /**
  * Internal dependencies
@@ -16,6 +17,7 @@ const Avatar = ( {
 	name = null,
 	size = 32,
 	src = null,
+	className = null,
 	...props
 } ) => (
 	<Box
@@ -34,6 +36,7 @@ const Avatar = ( {
 			padding: '1px',
 			textAlign: 'center',
 		} }
+		className={ classNames( 'vip-avatar-component', className ) }
 		{ ...props }
 	>
 		{ src ? (
@@ -68,6 +71,7 @@ Avatar.propTypes = {
 	size: PropTypes.number,
 	src: PropTypes.string,
 	name: PropTypes.string,
+	className: PropTypes.any,
 };
 
 export { Avatar };

--- a/src/system/Badge/Badge.js
+++ b/src/system/Badge/Badge.js
@@ -3,6 +3,7 @@
 /**
  * External dependencies
  */
+import classNames from 'classnames';
 import PropTypes from 'prop-types';
 
 /**
@@ -10,7 +11,7 @@ import PropTypes from 'prop-types';
  */
 import { Text } from '../';
 
-const Badge = ( { variant = 'blue', sx, ...props } ) => (
+const Badge = ( { variant = 'blue', sx, className, ...props } ) => (
 	<Text
 		as="span"
 		sx={ {
@@ -26,6 +27,7 @@ const Badge = ( { variant = 'blue', sx, ...props } ) => (
 			fontWeight: 'heading',
 			...sx,
 		} }
+		className={ classNames( 'vip-badge-component', className ) }
 		{ ...props }
 	/>
 );
@@ -33,6 +35,7 @@ const Badge = ( { variant = 'blue', sx, ...props } ) => (
 Badge.propTypes = {
 	variant: PropTypes.string,
 	sx: PropTypes.object,
+	className: PropTypes.any,
 };
 
 export { Badge };

--- a/src/system/Badge/Badge.js
+++ b/src/system/Badge/Badge.js
@@ -11,7 +11,7 @@ import PropTypes from 'prop-types';
  */
 import { Text } from '../';
 
-const Badge = ( { variant = 'blue', sx, className, ...props } ) => (
+const Badge = ( { variant = 'blue', sx, className = null, ...props } ) => (
 	<Text
 		as="span"
 		sx={ {

--- a/src/system/BlankState/BlankState.js
+++ b/src/system/BlankState/BlankState.js
@@ -3,6 +3,7 @@
 /**
  * External dependencies
  */
+import classNames from 'classnames';
 import PropTypes from 'prop-types';
 
 /**
@@ -17,9 +18,10 @@ const BlankState = ( {
 	image,
 	imageAlt = 'Image representing the blank state',
 	title,
+	className = null,
 } ) => {
 	return (
-		<Box sx={{ textAlign: 'center', padding: 5 }}>
+		<Box sx={{ textAlign: 'center', padding: 5 }} className={ classNames( 'vip-blank-state-component', className ) }>
 			{icon ? icon : <img src={image} sx={{ mb: 3 }} alt={imageAlt} />}
 			<Heading variant="h4">{title}</Heading>
 			<Text>{body}</Text>
@@ -35,6 +37,7 @@ BlankState.propTypes = {
 	image: PropTypes.oneOfType( [ PropTypes.object, PropTypes.string ] ),
 	imageAlt: PropTypes.string,
 	title: PropTypes.node,
+	className: PropTypes.any,
 };
 
 export { BlankState };

--- a/src/system/Box/Box.js
+++ b/src/system/Box/Box.js
@@ -3,11 +3,16 @@
 /**
  * External dependencies
  */
+import PropTypes from 'prop-types';
+import classNames from 'classnames';
 import { forwardRef } from 'react';
 import { Box as ThemeBox } from 'theme-ui';
 
-const Box = forwardRef( ( props, ref ) => <ThemeBox ref={ref} {...props} /> );
+const Box = forwardRef( ( props, ref ) => <ThemeBox ref={ref} className={ classNames( 'vip-box-component', props.className ) } {...props} /> );
 
 Box.displayName = 'Box';
+Box.propTypes = {
+	className: PropTypes.any,
+};
 
 export { Box };

--- a/src/system/Button/Button.js
+++ b/src/system/Button/Button.js
@@ -5,6 +5,7 @@
  */
 import { Button as ThemeButton } from 'theme-ui';
 import PropTypes from 'prop-types';
+import classNames from 'classnames';
 
 const Button = ( { sx, ...props } ) => (
 	<ThemeButton
@@ -22,12 +23,14 @@ const Button = ( { sx, ...props } ) => (
 			},
 			...sx,
 		}}
+		className={ classNames( 'vip-button-component', props.className ) }
 		{...props}
 	/>
 );
 
 Button.propTypes = {
 	sx: PropTypes.object,
+	className: PropTypes.any,
 };
 
 export { Button };

--- a/src/system/Card/Card.js
+++ b/src/system/Card/Card.js
@@ -10,8 +10,9 @@ import PropTypes from 'prop-types';
  * Internal dependencies
  */
 import { Box } from '..';
+import classNames from 'classnames';
 
-const Card = React.forwardRef( ( { variant = 'primary', sx = {}, ...props }, ref ) => {
+const Card = React.forwardRef( ( { variant = 'primary', sx = {}, className, ...props }, ref ) => {
 	return (
 		<Box
 			ref={ref}
@@ -21,6 +22,7 @@ const Card = React.forwardRef( ( { variant = 'primary', sx = {}, ...props }, ref
 				overflow: 'hidden',
 				...sx,
 			}}
+			className={ classNames( 'vip-card-component', className ) }
 			{...props}
 		/>
 	);
@@ -29,6 +31,7 @@ const Card = React.forwardRef( ( { variant = 'primary', sx = {}, ...props }, ref
 Card.propTypes = {
 	variant: PropTypes.string,
 	sx: PropTypes.object,
+	className: PropTypes.any,
 };
 
 Card.displayName = 'Card';

--- a/src/system/Code/Code.js
+++ b/src/system/Code/Code.js
@@ -3,11 +3,12 @@
 /**
  * External dependencies
  */
+import classNames from 'classnames';
 import PropTypes from 'prop-types';
 import { useRef, useState } from 'react';
 import { MdContentCopy } from 'react-icons/md';
 
-const Code = ( { prompt = false, showCopy = false, onCopy = null, ...props } ) => {
+const Code = ( { prompt = false, showCopy = false, onCopy = null, className, ...props } ) => {
 	const ref = useRef();
 
 	const codeDom = (
@@ -29,6 +30,7 @@ const Code = ( { prompt = false, showCopy = false, onCopy = null, ...props } ) =
 					userSelect: 'none',
 				},
 			} }
+			className={ classNames( 'vip-code-component', className ) }
 			{ ...props }
 		/>
 	);
@@ -88,6 +90,7 @@ Code.propTypes = {
 	prompt: PropTypes.bool,
 	showCopy: PropTypes.bool,
 	onCopy: PropTypes.func,
+	className: PropTypes.any,
 };
 
 export { Code };

--- a/src/system/ConfirmationDialog/ConfirmationDialog.js
+++ b/src/system/ConfirmationDialog/ConfirmationDialog.js
@@ -3,6 +3,7 @@
 /**
  * External dependencies
  */
+import classNames from 'classnames';
 import PropTypes from 'prop-types';
 import React from 'react';
 
@@ -11,8 +12,8 @@ import React from 'react';
  */
 import { Dialog, Box, Heading, Text, Flex, Button } from '../';
 
-const ConfirmationDialogContent = ( { title, body, onClose, label = 'Confirm', onConfirm } ) => (
-	<Box p={ 4 }>
+const ConfirmationDialogContent = ( { title, body, onClose, label = 'Confirm', onConfirm, className = null } ) => (
+	<Box p={ 4 } className={ classNames( 'vip-confirmation-dialog-component', className ) }>
 		<Heading variant="h3" sx={ { mb: 2 } }>
 			{ title }
 		</Heading>
@@ -40,6 +41,7 @@ ConfirmationDialogContent.propTypes = {
 	label: PropTypes.string,
 	onClose: PropTypes.func,
 	onConfirm: PropTypes.func,
+	className: PropTypes.any,
 };
 
 const ConfirmationDialog = ( { trigger, onConfirm, needsConfirm = true, ...props } ) => {

--- a/src/system/Dialog/Dialog.js
+++ b/src/system/Dialog/Dialog.js
@@ -46,7 +46,7 @@ const Dialog = ( { trigger, position = 'left', startOpen = false, content, disab
 	};
 
 	return (
-		<div onClick={ e => e.stopPropagation() } sx={ { position: 'relative' } } ref={ dialogRef }>
+		<div onClick={ e => e.stopPropagation() } sx={ { position: 'relative' } } ref={ dialogRef } className="vip-dialog-component">
 			<DialogTrigger
 				tabIndex="0"
 				sx={ { display: 'inline' } }

--- a/src/system/Form/Select.js
+++ b/src/system/Form/Select.js
@@ -36,7 +36,7 @@ const Select = ( { isMulti = false, isInline, isAsync, options, label, isSearch,
 			break;
 	}
 
-	return <div ref={selectRef}><Component isMulti={isMulti} label={label} options={options} {...portalProps} {...props} /></div>;
+	return <div ref={selectRef} className="vip-select-component"><Component isMulti={isMulti} label={label} options={options} {...portalProps} {...props} /></div>;
 };
 
 Select.propTypes = {

--- a/src/system/Form/Toggle.js
+++ b/src/system/Form/Toggle.js
@@ -3,10 +3,11 @@
 /**
  * External dependencies
  */
+import classNames from 'classnames';
 import PropTypes from 'prop-types';
 
-const Toggle = ( { name = 'toggle', ...props } ) => (
-	<CheckBoxWrapper>
+const Toggle = ( { name = 'toggle', className = null, ...props } ) => (
+	<CheckBoxWrapper className={ classNames( 'vip-checkbox-component', className ) }>
 		<CheckBox name={name} id={name} type="checkbox" {...props} />
 		<CheckBoxLabel htmlFor={name} />
 	</CheckBoxWrapper>
@@ -14,6 +15,7 @@ const Toggle = ( { name = 'toggle', ...props } ) => (
 
 Toggle.propTypes = {
 	name: PropTypes.string,
+	className: PropTypes.any,
 };
 
 export { Toggle };

--- a/src/system/Heading/Heading.js
+++ b/src/system/Heading/Heading.js
@@ -5,8 +5,9 @@
  */
 import { Heading as ThemeHeading } from 'theme-ui';
 import PropTypes from 'prop-types';
+import classNames from 'classnames';
 
-const Heading = ( { variant = 'h3', sx, ...props } ) => (
+const Heading = ( { variant = 'h3', sx, className = null, ...props } ) => (
 	<ThemeHeading
 		as={variant}
 		sx={{
@@ -15,6 +16,7 @@ const Heading = ( { variant = 'h3', sx, ...props } ) => (
 			variant: `text.${ variant }`,
 			...sx,
 		}}
+		className={ classNames( 'vip-heading-component', className ) }
 		{...props}
 	/>
 );
@@ -22,6 +24,7 @@ const Heading = ( { variant = 'h3', sx, ...props } ) => (
 Heading.propTypes = {
 	variant: PropTypes.string,
 	sx: PropTypes.object,
+	className: PropTypes.any,
 };
 
 export { Heading };

--- a/src/system/Notice/Notice.js
+++ b/src/system/Notice/Notice.js
@@ -3,6 +3,7 @@
 /**
  * External dependencies
  */
+import classNames from 'classnames';
 import PropTypes from 'prop-types';
 import { MdError, MdWarning, MdCheckCircle, MdInfo } from 'react-icons/md';
 
@@ -36,7 +37,7 @@ NoticeIcon.propTypes = {
 	variant: PropTypes.string,
 };
 
-const Notice = ( { variant = 'warning', inline = false, children, title, sx = {}, ...props } ) => {
+const Notice = ( { variant = 'warning', inline = false, children, title, sx = {}, className = null, ...props } ) => {
 	let color = 'yellow';
 
 	switch ( variant ) {
@@ -66,6 +67,7 @@ const Notice = ( { variant = 'warning', inline = false, children, title, sx = {}
 				},
 				...sx,
 			} }
+			className={ classNames( 'vip-notice-component', className ) }
 			{ ...props }
 		>
 			<Flex sx={ {
@@ -93,6 +95,7 @@ Notice.propTypes = {
 	sx: PropTypes.object,
 	title: PropTypes.node,
 	variant: PropTypes.string,
+	className: PropTypes.any,
 };
 
 export { Notice };

--- a/src/system/Notification/Notification.js
+++ b/src/system/Notification/Notification.js
@@ -13,6 +13,7 @@ import { Box, Button, Card, Flex, Heading, Text } from '../';
 
 const Notification = ( { title, body, status = 'success', onClose } ) => (
 	<Card
+		className="vip-notification-component"
 		sx={{
 			boxShadow: 'medium',
 			width: 320,

--- a/src/system/OptionRow/OptionRow.js
+++ b/src/system/OptionRow/OptionRow.js
@@ -11,6 +11,7 @@ import PropTypes from 'prop-types';
  * Internal dependencies
  */
 import { Badge, Box, Grid, Heading, Text } from '..';
+import classNames from 'classnames';
 
 const OptionRow = ( {
 	image,
@@ -25,6 +26,7 @@ const OptionRow = ( {
 	small = false,
 	disabled = false,
 	order = null,
+	className = null,
 	...props
 } ) => {
 	const mergedCard = disabled
@@ -55,6 +57,7 @@ const OptionRow = ( {
 			columns={[ 1, 1, 'auto 1fr auto' ]}
 			gap={[ 3, 3, `${ small ? 3 : 4 }` ]}
 			data-order={ order || undefined }
+			className={ classNames( 'vip-option-row-component', className ) }
 			{...props}
 			sx={{
 				alignItems: 'center',
@@ -122,6 +125,7 @@ OptionRow.propTypes = {
 	small: PropTypes.bool,
 	disabled: PropTypes.bool,
 	order: PropTypes.number,
+	className: PropTypes.any,
 };
 
 export { OptionRow };

--- a/src/system/Progress/Progress.js
+++ b/src/system/Progress/Progress.js
@@ -11,10 +11,12 @@ import PropTypes from 'prop-types';
  */
 import { Spinner } from '../Spinner';
 import { Box, Heading, Text, Flex } from '../';
+import classNames from 'classnames';
 
-const Progress = ( { steps, activeStep, sx, ...props } ) => (
+const Progress = ( { steps, activeStep, sx, className, ...props } ) => (
 	<Box>
 		<ThemeProgress
+			className={ classNames( 'vip-progress-component', className ) }
 			{ ...props }
 			sx={ {
 				color: 'primary',
@@ -39,6 +41,7 @@ Progress.propTypes = {
 	steps: PropTypes.array,
 	activeStep: PropTypes.number,
 	sx: PropTypes.object,
+	className: PropTypes.any,
 };
 
 export { Progress };

--- a/src/system/ResourceList/ResourceList.js
+++ b/src/system/ResourceList/ResourceList.js
@@ -59,7 +59,7 @@ const ResourceList = ( { groupedByDay = false, items, renderItem, dateKey } ) =>
 		itemsList.map( ( item, index ) => <StyledListItem key={index}>{renderItem( item )}</StyledListItem> );
 
 	return (
-		<Box as="ul" sx={{ listStyleType: 'none', m: 0, p: 0 }}>
+		<Box as="ul" sx={{ listStyleType: 'none', m: 0, p: 0 }} className="vip-resource-list-component">
 			{groupedByDay
 				? Object.keys( groupedItems ).map( ( groupName, index ) => (
 					<Box sx={{ mb: 4 }} key={index}>

--- a/src/system/Spinner/Spinner.js
+++ b/src/system/Spinner/Spinner.js
@@ -5,20 +5,23 @@
  */
 import { Spinner as ThemeSpinner } from 'theme-ui';
 import PropTypes from 'prop-types';
+import classNames from 'classnames';
 
-const Spinner = ( { sx, ...props } ) => (
+const Spinner = ( { sx, className = null, ...props } ) => (
 	<ThemeSpinner
 		strokeWidth={2}
 		sx={{
 			fill: 'none',
 			color: 'primary',
 		}}
+		className={ classNames( 'vip-spinner-component', className ) }
 		{...props}
 	/>
 );
 
 Spinner.propTypes = {
 	sx: PropTypes.object,
+	className: PropTypes.any,
 };
 
 export { Spinner };

--- a/src/system/Tabs/Tabs.js
+++ b/src/system/Tabs/Tabs.js
@@ -3,6 +3,7 @@
 /**
  * External dependencies
  */
+import classNames from 'classnames';
 import PropTypes from 'prop-types';
 
 /**
@@ -10,8 +11,9 @@ import PropTypes from 'prop-types';
  */
 import { Flex } from '..';
 
-const Tabs = ( { sx, ...props } ) => (
+const Tabs = ( { className = null, sx, ...props } ) => (
 	<Flex
+		className={ classNames( 'vip-tabs-component', className ) }
 		sx={{
 			borderBottom: '1px solid',
 			borderColor: 'border',
@@ -25,8 +27,9 @@ const Tabs = ( { sx, ...props } ) => (
 );
 
 Tabs.propTypes = {
-	variant: PropTypes.string,
+	className: PropTypes.any,
 	sx: PropTypes.object,
+	variant: PropTypes.string,
 };
 
 export { Tabs };

--- a/src/system/Text/Text.js
+++ b/src/system/Text/Text.js
@@ -5,8 +5,9 @@
  */
 import { Text as ThemeText } from 'theme-ui';
 import PropTypes from 'prop-types';
+import classNames from 'classnames';
 
-const Text = ( { sx, ...props } ) => (
+const Text = ( { sx, className = null, ...props } ) => (
 	<ThemeText
 		as="p"
 		sx={{
@@ -14,12 +15,14 @@ const Text = ( { sx, ...props } ) => (
 			marginBottom: 2,
 			...sx,
 		}}
+		className={ classNames( 'vip-text-component', className ) }
 		{...props}
 	/>
 );
 
 Text.propTypes = {
 	sx: PropTypes.object,
+	className: PropTypes.any,
 };
 
 export { Text };

--- a/src/system/Time/index.js
+++ b/src/system/Time/index.js
@@ -5,6 +5,7 @@
  */
 import { Text } from 'theme-ui';
 import PropTypes from 'prop-types';
+import classNames from 'classnames';
 
 const formatter = new Intl.RelativeTimeFormat( undefined, {
 	numeric: 'auto',
@@ -31,7 +32,7 @@ function formatTimeAgo( date ) {
 	}
 }
 
-const Time = ( { time, relativeTime = false, timeOnly = false, ...props } ) => {
+const Time = ( { time, relativeTime = false, timeOnly = false, className = null, ...props } ) => {
 	let formattedTime;
 	if ( relativeTime ) {
 		formattedTime = formatTimeAgo( time );
@@ -46,6 +47,7 @@ const Time = ( { time, relativeTime = false, timeOnly = false, ...props } ) => {
 			title={time.toLocaleString( 'sv', { timeZoneName: 'short' } )}
 			datetime={time}
 			as="time"
+			className={ classNames( 'vip-time-component', className ) }
 			{...props}
 		>
 			{formattedTime}
@@ -57,6 +59,7 @@ Time.propTypes = {
 	time: PropTypes.string,
 	timeOnly: PropTypes.bool,
 	relativeTime: PropTypes.bool,
+	className: PropTypes.any,
 };
 
 export { Time };

--- a/src/system/Timeline/Timeline.js
+++ b/src/system/Timeline/Timeline.js
@@ -6,6 +6,7 @@
 import { Flex } from 'theme-ui';
 import { MdWatchLater } from 'react-icons/md';
 import PropTypes from 'prop-types';
+import classNames from 'classnames';
 
 const VerticalLine = () => {
 	return (
@@ -20,8 +21,8 @@ const VerticalLine = () => {
 	);
 };
 
-const Timeline = ( { time, first = false, last = false, ...props } ) => (
-	<Flex { ...props }>
+const Timeline = ( { time, first = false, last = false, className = null, ...props } ) => (
+	<Flex className={ classNames( 'vip-timeline-component', className ) } { ...props }>
 		<Flex sx={ { flexDirection: 'column', justifyContent: 'space-evenly', alignItems: 'center' } }>
 			{ ! first && (
 				<VerticalLine />
@@ -41,6 +42,7 @@ Timeline.propTypes = {
 	first: PropTypes.bool,
 	time: PropTypes.node,
 	last: PropTypes.bool,
+	className: PropTypes.any,
 };
 
 export { Timeline };

--- a/src/system/Wizard/Wizard.js
+++ b/src/system/Wizard/Wizard.js
@@ -5,6 +5,7 @@
  */
 import React from 'react';
 import PropTypes from 'prop-types';
+import classNames from 'classnames';
 import { MdArrowForward } from 'react-icons/md';
 
 /**
@@ -12,9 +13,9 @@ import { MdArrowForward } from 'react-icons/md';
  */
 import { Box, WizardStep, Flex, WizardStepHorizontal } from '..';
 
-const Wizard = ( { steps, activeStep, variant, completed = [], ...props } ) => {
+const Wizard = ( { steps, activeStep, variant, completed = [], className = null, ...props } ) => {
 	return (
-		<Box>
+		<Box className={ classNames( 'vip-wizard-component', className ) }>
 			{variant === 'horizontal' ? (
 				<Box>
 					<Flex
@@ -60,6 +61,7 @@ Wizard.propTypes = {
 	activeStep: PropTypes.number,
 	variant: PropTypes.string,
 	completed: PropTypes.array,
+	className: PropTypes.any,
 };
 
 export { Wizard };

--- a/src/system/Wizard/Wizard.stories.js
+++ b/src/system/Wizard/Wizard.stories.js
@@ -51,7 +51,7 @@ export const Default = () => {
 				</Box>
 			</Flex>
 			<Box mt={4}>
-				<Wizard activeStep={0} steps={steps} />
+				<Wizard activeStep={0} steps={steps} className="vip-wizard-xyz" />
 			</Box>
 		</React.Fragment>
 	);


### PR DESCRIPTION
## Description

Adds a base class `vip-name-component` to all components.

## Checklist

- [ ] This PR has good automated test coverage
- [x] The storybook for the component has been updated

## Steps to Test

Outline the steps to test and verify the PR here.

Example:

1. Pull down PR.
2. `npm run dev`.
3. Check source code that all VIP components have a class `vip-name-component` in the closest parent