### PR TITLE
[DONT MERGE] Change package references to valet-design-system

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,8 +1,8 @@
-# VIP Design System
+# Valet Design System
 
-Design system components used throughout VIP.
+Design system components used for the Valet Design System.
 
-[Storybook Components](https://vip-design-system-components.netlify.app/)
+[Storybook Components](https://valet-design-system-components.netlify.app/)
 
 ## Development
 
@@ -12,7 +12,7 @@ Make sure you have [node.js](https://nodejs.org/) and [NPM](https://docs.npmjs.c
 
 ### Install
 
-To get setup run the following command in the `vip-design-system` directory:
+To get setup run the following command in the `valet-design-system` directory:
 
 ```
 npm install
@@ -37,7 +37,7 @@ For components that include storybooks, we can run `npm run storybook` to view t
 **npm link**
 
 1. Run `npm link` in your checkout of this repo.
-2. Spin up a local copy of [the VIP Dashboard](https://github.com/automattic/vip-ui) and navigate to a page using the linked components from `@automattic/vip-design-system`
+2. Spin up a local copy of [the VIP Dashboard](https://github.com/automattic/vip-ui) and navigate to a page using the linked components from `@automattic/valet-design-system`
 
 Note: it's super useful to run `npm run watch` in another process, so any changes will be almost immediately available / testable.
 
@@ -74,4 +74,4 @@ git push --tags
 git push origin trunk
 ```
 
-8. For major versions or breaking changes, it's recommended to [create a RELEASE](https://github.com/Automattic/vip-design-system/releases) with the published tag.
+8. For major versions or breaking changes, it's recommended to [create a RELEASE](https://github.com/Automattic/valet-design-system/releases) with the published tag.

--- a/package-lock.json
+++ b/package-lock.json
@@ -1,11 +1,11 @@
 {
-	"name": "@automattic/vip-design-system",
+	"name": "@automattic/valet-design-system",
 	"version": "0.10.3",
 	"lockfileVersion": 2,
 	"requires": true,
 	"packages": {
 		"": {
-			"name": "@automattic/vip-design-system",
+			"name": "@automattic/valet-design-system",
 			"version": "0.10.3",
 			"dependencies": {
 				"@radix-ui/react-checkbox": "^0.1.0",

--- a/package.json
+++ b/package.json
@@ -1,5 +1,5 @@
 {
-	"name": "@automattic/vip-design-system",
+	"name": "@automattic/valet-design-system",
 	"version": "0.10.3",
 	"main": "build/system/index.js",
 	"scripts": {


### PR DESCRIPTION
## Description

Per design system work with @dabowman, the "VIP Design System" is being generalized to the "Valet Design System". The goal is to have a comprehensive design system that can be used outside of the current wpvip dashboard.

My intended path is to rename this repository in GitHub, publish a new `@automattic/valet-design-system` package on NPM, and update dependents. See **Post-merge steps** below.

This PR contains the small code changes needed in this repository and documents the steps I'll need to take next. There are no other functional or feature changes being made to this repository, just renaming the repository and package.

## Pre-merge checklist

Here are things I need to have ready before pushing an update:

- [ ] Ensure I have `npm` push access [as outlined in the README](https://github.com/Automattic/vip-design-system#publish-npm-package-instructions).

## Post-merge steps

When I have necessary access and this PR is approved, the next steps are to:

1. Rename the `vip-design-system` to `valet-design-system` using [repository settings in GitHub](https://github.com/Automattic/vip-design-system/settings).
2. Merge my changes.
3. Publish a new `@automattic/valet-design-system` package to npm.
4. [Add a deprecation message](https://stackoverflow.com/a/28841779/770938) to the `@automattic/vip-design-system` package pointing to `@automattic/valet-design-system`.
5. Open PR in [`vip-ui`](https://github.com/automattic/vip-ui) to change the design system dependency name [in `package.json`](https://github.com/Automattic/vip-ui/blob/develop/package.json#L8) and imported places to the `valet-design-system` package. The now-deprecated `vip-design-system` package should continue to work, so it should be okay if this isn't merged immediately.
6. Login to Netlify using secret login credentials. Undeploy https://vip-design-system-components.netlify.app/ and deploy new repo to `https://valet-design-system-components.netlify.app/`.

## Verification

I should be able to verify everything is working successfully by:

- [ ] `npm install` and build in `vip-ui` and ensure we're pulling from `valet-design-system` successfully and properly referencing the new package in code.
- [ ] Verifying the new Netlify storybook URL `https://valet-design-system-components.netlify.app/` is deployed.

## Open questions

1. Another migration strategy would be to create a new repository, copy this repository over to it, and then archive-only this repository. This would be a bit safer than a direct rename, but doesn't seem worthwhile to me to have two repositories. Would there be any other benefit to making a fresh repository instead of renaming?
2. Are there any packages other than [`vip-ui`](https://github.com/automattic/vip-ui) that depend on `vip-design-system`? [npm shows 0 public dependencies](https://www.npmjs.com/package/@automattic/vip-design-system) but there may be other private dependents.
3. Will creating a new `@automattic/valet-design-system` on npm require any special setup or privileges?
4. Am I missing any other important steps?