### PR TITLE
Fix <Notice/> component icon size and colors

### DIFF
--- a/src/system/Notice/Notice.js
+++ b/src/system/Notice/Notice.js
@@ -27,7 +27,7 @@ const NoticeIcon = ( { color, variant } ) => {
 			break;
 	}
 
-	return <Icon sx={ { marginRight: 2, color, flex: '0 0 auto' } } />;
+	return <Icon sx={ { color, flex: '0 0 auto' } } size={ 21 } />;
 };
 
 NoticeIcon.propTypes = {
@@ -86,10 +86,10 @@ const Notice = ( {
 						alignItems: 'center',
 					} }
 				>
-					<NoticeIcon color={ `${ color }.100` } variant={ variant } />
+					<NoticeIcon color={ `${ color }.200` } variant={ variant } />
 				</Flex>
 
-				<Box sx={ { ml: 23 } }>
+				<Box sx={ { ml: 3 } }>
 					{ title && (
 						<Heading variant="h4" as="p" sx={ { color: `${ color }.100`, mb: 0 } }>
 							{ title }


### PR DESCRIPTION
## Description

Currently, the `<Notice />` icons are too small, and with strange colors compared to the rest of the component's pallet. I realized that's because we are using a different color tone. Also, the Icon sizes are incompatible with the `<Notice />` container size/paddings.

### Before
![image](https://user-images.githubusercontent.com/3402/178340157-50a67aa5-dba7-45f2-8420-0cac4235ecc3.png)

![image](https://user-images.githubusercontent.com/3402/178340219-f37d51fb-ae26-4e79-aec9-51a56005d5c2.png)


### Light
![Screen Shot 2022-07-11 at 16 07 37](https://user-images.githubusercontent.com/3402/178340059-9d044d5d-d6cd-470a-986a-49f1aab3458a.png)

### Dark
![Screen Shot 2022-07-11 at 16 09 50](https://user-images.githubusercontent.com/3402/178340073-14ef6668-e6af-4757-833a-2986214a372a.png)


## Checklist

- [ ] This PR has good automated test coverage
- [x] The storybook for the component has been updated

## Steps to Test

1. Pull down PR.
2. `npm run dev`.
3. Open https://deploy-preview-76--vip-design-system-components.netlify.app/?path=/story/notice--default
4. Check Icon size and colors are fixed