### PR TITLE
Exposes <TableCell> so users have more control over table markups

### DIFF
--- a/src/system/Table/Table.stories.jsx
+++ b/src/system/Table/Table.stories.jsx
@@ -1,7 +1,7 @@
 /**
  * Internal dependencies
  */
-import { Table, TableRow, Flex, Heading, Text } from '..';
+import { Table, TableRow, Flex, Heading, Text, TableCell } from '..';
 
 export default {
 	title: 'Table',
@@ -36,6 +36,34 @@ export const Default = () => (
 					</Text>,
 				] }
 			/>
+			<TableRow>
+				<TableCell sx={ { backgroundColor: 'gray' } }>
+					<Flex sx={ { alignItems: 'center' } } key="user">
+						<Heading variant="h4" sx={ { mb: 0 } }>
+							simon
+						</Heading>
+					</Flex>
+				</TableCell>
+				<TableCell>
+					<Heading
+						variant="h4"
+						key="command"
+						sx={ { mb: 0, display: 'flex', alignItems: 'center' } }
+					>
+						wp posts list
+					</Heading>
+				</TableCell>
+				<TableCell>
+					<Text sx={ { mb: 0 } } key="duration">
+						3s
+					</Text>
+				</TableCell>
+				<TableCell>
+					<Text sx={ { mb: 0, color: 'muted' } } key="time">
+						3rd May 2021, 13:22:13
+					</Text>
+				</TableCell>
+			</TableRow>
 		</tbody>
 	</Table>
 );

--- a/src/system/Table/Table.stories.jsx
+++ b/src/system/Table/Table.stories.jsx
@@ -37,7 +37,7 @@ export const Default = () => (
 				] }
 			/>
 			<TableRow>
-				<TableCell sx={ { backgroundColor: 'gray' } }>
+				<TableCell sx={ { backgroundColor: 'lightgray' } }>
 					<Flex sx={ { alignItems: 'center' } } key="user">
 						<Heading variant="h4" sx={ { mb: 0 } }>
 							simon

--- a/src/system/Table/TableCell.js
+++ b/src/system/Table/TableCell.js
@@ -11,15 +11,7 @@ import PropTypes from 'prop-types';
  */
 import { Heading, Box } from '../';
 
