### PR TITLE
Adjust/option row and table

### DIFF
--- a/package.json
+++ b/package.json
@@ -11,6 +11,7 @@
 		"jest:watch": "npm run jest --watch",
 		"lint": "eslint . -f json | eslines --quiet",
 		"storybook": "start-storybook -p 6006",
+		"dev": "npm run storybook",
 		"test": "npm run lint && npm run jest",
 		"watch": "npm run build -- --watch"
 	},

--- a/src/system/Table/Table.js
+++ b/src/system/Table/Table.js
@@ -6,7 +6,7 @@
 import PropTypes from 'prop-types';
 
 const Table = ( { sx, ...props } ) => (
-	<div sx={ { overflowX: 'auto', pb: 300, mb: -300 } }>
+	<div sx={ { overflowX: 'auto' } }>
 		<table
 			sx={ { width: '100%', minWidth: 1024, ...sx } }
 			cellPadding={ 0 }


### PR DESCRIPTION
## Description

Removes the weird extra padding we have for tables.

## Checklist

- [ ] This PR has good automated test coverage
- [x] The storybook for the component has been updated

## Steps to Test

1. Pull down PR.
2. `npm run dev`.
3. Open Storybook.
4. http://localhost:6006/?path=/story/table--default should have no extra 300 padding bottom and top

