### PR TITLE
Add another visual indicator for the Toggle component state

### DIFF
--- a/src/system/Form/Toggle.js
+++ b/src/system/Form/Toggle.js
@@ -23,20 +23,21 @@ export const Toggle = ( { name = 'toggle', onChange, className = null, ...rest }
 			position: 'relative',
 			WebkitTapHighlightColor: 'rgba(0, 0, 0, 0)',
 			'::after': {
-				content: '"o"',
+				fontFamily: 'system-ui, Helvetica, sans-serif',
+				content: '"\\2715"',
 				position: 'absolute',
 				color: 'white',
 				fontSize: '10px',
 				fontWeight: 'bold',
 				top: 1,
-				right: 10,
+				right: '9px',
 			},
 			'&[data-state="checked"]': {
 				backgroundColor: 'success',
 				'::after': {
-					content: '"I"',
+					content: '"\\2713"',
 					top: 1,
-					left: 10,
+					left: '8px',
 				},
 			},
 		} }

--- a/src/system/Form/Toggle.js
+++ b/src/system/Form/Toggle.js
@@ -16,7 +16,7 @@ export const Toggle = ( {
 	name = 'toggle',
 	onChange,
 	className = null,
-	variant = 'success',
+	variant = 'primary',
 	...rest
 } ) => (
 	<Switch.Root
@@ -29,16 +29,16 @@ export const Toggle = ( {
 			borderRadius: '32px',
 			backgroundColor: 'muted',
 			backgroundRepeat: 'no-repeat',
-			backgroundPosition: 'right 6px top 5px',
+			backgroundPosition: 'right 2px top 2px',
 			backgroundImage: `url(
-				'data:image/svg+xml;utf8,<svg width="10" height="10" viewBox="0 0 10 10" fill="none" xmlns="http://www.w3.org/2000/svg"><rect x="7.7782" y="0.403809" width="2" height="11" transform="rotate(45 7.7782 0.403809)" fill="white"/><rect y="1.81799" width="2" height="11" transform="rotate(-45 0 1.81799)" fill="white"/></svg>')`,
+				'data:image/svg+xml;utf8,<svg width="16" height="16" viewBox="0 0 16 16" fill="none" xmlns="http://www.w3.org/2000/svg"><path fill-rule="evenodd" clip-rule="evenodd" d="M4.53846 3L3 4.53846L6.46156 8.00001L3.00003 11.4615L4.53848 13L8.00001 9.53847L11.4615 13L13 11.4615L9.53847 8.00001L13 4.53849L11.4615 3.00003L8.00001 6.46156L4.53846 3Z" fill="white"/></svg>')`,
 			WebkitTapHighlightColor: 'rgba(0, 0, 0, 0)',
 
 			'&[data-state="checked"]': {
 				backgroundColor: variant,
-				backgroundPosition: 'left 6px top 4px',
+				backgroundPosition: 'left 2px top 2px',
 				backgroundImage: `url(
-					'data:image/svg+xml;utf8,<svg width="11" height="10" viewBox="0 0 11 9" fill="none" xmlns="http://www.w3.org/2000/svg"><path d="M1 5.98L3.64706 8.5L11 1.5" stroke="white" stroke-width="2"/></svg>')`,
+					'data:image/svg+xml;utf8,<svg width="16" height="16" viewBox="0 0 16 16" fill="none" xmlns="http://www.w3.org/2000/svg"><path fill-rule="evenodd" clip-rule="evenodd" d="M13.4999 4.9995L5.7254 12.4008L2.5 9.33023L3.83307 7.92994L5.7254 9.73144L12.1668 3.59921L13.4999 4.9995Z" fill="white"/></svg>')`,
 			},
 		} }
 		name={ name }

