### PR TITLE
Update `<OptionRow />` disabled styles

### DIFF
--- a/src/system/OptionRow/OptionRow.js
+++ b/src/system/OptionRow/OptionRow.js
@@ -107,7 +107,9 @@ const OptionRow = ( {
 				{subTitle && <Text sx={{ mb: 1, color: 'muted' }}>{subTitle}</Text>}
 				{body && <Text sx={{ mb: 0 }}>{body}</Text>}
 			</Box>
-			<Box>{meta ? meta : ! disabled && <MdArrowForward size={24} />}</Box>
+			{ ( false !== meta && '' !== meta ) && (
+				<Box data-testid="meta">{ meta ? meta : <MdArrowForward size={24} /> }</Box>
+			) }
 		</Grid>
 	);
 };

--- a/src/system/OptionRow/OptionRow.js
+++ b/src/system/OptionRow/OptionRow.js
@@ -27,6 +27,8 @@ const OptionRow = ( {
 	disabled = false,
 	order = null,
 	className = null,
+	as,
+	title,
 	...props
 } ) => {
 	const mergedCard = disabled
@@ -51,20 +53,30 @@ const OptionRow = ( {
 			borderBottom: '1px solid',
 			borderColor: 'border',
 		};
+
+	const gridProps = disabled
+		? {
+			as: Box,
+		} : {
+			to,
+			as,
+			title,
+		};
+
 	return (
 		<Grid
-			to={to}
 			columns={[ 1, 1, 'auto 1fr auto' ]}
 			gap={[ 3, 3, `${ small ? 3 : 4 }` ]}
 			data-order={ order || undefined }
 			className={ classNames( 'vip-option-row-component', className ) }
+			{...gridProps}
 			{...props}
 			sx={{
 				alignItems: 'center',
 				cursor: disabled ? 'auto' : 'pointer',
 				textDecoration: 'none',
 				color: 'inherit',
-				'&:hover': {
+				'&:hover': ! disabled && {
 					backgroundColor: 'hover',
 				},
 				...inlineStyles,
@@ -107,7 +119,7 @@ const OptionRow = ( {
 				{subTitle && <Text sx={{ mb: 1, color: 'muted' }}>{subTitle}</Text>}
 				{body && <Text sx={{ mb: 0 }}>{body}</Text>}
 			</Box>
-			<Box>{meta ? meta : <MdArrowForward size={24} />}</Box>
+			<Box>{meta ? meta : ! disabled && <MdArrowForward size={24} />}</Box>
 		</Grid>
 	);
 };
@@ -126,6 +138,8 @@ OptionRow.propTypes = {
 	disabled: PropTypes.bool,
 	order: PropTypes.number,
 	className: PropTypes.any,
+	as: PropTypes.node,
+	title: PropTypes.string,
 };
 
 export { OptionRow };

--- a/src/system/OptionRow/OptionRow.js
+++ b/src/system/OptionRow/OptionRow.js
@@ -27,8 +27,6 @@ const OptionRow = ( {
 	disabled = false,
 	order = null,
 	className = null,
-	as,
-	title,
 	...props
 } ) => {
 	const mergedCard = disabled
@@ -53,23 +51,13 @@ const OptionRow = ( {
 			borderBottom: '1px solid',
 			borderColor: 'border',
 		};
-
-	const gridProps = disabled
-		? {
-			as: Box,
-		} : {
-			to,
-			as,
-			title,
-		};
-
 	return (
 		<Grid
+			to={to}
 			columns={[ 1, 1, 'auto 1fr auto' ]}
 			gap={[ 3, 3, `${ small ? 3 : 4 }` ]}
 			data-order={ order || undefined }
 			className={ classNames( 'vip-option-row-component', className ) }
-			{...gridProps}
 			{...props}
 			sx={{
 				alignItems: 'center',
@@ -138,8 +126,6 @@ OptionRow.propTypes = {
 	disabled: PropTypes.bool,
 	order: PropTypes.number,
 	className: PropTypes.any,
-	as: PropTypes.node,
-	title: PropTypes.string,
 };
 
 export { OptionRow };

--- a/src/system/OptionRow/OptionRow.stories.js
+++ b/src/system/OptionRow/OptionRow.stories.js
@@ -32,8 +32,9 @@ export const Default = () => (
 			image={image2}
 			label="Option Row – Disabled"
 			subTitle="Mostly used to link off to other pages."
-			as="a"
+			as={ Box }
 			disabled
+			meta=""
 		/>
 	</Box>
 );

--- a/src/system/OptionRow/OptionRow.stories.js
+++ b/src/system/OptionRow/OptionRow.stories.js
@@ -28,5 +28,12 @@ export const Default = () => (
 			as="a"
 			order={ 2 }
 		/>
+		<OptionRow
+			image={image2}
+			label="Option Row – Disabled"
+			subTitle="Mostly used to link off to other pages."
+			as="a"
+			disabled
+		/>
 	</Box>
 );

--- a/src/system/OptionRow/OptionRow.test.js
+++ b/src/system/OptionRow/OptionRow.test.js
@@ -24,4 +24,26 @@ describe( '<OptionRow />', () => {
 		// Check for accessibility issues
 		await expect( await axe( container ) ).toHaveNoViolations();
 	} );
+
+	it( 'renders a disabled OptionRow', async () => {
+		// eslint-disable-next-line max-len
+		const image1 = "data:image/svg+xml,%3Csvg xmlns='http://www.w3.org/2000/svg' width='79' height='79' viewBox='0 0 79 79' fill='none' %3E%3Cpath d='M71.4 15.3L54.2 4.2C54 4 53.7 4 53.4 4H26.4C26.1 4 25.8 4.1 25.6 4.2L8.29997 15.3C7.89997 15.6 7.59998 16 7.59998 16.5V32.1V63C7.59998 63.5 7.89997 64 8.29997 64.2L25.5 75.3C25.5 75.3 25.6 75.3 25.6 75.4C25.6 75.4 25.7 75.4 25.7 75.5C25.9 75.6 26 75.6 26.2 75.6H53.2C53.4 75.6 53.5 75.6 53.7 75.5C53.8 75.5 53.8 75.5 53.8 75.4C53.8 75.4 53.9 75.4 53.9 75.3L71.4 64.2C71.5 64.1 71.7 64 71.8 63.8C71.8 63.8 71.8 63.7 71.9 63.7C72 63.6 72.1 63.4 72.1 63.2V63.1C72.1 63 72.1 62.9 72.1 62.8V32.1V16.5C72.1 16 71.8 15.6 71.4 15.3ZM24.9 71.4L10.6 62.2V34.8L24.9 44V71.4ZM51.9 72.6H27.8V44.7H51.9V72.6ZM69.1 31.3L52.9 41.7H26.8L10.6 31.3V17.3L26.8 6.9H52.9L69.1 17.3V31.3Z' fill='%23BD9D70' /%3E%3C/svg%3E";
+
+		const { container } = render(
+			<OptionRow
+				image={image1}
+				label="Option Row"
+				subTitle="Mostly used to link off to other pages."
+				as="a"
+				disabled
+				meta=""
+			/>
+		);
+
+		expect( screen.getByAltText( 'Image representing the list item' ).closest( 'div' ) ).toHaveStyle( { background: 'none' } );
+		expect( screen.queryByTestId( 'meta' ) ).not.toBeInTheDocument();
+
+		// Check for accessibility issues
+		await expect( await axe( container ) ).toHaveNoViolations();
+	} );
 } );


### PR DESCRIPTION
## Description

Currently when disabled, the `<OptionRow />` component retains some styling which may make it look like it's still enabled. Namely, the background colour change on hover, and the arrow.  This PR removes these styles if the component is disabled. In 91785be65964540f8b33139e78fbd729d410a0e9 I explored further changes that could potentially be applied in a disabled state, but decided that these were maybe too opinionated. 

#### Before
![Screen Capture on 2022-06-02 at 13-09-02](https://user-images.githubusercontent.com/4177859/171544959-0082b81c-a00c-4bfa-98fb-b8a1026f036f.gif)

#### After
![Screen Capture on 2022-06-02 at 13-09-56](https://user-images.githubusercontent.com/4177859/171544954-aaa14117-3bb0-4d52-a4d7-fad8b79f0d5c.gif)

## Checklist

- [ ] This PR has good automated test coverage
- [x] The storybook for the component has been updated

## Steps to Test

1. Pull down PR.
2. `npm run build`
1. Copy the `vip-design-system/build` contents into the `vip-ui/node_modules/@automattic/vip-design-system/build` folder
1. Start the vip-ui `npm run dev`
1. Go to http://localhost:3000/apps/2003/production/data
1. View the disabled `<OptionRow />` at at the top of the page and verify hover style and arrow are not displayed.
