### PR TITLE
Add/alert role to notifications and ScreenReaderText

### DIFF
--- a/src/system/Notification/Notification.js
+++ b/src/system/Notification/Notification.js
@@ -11,55 +11,45 @@ import PropTypes from 'prop-types';
  */
 import { Box, Card, Flex, Text, Button } from '../';
 import ScreenReaderText from '../ScreenReaderText/ScreenReaderText';
-import { useLayoutEffect, useRef } from 'react';
 
-const Notification = ( { title, body, status = 'success', onClose } ) => {
-	const buttonRef = useRef();
+const Notification = ( { title, body, status = 'success', onClose } ) =>(
+	<Card
+		role="alert"
+		className="vip-notification-component"
+		sx={{
+			boxShadow: 'medium',
+			width: 320,
+			position: 'relative',
+			variant: `notification.${ status }`,
+		}}
+	>
+		<ScreenReaderText>Alert,</ScreenReaderText>
+		<Flex sx={{ alignItems: 'center' }}>
+			{status === 'error' ? (
+				<MdError sx={{ color: 'error', flex: '0 0 auto' }} aria-hidden="true" />
+			) : (
+				<MdCheckCircle sx={{ color: 'success', flex: '0 0 auto' }} aria-hidden="true" />
+			)}
+			<Box sx={{ flex: '1 1 auto', ml: 3 }}>
+				<p sx={{ my: 0, color: 'heading', fontWeight: 'bold' }}>
+					{title}
+				</p>
+				{body && <Text sx={{ mb: 0, mt: 1 }}>{body}</Text>}
+			</Box>
+		</Flex>
 
-	useLayoutEffect( () => {
-		buttonRef.current.focus();
-	}, [] );
-
-	return (
-		<Card
-			ref={buttonRef}
-			role="alert"
-			className="vip-notification-component"
-			sx={{
-				boxShadow: 'medium',
-				width: 320,
-				position: 'relative',
-				variant: `notification.${ status }`,
-			}}
-		>
-			<ScreenReaderText>Alert,</ScreenReaderText>
-			<Flex sx={{ alignItems: 'center' }}>
-				{status === 'error' ? (
-					<MdError sx={{ color: 'error', flex: '0 0 auto' }} aria-hidden="true" />
-				) : (
-					<MdCheckCircle sx={{ color: 'success', flex: '0 0 auto' }} aria-hidden="true" />
-				)}
-				<Box sx={{ flex: '1 1 auto', ml: 3 }}>
-					<p sx={{ my: 0, color: 'heading', fontWeight: 'bold' }}>
-						{title}
-					</p>
-					{body && <Text sx={{ mb: 0, mt: 1 }}>{body}</Text>}
-				</Box>
-			</Flex>
-
-			{ onClose && (
-				<Button
-					onClick={onClose}
-					variant="icon"
-					sx={{ color: 'muted', position: 'absolute', top: 2, right: 2 }}
-					aria-hidden="true"
-				>
-					<MdClose />
-				</Button>
-			) }
-		</Card>
-	);
-};
+		{ onClose && (
+			<Button
+				onClick={onClose}
+				variant="icon"
+				sx={{ color: 'muted', position: 'absolute', top: 2, right: 2 }}
+				aria-hidden="true"
+			>
+				<MdClose />
+			</Button>
+		) }
+	</Card>
+);
 
 Notification.propTypes = {
 	title: PropTypes.node,

--- a/src/system/Notification/Notification.js
+++ b/src/system/Notification/Notification.js
@@ -24,7 +24,7 @@ const Notification = ( { title, body, status = 'success', onClose, prefix = 'Ale
 	>
 		<div role="alert">
 			<ScreenReaderText>
-				{prefix}, {title} {body && `, ${ body }`}
+				{prefix} {status}, {title} {body && `, ${ body }`}
 			</ScreenReaderText>
 		</div>
 

--- a/src/system/Notification/Notification.js
+++ b/src/system/Notification/Notification.js
@@ -9,54 +9,60 @@ import PropTypes from 'prop-types';
 /**
  * Internal dependencies
  */
-import { Box, Button, Card, Flex, Heading, Text } from '../';
+import { Box, Card, Flex, Text, Button } from '../';
 import ScreenReaderText from '../ScreenReaderText/ScreenReaderText';
+import { useLayoutEffect, useRef } from 'react';
 
-const Notification = ( { title, body, status = 'success', onClose, prefix = 'Alert' } ) => (
-	<Card
-		className="vip-notification-component"
-		sx={{
-			boxShadow: 'medium',
-			width: 320,
-			position: 'relative',
-			variant: `notification.${ status }`,
-		}}
-	>
-		<div role="alert">
-			<ScreenReaderText>
-				{prefix} {status}, {title} {body && `, ${ body }`}
-			</ScreenReaderText>
-		</div>
+const Notification = ( { title, body, status = 'success', onClose } ) => {
+	const buttonRef = useRef();
 
-		<Button
-			onClick={onClose}
-			variant="icon"
-			sx={{ color: 'muted', position: 'absolute', top: 2, right: 2 }}
+	useLayoutEffect( () => {
+		buttonRef.current.focus();
+	}, [] );
+
+	return (
+		<Card
+			ref={buttonRef}
+			role="alert"
+			className="vip-notification-component"
+			sx={{
+				boxShadow: 'medium',
+				width: 320,
+				position: 'relative',
+				variant: `notification.${ status }`,
+			}}
 		>
-			<ScreenReaderText>Close notification</ScreenReaderText>
+			<ScreenReaderText>Alert,</ScreenReaderText>
+			<Flex sx={{ alignItems: 'center' }}>
+				{status === 'error' ? (
+					<MdError sx={{ color: 'error', flex: '0 0 auto' }} aria-hidden="true" />
+				) : (
+					<MdCheckCircle sx={{ color: 'success', flex: '0 0 auto' }} aria-hidden="true" />
+				)}
+				<Box sx={{ flex: '1 1 auto', ml: 3 }}>
+					<p sx={{ my: 0, color: 'heading', fontWeight: 'bold' }}>
+						{title}
+					</p>
+					{body && <Text sx={{ mb: 0, mt: 1 }}>{body}</Text>}
+				</Box>
+			</Flex>
 
-			<MdClose aria-hidden="true" />
-		</Button>
-
-		<Flex sx={{ alignItems: 'center' }} aria-hidden="true">
-			{status === 'error' ? (
-				<MdError sx={{ color: 'error', flex: '0 0 auto' }} />
-			) : (
-				<MdCheckCircle sx={{ color: 'success', flex: '0 0 auto' }} />
-			)}
-			<Box sx={{ flex: '1 1 auto', ml: 3 }}>
-				<Heading variant="h4" sx={{ mb: 0 }}>
-					{title}
-				</Heading>
-				{body && <Text sx={{ mb: 0, mt: 1 }}>{body}</Text>}
-			</Box>
-		</Flex>
-	</Card>
-);
+			{ onClose && (
+				<Button
+					onClick={onClose}
+					variant="icon"
+					sx={{ color: 'muted', position: 'absolute', top: 2, right: 2 }}
+					aria-hidden="true"
+				>
+					<MdClose />
+				</Button>
+			) }
+		</Card>
+	);
+};
 
 Notification.propTypes = {
 	title: PropTypes.node,
-	prefix: PropTypes.string,
 	body: PropTypes.node,
 	status: PropTypes.string,
 	onClose: PropTypes.func,

--- a/src/system/Notification/Notification.js
+++ b/src/system/Notification/Notification.js
@@ -10,8 +10,9 @@ import PropTypes from 'prop-types';
  * Internal dependencies
  */
 import { Box, Button, Card, Flex, Heading, Text } from '../';
+import ScreenReaderText from '../ScreenReaderText/ScreenReaderText';
 
-const Notification = ( { title, body, status = 'success', onClose } ) => (
+const Notification = ( { title, body, status = 'success', onClose, prefix = 'Alert' } ) => (
 	<Card
 		className="vip-notification-component"
 		sx={{
@@ -21,14 +22,23 @@ const Notification = ( { title, body, status = 'success', onClose } ) => (
 			variant: `notification.${ status }`,
 		}}
 	>
+		<div role="alert">
+			<ScreenReaderText>
+				{prefix}, {title} {body && `, ${ body }`}
+			</ScreenReaderText>
+		</div>
+
 		<Button
 			onClick={onClose}
 			variant="icon"
 			sx={{ color: 'muted', position: 'absolute', top: 2, right: 2 }}
 		>
-			<MdClose />
+			<ScreenReaderText>Close notification</ScreenReaderText>
+
+			<MdClose aria-hidden="true" />
 		</Button>
-		<Flex sx={{ alignItems: 'center' }}>
+
+		<Flex sx={{ alignItems: 'center' }} aria-hidden="true">
 			{status === 'error' ? (
 				<MdError sx={{ color: 'error', flex: '0 0 auto' }} />
 			) : (
@@ -46,6 +56,7 @@ const Notification = ( { title, body, status = 'success', onClose } ) => (
 
 Notification.propTypes = {
 	title: PropTypes.node,
+	prefix: PropTypes.string,
 	body: PropTypes.node,
 	status: PropTypes.string,
 	onClose: PropTypes.func,

--- a/src/system/Notification/Notification.stories.jsx
+++ b/src/system/Notification/Notification.stories.jsx
@@ -1,6 +1,7 @@
 /**
  * Internal dependencies
  */
+import { useLayoutEffect, useState } from 'react';
 import { Notification } from '..';
 
 export default {
@@ -14,3 +15,24 @@ export const Default = () => (
 		subTitle="Use when providing success or error feedback on global action"
 	/>
 );
+
+export const Alert = () => {
+	const [show, setShow] = useState(false);
+
+	useLayoutEffect(() => {
+		setTimeout(() => {
+			setShow(true);
+		}, 1000);
+	}, []);
+
+	if (!show) {
+		return null;
+	}
+
+	return (
+		<Notification
+			title="My first notification"
+			subTitle="Use when providing success or error feedback on global action"
+		/>
+	);
+};

--- a/src/system/Notification/Notification.stories.jsx
+++ b/src/system/Notification/Notification.stories.jsx
@@ -1,7 +1,6 @@
 /**
  * Internal dependencies
  */
-import { useLayoutEffect, useState } from 'react';
 import { Notification } from '..';
 
 export default {
@@ -11,28 +10,14 @@ export default {
 
 export const Default = () => (
 	<Notification
-		title="My first notification"
-		subTitle="Use when providing success or error feedback on global action"
+		title="Awesome!"
+		body="Your message has been sent successfully."
 	/>
 );
-
-export const Alert = () => {
-	const [show, setShow] = useState(false);
-
-	useLayoutEffect(() => {
-		setTimeout(() => {
-			setShow(true);
-		}, 1000);
-	}, []);
-
-	if (!show) {
-		return null;
-	}
-
-	return (
-		<Notification
-			title="My first notification"
-			subTitle="Use when providing success or error feedback on global action"
-		/>
-	);
-};
+export const Error = () => (
+	<Notification
+		status="error"
+		title="Snag!"
+		body="Your message could not be sent."
+	/>
+);

--- a/src/system/ScreenReaderText/ScreenReader.test.js
+++ b/src/system/ScreenReaderText/ScreenReader.test.js
@@ -1,0 +1,28 @@
+/**
+ * External dependencies
+ */
+import React from 'react';
+
+import { render, screen } from '@testing-library/react';
+import '@testing-library/jest-dom';
+/**
+* Internal dependencies
+*/
+import ScreenReaderText from './ScreenReaderText';
+
+describe( '<ScreenReaderText />', () => {
+	it( 'should render correctly', () => {
+		const props = {};
+		const text = 'Hello there';
+		const { container } = render(
+			<ScreenReaderText {...props}>
+				{text}
+			</ScreenReaderText>
+		);
+		// we're using the querySelector to ensure the class is rendered since it affects the A11Y
+		// in case it's removed it could compromise the A11Y of the components using it.
+		expect( container.querySelector( '.screen-reader-text' ) ).toBeInTheDocument();
+
+		expect( screen.queryByText( text ) ).toBeInTheDocument();
+	} );
+} );

--- a/src/system/ScreenReaderText/ScreenReaderText.js
+++ b/src/system/ScreenReaderText/ScreenReaderText.js
@@ -1,0 +1,40 @@
+/**
+ * External dependencies
+ */
+
+import React from 'react';
+import PropTypes from 'prop-types';
+
+/**
+ * Internal dependencies
+ */
+
+export default function ScreenReaderText( props ) {
+	return (
+		<span
+			className="screen-reader-text"
+			style={{
+				border: 'none',
+				clip: 'rect(1px, 1px, 1px, 1px)',
+				clipPath: 'inset(50%)',
+				height: '1px',
+				margin: '-1px',
+				overflow: 'hidden',
+				padding: '0',
+				position: 'absolute',
+				width: '1px',
+				wordWrap: 'normal !important',
+			}}
+			{...props}
+		>
+			{props.children}
+		</span>
+	);
+}
+
+/**
+ * propTypes
+ */
+ScreenReaderText.propTypes = {
+	children: PropTypes.node.isRequired,
+};

--- a/src/system/ScreenReaderText/ScreenReaderText.js
+++ b/src/system/ScreenReaderText/ScreenReaderText.js
@@ -1,3 +1,4 @@
+/** @jsxImportSource theme-ui */
 /**
  * External dependencies
  */
@@ -13,7 +14,7 @@ export default function ScreenReaderText( props ) {
 	return (
 		<span
 			className="screen-reader-text"
-			style={{
+			sx={{
 				border: 'none',
 				clip: 'rect(1px, 1px, 1px, 1px)',
 				clipPath: 'inset(50%)',

--- a/src/system/ScreenReaderText/index.js
+++ b/src/system/ScreenReaderText/index.js
@@ -1,0 +1,7 @@
+/**
+ * Internal dependencies
+ */
+
+import { ScreenReaderText } from './ScreenReaderText';
+
+export { ScreenReaderText };


### PR DESCRIPTION
## Description

- New proposal for `Notification`.

We are adding the `role="alert"` to the Notification component when it appears. It will not focus on the element.

![image](https://user-images.githubusercontent.com/3402/176542944-ea208c86-ec24-4e88-bca9-f2ccbd1b6b98.png)

![image](https://user-images.githubusercontent.com/3402/176542962-30044b10-e744-45b1-9f87-bdb2fcc14c14.png)


- Adding `ScreenReaderText` component for easy screen-reader-text class access

## Checklist

- [x] This PR has good automated test coverage
- [x] The storybook for the component has been updated

## Steps to Test

1. Pull down PR.
2. `npm run dev`.
3. Activate voice over (cmd+fn+f5 on macOS)
4. Open http://localhost:6006/?path=/story/notification--default
5. You should listen: `Alert, Awesome! Your message has been sent successfully.`