--- a/src/system/Form/Toggle.js
+++ b/src/system/Form/Toggle.js
@@ -1,3 +1,4 @@
+/* eslint-disable max-len */
 /** @jsxImportSource theme-ui */
 
 /**
@@ -11,34 +12,33 @@ import * as Switch from '@radix-ui/react-switch';
 // Documentation for Radix Switch component
 // https://www.radix-ui.com/docs/primitives/components/switch
 
-export const Toggle = ( { name = 'toggle', onChange, className = null, ...rest } ) => (
+export const Toggle = ( {
+	name = 'toggle',
+	onChange,
+	className = null,
+	variant = 'success',
+	...rest
+} ) => (
 	<Switch.Root
 		className={ classNames( 'vip-toggle-component', className ) }
 		sx={ {
 			all: 'unset',
-			width: 42,
-			height: 24,
-			backgroundColor: 'muted',
-			borderRadius: '15px',
 			position: 'relative',
+			width: 40,
+			height: 20,
+			borderRadius: '32px',
+			backgroundColor: 'muted',
+			backgroundRepeat: 'no-repeat',
+			backgroundPosition: 'right 6px top 5px',
+			backgroundImage: `url(
+				'data:image/svg+xml;utf8,<svg width="10" height="10" viewBox="0 0 10 10" fill="none" xmlns="http://www.w3.org/2000/svg"><rect x="7.7782" y="0.403809" width="2" height="11" transform="rotate(45 7.7782 0.403809)" fill="white"/><rect y="1.81799" width="2" height="11" transform="rotate(-45 0 1.81799)" fill="white"/></svg>')`,
 			WebkitTapHighlightColor: 'rgba(0, 0, 0, 0)',
-			'::after': {
-				fontFamily: 'system-ui, Helvetica, sans-serif',
-				content: '"\\2715"',
-				position: 'absolute',
-				color: 'white',
-				fontSize: '10px',
-				fontWeight: 'bold',
-				top: 1,
-				right: '9px',
-			},
+
 			'&[data-state="checked"]': {
-				backgroundColor: 'success',
-				'::after': {
-					content: '"\\2713"',
-					top: 1,
-					left: '8px',
-				},
+				backgroundColor: variant,
+				backgroundPosition: 'left 6px top 4px',
+				backgroundImage: `url(
+					'data:image/svg+xml;utf8,<svg width="11" height="10" viewBox="0 0 11 9" fill="none" xmlns="http://www.w3.org/2000/svg"><path d="M1 5.98L3.64706 8.5L11 1.5" stroke="white" stroke-width="2"/></svg>')`,
 			},
 		} }
 		name={ name }
@@ -48,15 +48,15 @@ export const Toggle = ( { name = 'toggle', onChange, className = null, ...rest }
 		<Switch.Thumb
 			sx={ {
 				display: 'block',
-				width: 18,
-				height: 18,
+				width: 16,
+				height: 16,
 				backgroundColor: 'white',
 				borderRadius: '50%',
 				boxShadow: 'rgb(0 0 0 / 5%) 0px 1px 5px, rgb(0 0 0 / 15%) 0px 1px 1px',
 				transition: 'transform 100ms',
-				transform: 'translateX(3px)',
+				transform: 'translateX(2px)',
 				willChange: 'transform',
-				'&[data-state="checked"]': { transform: 'translateX(21px)' },
+				'&[data-state="checked"]': { transform: 'translateX(22px)' },
 			} }
 		/>
 	</Switch.Root>
@@ -66,4 +66,5 @@ Toggle.propTypes = {
 	name: PropTypes.string,
 	className: PropTypes.any,
 	onChange: PropTypes.func,
+	variant: PropTypes.string,
 };

--- a/src/system/Form/Toggle.js
+++ b/src/system/Form/Toggle.js
@@ -22,7 +22,23 @@ export const Toggle = ( { name = 'toggle', onChange, className = null, ...rest }
 			borderRadius: '15px',
 			position: 'relative',
 			WebkitTapHighlightColor: 'rgba(0, 0, 0, 0)',
-			'&[data-state="checked"]': { backgroundColor: 'success' },
+			'::after': {
+				content: '"o"',
+				position: 'absolute',
+				color: 'white',
+				fontSize: '10px',
+				fontWeight: 'bold',
+				top: 1,
+				right: 10,
+			},
+			'&[data-state="checked"]': {
+				backgroundColor: 'success',
+				'::after': {
+					content: '"I"',
+					top: 1,
+					left: 10,
+				},
+			},
 		} }
 		name={ name }
 		onCheckedChange={ onChange || undefined }

--- a/src/system/Form/Toggle.stories.jsx
+++ b/src/system/Form/Toggle.stories.jsx
@@ -59,7 +59,7 @@ const CustomStyling = args => (
 				defaultChecked
 				checked={ args.checked }
 				aria-label="Feature flag"
-				variant="primary"
+				variant="success"
 			/>{ ' ' }
 			<Toggle
 				id="custom-label-input-error"

--- a/src/system/Form/Toggle.stories.jsx
+++ b/src/system/Form/Toggle.stories.jsx
@@ -1,3 +1,4 @@
+/** @jsxImportSource theme-ui */
 /**
  * External dependencies
  */
