### PR TITLE
Fix table overflow

### DIFF
--- a/src/system/Table/Table.js
+++ b/src/system/Table/Table.js
@@ -4,20 +4,21 @@
  * External dependencies
  */
 import PropTypes from 'prop-types';
+import classNames from 'classnames';
 
-const Table = ( { sx, ...props } ) => (
-	<div sx={ { overflowX: 'auto' } }>
-		<table
-			sx={ { width: '100%', minWidth: 1024, ...sx } }
-			cellPadding={ 0 }
-			cellSpacing={ 0 }
-			{ ...props }
-		/>
-	</div>
+const Table = ( { sx, className, ...props } ) => (
+	<table
+		sx={{ width: '100%', minWidth: 1024, ...sx }}
+		cellPadding={0}
+		cellSpacing={0}
+		className={classNames( 'vip-table-component', className )}
+		{...props}
+	/>
 );
 
 Table.propTypes = {
 	sx: PropTypes.object,
+	className: PropTypes.any,
 };
 
 export { Table };


### PR DESCRIPTION
## Description

Table overflow was causing some z-index problems.

<img width="379" alt="Screen Shot 2022-06-24 at 14 55 46" src="https://user-images.githubusercontent.com/3402/175616243-3a473a1a-cf89-419e-9a70-4139810f09ed.png">

## Checklist

- [ ] This PR has good automated test coverage
- [x] The storybook for the component has been updated

## Steps to Test

1. Pull down PR.
2. `npm run dev`.
3. Open Storybook.
4. Go to http://localhost:6006/?path=/story/table--default
5. Table show continue with no overflow wissues
