### PR TITLE
Hide Avatar from Screen Readers

### DIFF
--- a/src/system/Avatar/Avatar.js
+++ b/src/system/Avatar/Avatar.js
@@ -21,7 +21,7 @@ const Avatar = ( {
 	...props
 } ) => (
 	<Box
-		sx={ {
+		sx={{
 			borderRadius: 9999,
 			height: size + 2, // +2 to compensate padding on both sides
 			width: size + 2, // +2 to compensate padding on both sides
@@ -35,34 +35,35 @@ const Avatar = ( {
 			color: 'white',
 			padding: '1px',
 			textAlign: 'center',
-		} }
-		className={ classNames( 'vip-avatar-component', className ) }
-		{ ...props }
+		}}
+		className={classNames( 'vip-avatar-component', className )}
+		aria-hidden="true"
+		{...props}
 	>
-		{ src ? (
+		{src ? (
 			<Image
-				src={ src }
-				alt={ `Avatar image from ${ name }` }
-				sx={ {
+				src={src}
+				alt={`Avatar image from ${ name }`}
+				sx={{
 					borderRadius: 9999,
 					width: '100%',
 					display: 'block',
-				} }
+				}}
 			/>
 		) : (
 			<Text
 				as="span"
-				sx={ {
+				sx={{
 					color: 'white',
 					mb: 0,
 					fontWeight: 'bold',
 					fontSize: 0,
 					textTransform: 'uppercase',
-				} }
+				}}
 			>
-				{ name ? name.charAt( 0 ) : null }
+				{name ? name.charAt( 0 ) : null}
 			</Text>
-		) }
+		)}
 	</Box>
 );
 

--- a/src/system/Avatar/Avatar.js
+++ b/src/system/Avatar/Avatar.js
@@ -21,7 +21,7 @@ const Avatar = ( {
 	...props
 } ) => (
 	<Box
-		sx={{
+		sx={ {
 			borderRadius: 9999,
 			height: size + 2, // +2 to compensate padding on both sides
 			width: size + 2, // +2 to compensate padding on both sides
@@ -35,35 +35,35 @@ const Avatar = ( {
 			color: 'white',
 			padding: '1px',
 			textAlign: 'center',
-		}}
-		className={classNames( 'vip-avatar-component', className )}
+		} }
+		className={ classNames( 'vip-avatar-component', className ) }
 		aria-hidden="true"
-		{...props}
+		{ ...props }
 	>
-		{src ? (
+		{ src ? (
 			<Image
-				src={src}
-				alt={`Avatar image from ${ name }`}
-				sx={{
+				src={ src }
+				alt={ `Avatar image from ${ name }` }
+				sx={ {
 					borderRadius: 9999,
 					width: '100%',
 					display: 'block',
-				}}
+				} }
 			/>
 		) : (
 			<Text
 				as="span"
-				sx={{
+				sx={ {
 					color: 'white',
 					mb: 0,
 					fontWeight: 'bold',
 					fontSize: 0,
 					textTransform: 'uppercase',
-				}}
+				} }
 			>
-				{name ? name.charAt( 0 ) : null}
+				{ name ? name.charAt( 0 ) : null }
 			</Text>
-		)}
+		) }
 	</Box>
 );
 

--- a/src/system/Form/Select.stories.jsx
+++ b/src/system/Form/Select.stories.jsx
@@ -122,7 +122,6 @@ export const Async = () => {
 				label="Async Select"
 				value={ value }
 				isAsync
-				usePortal
 				loadOptions={ loadOptions }
 				noneLabel="Everyone"
 				placeholder="Load async..."


### PR DESCRIPTION
## Description

As agreed internally at A8C, we are hiding the Avatar component from screen readers. The Avatar provides no useful information to users.

## Checklist

- [ ] This PR has good automated test coverage
- [x] The storybook for the component has been updated

## Steps to Test

1. Pull down PR.
2. `npm run dev`.
3. Open http://localhost:6006/?path=/story/avatar--default
4. All Avatar rendered components should have `aria-hidden="true"`