@@ -21,7 +22,17 @@ export default {
 
 const Default = args => (
 	<form>
-		<Toggle defaultChecked checked={ args.checked } aria-label="Feature flag" />
+		<Toggle
+			checked={ args.checked }
+			defaultChecked
+			color={ args.color }
+			aria-label="Feature flag"
+		/>
+
+		<br />
+		<br />
+
+		<Toggle checked={ args.checked } defaultChecked={ false } aria-label="Feature flag 2" />
 	</form>
 );
 
@@ -38,5 +49,36 @@ const WithLabel = args => (
 	</form>
 );
 
+const CustomStyling = args => (
+	<form>
+		<Label htmlFor="custom-label-input">Custom Styling</Label>
+
+		<div>
+			<Toggle
+				id="custom-label-input"
+				defaultChecked
+				checked={ args.checked }
+				aria-label="Feature flag"
+				variant="primary"
+			/>{ ' ' }
+			<Toggle
+				id="custom-label-input-error"
+				defaultChecked
+				checked={ args.checked }
+				aria-label="Error flag"
+				variant="error"
+			/>{ ' ' }
+			<Toggle
+				id="custom-label-input-warning"
+				defaultChecked
+				checked={ args.checked }
+				aria-label="Warning flag"
+				variant="warning"
+			/>
+		</div>
+	</form>
+);
+
 export const Primary = Default.bind( { checked: true } );
 export const ExternalLabel = WithLabel.bind( { checked: true } );
+export const CustomStyle = CustomStyling.bind( { checked: true } );


### PR DESCRIPTION
## Description

According to the Guidelines ([this one as a reference](https://developer.wordpress.org/block-editor/reference-guides/components/form-toggle/)) and our expert consultant @rianrietveld, it's a WCAG requirement to have an indicator of the toggle state that is not only a color indicator. For folks with color blindness, for example, the color would not matter.

We are adding a visual indicator similar to the WordPress [FormToggle component](https://developer.wordpress.org/block-editor/reference-guides/components/form-toggle/) indicating when the Toggle is On or Off.

![image](https://user-images.githubusercontent.com/3402/179276625-15a67a82-7365-4a48-bc24-240f14cb3b9c.png)

![Screen Shot 2022-07-15 at 14 26 14](https://user-images.githubusercontent.com/3402/179276646-b1352161-69f4-42ef-9349-bb35a49ceec0.png)

Ps: Bonus: You can pass a `variant` to determine which theme color you want. Any color available on the theme is possible.

## Checklist

- [ ] This PR has good automated test coverage
- [x] The storybook for the component has been updated

## Steps to Test

1. Pull down PR.
2. `npm run dev`.
3. Open https://deploy-preview-78--vip-design-system-components.netlify.app/?path=/story/toggle--primary
4. You should see the symbol "✓" as an indicator of ON
5. You should see the symbol "✕" as an indicator of OFF