-const TableCell = ( { head, isRowHead, children, ...rest } ) => {
-	let scope = null;
-
-	if ( head ) {
-		scope = 'col';
-	} else if ( isRowHead ) {
-		scope = 'row';
-	}
-
+const TableCell = ( { head, children, ...rest } ) => {
 	const sx = {
 		borderBottom: '1px solid',
 		borderTop: head ? '1px solid' : 'none',
@@ -36,7 +28,7 @@ const TableCell = ( { head, isRowHead, children, ...rest } ) => {
 	};
 
 	return (
-		<Box as={ isRowHead || head ? 'th' : 'td' } scope={ scope } { ...{ ...rest, sx } }>
+		<Box as={ head ? 'th' : 'td' } { ...{ ...rest, sx } }>
 			{ head ? (
 				<Heading variant="caps" as="div" sx={ { mb: 0 } }>
 					{ children }
@@ -51,7 +43,6 @@ const TableCell = ( { head, isRowHead, children, ...rest } ) => {
 TableCell.propTypes = {
 	children: PropTypes.node,
 	head: PropTypes.bool,
-	isRowHead: PropTypes.bool,
 };
 
 export { TableCell };

--- a/src/system/Table/TableCell.js
+++ b/src/system/Table/TableCell.js
@@ -11,7 +11,7 @@ import PropTypes from 'prop-types';
  */
 import { Heading, Box } from '../';
 
-const TableCell = ( { head, isRowHead, cell, ...rest } ) => {
+const TableCell = ( { head, isRowHead, children, ...rest } ) => {
 	let scope = null;
 
 	if ( head ) {
@@ -20,39 +20,37 @@ const TableCell = ( { head, isRowHead, cell, ...rest } ) => {
 		scope = 'row';
 	}
 
+	const sx = {
+		borderBottom: '1px solid',
+		borderColor: 'border',
+		borderTop: head ? '1px solid' : 'none',
+		fontWeight: 'body',
+		px: 3,
+		py: 2,
+		textAlign: 'left',
+		'&:first-of-type': {
+			pl: 5,
+		},
+		...rest.sx,
+	};
+
 	return (
-		<Box
-			as={ isRowHead || head ? 'th' : 'td' }
-			scope={ scope }
-			sx={ {
-				borderBottom: '1px solid',
-				borderColor: 'border',
-				borderTop: head ? '1px solid' : 'none',
-				fontWeight: 'body',
-				px: 3,
-				py: 2,
-				textAlign: 'left',
-				'&:first-of-type': {
-					pl: 5,
-				},
-			} }
-			{ ...rest }
-		>
+		<Box as={ isRowHead || head ? 'th' : 'td' } scope={ scope } { ...{ ...rest, sx } }>
 			{ head ? (
 				<Heading variant="caps" as="div" sx={ { mb: 0 } }>
-					{ cell }
+					{ children }
 				</Heading>
 			) : (
-				cell
+				children
 			) }
 		</Box>
 	);
 };
 
 TableCell.propTypes = {
+	children: PropTypes.node,
 	head: PropTypes.bool,
 	isRowHead: PropTypes.bool,
-	cell: PropTypes.node,
 };
 
 export { TableCell };

--- a/src/system/Table/TableCell.js
+++ b/src/system/Table/TableCell.js
@@ -1,0 +1,58 @@
+/** @jsxImportSource theme-ui */
+
+/**
+ * External dependencies
+ */
+
+import PropTypes from 'prop-types';
+
+/**
+ * Internal dependencies
+ */
+import { Heading, Box } from '../';
+
+const TableCell = ( { head, isRowHead, cell, ...rest } ) => {
+	let scope = null;
+
+	if ( head ) {
+		scope = 'col';
+	} else if ( isRowHead ) {
+		scope = 'row';
+	}
+
+	return (
+		<Box
+			as={ isRowHead || head ? 'th' : 'td' }
+			scope={ scope }
+			sx={ {
+				borderBottom: '1px solid',
+				borderColor: 'border',
+				borderTop: head ? '1px solid' : 'none',
+				fontWeight: 'body',
+				px: 3,
+				py: 2,
+				textAlign: 'left',
+				'&:first-of-type': {
+					pl: 5,
+				},
+			} }
+			{ ...rest }
+		>
+			{ head ? (
+				<Heading variant="caps" as="div" sx={ { mb: 0 } }>
+					{ cell }
+				</Heading>
+			) : (
+				cell
+			) }
+		</Box>
+	);
+};
+
+TableCell.propTypes = {
+	head: PropTypes.bool,
+	isRowHead: PropTypes.bool,
+	cell: PropTypes.node,
+};
+
+export { TableCell };

--- a/src/system/Table/TableCell.js
+++ b/src/system/Table/TableCell.js
@@ -22,8 +22,9 @@ const TableCell = ( { head, isRowHead, children, ...rest } ) => {
 
 	const sx = {
 		borderBottom: '1px solid',
-		borderColor: 'border',
 		borderTop: head ? '1px solid' : 'none',
+		// borderColor should come after borderTop so it can override it
+		borderColor: 'border',
 		fontWeight: 'body',
 		px: 3,
 		py: 2,

--- a/src/system/Table/TableRow.js
+++ b/src/system/Table/TableRow.js
@@ -11,7 +11,7 @@ import PropTypes from 'prop-types';
  */
 import { TableCell } from './TableCell';
 
-const TableRow = ( { onClick, head = false, rowHead = false, cells } ) => {
+const TableRow = ( { onClick, head = false, rowHead = false, cells = [], children } ) => {
 	const hoverStyles = onClick
 		? { cursor: 'pointer', '&:hover': { bg: 'hover', borderRadius: 2 } }
 		: {};
@@ -30,14 +30,19 @@ const TableRow = ( { onClick, head = false, rowHead = false, cells } ) => {
 			onKeyDown={ handleKeyPress }
 		>
 			{ cells.map( ( cell, index ) => (
-				<TableCell key={ index } cell={ cell } head={ head } isRowHead={ index === 0 && rowHead } />
+				<TableCell key={ index } head={ head } isRowHead={ index === 0 && rowHead }>
+					{ cell }
+				</TableCell>
 			) ) }
+
+			{ children }
 		</tr>
 	);
 };
 
 TableRow.propTypes = {
 	cells: PropTypes.array,
+	children: PropTypes.node,
 	head: PropTypes.bool,
 	onClick: PropTypes.func,
 	rowHead: PropTypes.bool,

--- a/src/system/Table/TableRow.js
+++ b/src/system/Table/TableRow.js
@@ -9,7 +9,7 @@ import PropTypes from 'prop-types';
 /**
  * Internal dependencies
  */
-import { Heading, Box } from '../';
+import { TableCell } from './TableCell';
 
 const TableRow = ( { onClick, head = false, rowHead = false, cells } ) => {
 	const hoverStyles = onClick
@@ -36,51 +36,10 @@ const TableRow = ( { onClick, head = false, rowHead = false, cells } ) => {
 	);
 };
 
-const TableCell = ( { head, isRowHead, cell } ) => {
-	let scope = null;
-	if ( head ) {
-		scope = 'col';
-	} else if ( isRowHead ) {
-		scope = 'row';
-	}
-	return (
-		<Box
-			as={ isRowHead || head ? 'th' : 'td' }
-			scope={ scope }
-			sx={ {
-				px: 3,
-				py: 2,
-				textAlign: 'left',
-				borderBottom: '1px solid',
-				fontWeight: 'body',
-				borderTop: head ? '1px solid' : 'none',
-				borderColor: 'border',
-				'&:first-of-type': {
-					pl: 5,
-				},
-			} }
-		>
-			{ head ? (
-				<Heading variant="caps" as="div" sx={ { mb: 0 } }>
-					{ cell }
-				</Heading>
-			) : (
-				cell
-			) }
-		</Box>
-	);
-};
-
-TableCell.propTypes = {
-	head: PropTypes.bool,
-	isRowHead: PropTypes.bool,
-	cell: PropTypes.node,
-};
-
 TableRow.propTypes = {
-	onClick: PropTypes.func,
-	head: PropTypes.bool,
 	cells: PropTypes.array,
+	head: PropTypes.bool,
+	onClick: PropTypes.func,
 	rowHead: PropTypes.bool,
 };
 

--- a/src/system/Table/TableRow.js
+++ b/src/system/Table/TableRow.js
@@ -11,7 +11,7 @@ import PropTypes from 'prop-types';
  */
 import { TableCell } from './TableCell';
 
-const TableRow = ( { onClick, head = false, rowHead = false, cells = [], children } ) => {
+const TableRow = ( { onClick, head = false, cells = [], children } ) => {
 	const hoverStyles = onClick
 		? { cursor: 'pointer', '&:hover': { bg: 'hover', borderRadius: 2 } }
 		: {};
@@ -30,7 +30,7 @@ const TableRow = ( { onClick, head = false, rowHead = false, cells = [], childre
 			onKeyDown={ handleKeyPress }
 		>
 			{ cells.map( ( cell, index ) => (
-				<TableCell key={ index } head={ head } isRowHead={ index === 0 && rowHead }>
+				<TableCell key={ index } head={ head }>
 					{ cell }
 				</TableCell>
 			) ) }
@@ -45,7 +45,6 @@ TableRow.propTypes = {
 	children: PropTypes.node,
 	head: PropTypes.bool,
 	onClick: PropTypes.func,
-	rowHead: PropTypes.bool,
 };
 
 export { TableRow };

--- a/src/system/Table/index.js
+++ b/src/system/Table/index.js
@@ -3,5 +3,6 @@
  */
 import { Table } from './Table';
 import { TableRow } from './TableRow';
+import { TableCell } from './TableCell';
 
-export { Table, TableRow };
+export { Table, TableRow, TableCell };

--- a/src/system/Time/index.js
+++ b/src/system/Time/index.js
@@ -56,7 +56,7 @@ const Time = ( { time, relativeTime = false, timeOnly = false, className = null,
 };
 
 Time.propTypes = {
-	time: PropTypes.oneOfType( [ PropTypes.string, PropTypes.date ] ),
+	time: PropTypes.oneOfType( [ PropTypes.string, PropTypes.instanceOf( Date ) ] ),
 	timeOnly: PropTypes.bool,
 	relativeTime: PropTypes.bool,
 	className: PropTypes.any,

--- a/src/system/index.js
+++ b/src/system/index.js
@@ -44,7 +44,7 @@ import { Time } from './Time';
 import { Timeline } from './Timeline';
 import { Notification } from './Notification';
 import { OptionRow } from './OptionRow';
-import { Table, TableRow } from './Table';
+import { Table, TableRow, TableCell } from './Table';
 import { TabItem, Tabs } from './Tabs';
 import { Text } from './Text';
 import theme from './theme';
@@ -77,6 +77,7 @@ export {
 	Spinner,
 	Table,
 	TableRow,
+	TableCell,
 	Tooltip,
 	Notification,
 	Link,


### PR DESCRIPTION
## Description

Right now users don't have much control over the markup of the `<td>` on a table. This PR allows them to build tables with more granular control. Like this:

```jsx
<TableRow>
    <TableCell sx={ { backgroundColor: 'gray' } }>
        simon
    </TableCell>
</TableRow>
```

Note that we can now specify styles for the `<td>` or `<th>` which we couldn't do before. One use case is on the Dashboard: I want the first column to have a specific width since it only contains a thumbnail.

***Before***

![before_table](https://user-images.githubusercontent.com/156388/177326326-062d4881-bbe9-4676-ace6-b7933865639b.png)

***After***

![after_table](https://user-images.githubusercontent.com/156388/177326346-a600d926-41c3-4d1f-b03c-db146973c408.png)

## Checklist

- [ ] This PR has good automated test coverage
- [x] The storybook for the component has been updated

## Steps to Test

1. Pull down PR.
1. `npm run dev`.
1. Open Storybook.
1. Go to the Table component
1. Verify there's a custom `<td>` with its own background
