### PR TITLE
Improvements for Focus and Disabled states

### DIFF
--- a/.storybook/decorators/withColorMode.jsx
+++ b/.storybook/decorators/withColorMode.jsx
@@ -4,7 +4,7 @@ import { useColorMode } from 'theme-ui';
 
 // These need to be updated to import VIP design tokens;
 const lightBackground = '#ffffff';
-const darkBackground = '#333333';
+const darkBackground = '#1C1C1B';
 
 export const backgrounds = {
 	default: 'Light',
@@ -21,7 +21,7 @@ export const backgrounds = {
 };
 
 function ThemeChanger( { background } ) {
-	const [colorMode, setColorMode] = useColorMode();
+	const [ colorMode, setColorMode ] = useColorMode();
 	const newColorMode = darkBackground === background ? 'dark' : 'default';
 
 	useEffect( () => {
@@ -29,7 +29,7 @@ function ThemeChanger( { background } ) {
 	}, [ newColorMode ] );
 
 	return null;
-};
+}
 
 export default makeDecorator( {
 	name: 'withColorMode',
@@ -37,9 +37,9 @@ export default makeDecorator( {
 	wrapper: ( storyFn, context ) => {
 		return (
 			<>
-				<ThemeChanger background={context.globals?.backgrounds?.value} />
-				{storyFn()}
+				<ThemeChanger background={ context.globals?.backgrounds?.value } />
+				{ storyFn() }
 			</>
 		);
-	}
+	},
 } );

--- a/src/system/Button/Button.js
+++ b/src/system/Button/Button.js
@@ -16,8 +16,10 @@ const Button = ( { sx, ...props } ) => (
 			justifyContent: 'center',
 			height: '36px',
 			py: 0,
+			'&:focus': theme => theme.outline,
+			'&:focus-visible': theme => theme.outline,
 			'&:disabled': {
-				opacity: 0.5,
+				opacity: 0.7,
 				cursor: 'not-allowed',
 				pointerEvents: 'all',
 			},

--- a/src/system/Form/Toggle.js
+++ b/src/system/Form/Toggle.js
@@ -34,6 +34,11 @@ export const Toggle = ( {
 				'data:image/svg+xml;utf8,<svg width="16" height="16" viewBox="0 0 16 16" fill="none" xmlns="http://www.w3.org/2000/svg"><path fill-rule="evenodd" clip-rule="evenodd" d="M4.53846 3L3 4.53846L6.46156 8.00001L3.00003 11.4615L4.53848 13L8.00001 9.53847L11.4615 13L13 11.4615L9.53847 8.00001L13 4.53849L11.4615 3.00003L8.00001 6.46156L4.53846 3Z" fill="white"/></svg>')`,
 			WebkitTapHighlightColor: 'rgba(0, 0, 0, 0)',
 
+			'&:focus': theme => theme.outline,
+			'&:focus-visible': theme => theme.outline,
+			'&[disabled]': {
+				opacity: 0.7,
+			},
 			'&[data-state="checked"]': {
 				backgroundColor: variant,
 				backgroundPosition: 'left 2px top 2px',

--- a/src/system/Form/Toggle.stories.jsx
+++ b/src/system/Form/Toggle.stories.jsx
@@ -33,6 +33,11 @@ const Default = args => (
 		<br />
 
 		<Toggle checked={ args.checked } defaultChecked={ false } aria-label="Feature flag 2" />
+
+		<br />
+		<br />
+
+		<Toggle aria-label="Feature Disabled" disabled defaultChecked={ false } />
 	</form>
 );
 

--- a/src/system/Link/Link.js
+++ b/src/system/Link/Link.js
@@ -20,6 +20,8 @@ const Link = ( { active = false, sx, ...props } ) => (
 			'&:hover, &:focus': {
 				color: 'heading',
 			},
+			'&:focus': theme => theme.outline,
+			'&:focus-visible': theme => theme.outline,
 			...sx,
 		} }
 	/>

--- a/src/system/NewDialog/DialogClose.js
+++ b/src/system/NewDialog/DialogClose.js
@@ -34,7 +34,8 @@ export const DialogClose = React.forwardRef( ( props, forwardedRef ) => (
 					outlineColor: 'primary',
 					outlineWidth: '2px',
 				},
-				'&:focus': { outlineStyle: 'solid', outlineColor: 'primary', outlineWidth: '2px' },
+				'&:focus': theme => theme.outline,
+				'&:focus-visible': theme => theme.outline,
 			} }
 		>
 			<IoClose aria-hidden="true" />

--- a/src/system/theme/getColor.js
+++ b/src/system/theme/getColor.js
@@ -1,0 +1,29 @@
+/**
+ * Internal dependencies
+ */
+
+import Valet from '../../../tokens/valet-color.json';
+
+const ThemeColors = Valet[ 'productive-color-wpvip' ];
+const CoreColors = Valet[ 'valet-core' ];
+console.log( ThemeColors );
+export const getColor = ( color, variant = 'default' ) => {
+	if ( ! ThemeColors[ color ] ) {
+		return '#000000';
+	}
+
+	const colorValue = ThemeColors[ color ][ variant ].value;
+
+	if ( colorValue.startsWith( '{' ) ) {
+		const [ name, number ] = colorValue.replace( /[{}]/g, '' ).split( '.' );
+
+		// Some colors are flat, there is no sub values.
+		if ( CoreColors[ name ][ number ] ) {
+			return CoreColors[ name ][ number ].value;
+		}
+
+		return CoreColors[ name ].value;
+	}
+
+	return colorValue;
+};

--- a/src/system/theme/getColor.js
+++ b/src/system/theme/getColor.js
@@ -6,7 +6,7 @@ import Valet from '../../../tokens/valet-color.json';
 
 const ThemeColors = Valet[ 'productive-color-wpvip' ];
 const CoreColors = Valet[ 'valet-core' ];
-console.log( ThemeColors );
+
 export const getColor = ( color, variant = 'default' ) => {
 	if ( ! ThemeColors[ color ] ) {
 		return '#000000';

--- a/src/system/theme/index.js
+++ b/src/system/theme/index.js
@@ -51,7 +51,12 @@ const textStyles = {
 	},
 };
 
-const outline = { outlineStyle: 'solid', outlineColor: '#005fcc', outlineWidth: '2px' };
+const outline = {
+	outlineStyle: 'solid',
+	outlineColor: '#ffffff',
+	outlineWidth: '1px',
+	boxShadow: '0 0 0 1px #fff, 0 0 0 3px #0f62fe',
+};
 
 export default {
 	outline,

--- a/src/system/theme/index.js
+++ b/src/system/theme/index.js
@@ -2,6 +2,7 @@
  * Internal dependencies
  */
 import { light, dark } from './colors';
+import { getColor } from './getColor';
 
 const textStyles = {
 	h1: {
@@ -55,7 +56,7 @@ const outline = {
 	outlineStyle: 'solid',
 	outlineColor: '#ffffff',
 	outlineWidth: '1px',
-	boxShadow: '0 0 0 1px #fff, 0 0 0 3px #0f62fe',
+	boxShadow: `0 0 0 1px #fff, 0 0 0 3px ${ getColor( 'focus' ) }`,
 };
 
 export default {
@@ -86,8 +87,8 @@ export default {
 	},
 	initialColorModeName: 'light',
 	colors: {
-		text: light.grey[ '90' ],
-		heading: light.grey[ '100' ],
+		text: getColor( 'text', 'secondary' ),
+		heading: getColor( 'text', 'primary' ),
 		background: '#fdfdfd',
 		backgroundSecondary: light.grey[ '10' ],
 		primary: light.brand[ '70' ],

--- a/src/system/theme/index.js
+++ b/src/system/theme/index.js
@@ -51,7 +51,10 @@ const textStyles = {
 	},
 };
 
+const outline = { outlineStyle: 'solid', outlineColor: '#005fcc', outlineWidth: '2px' };
+
 export default {
+	outline,
 	space: [ 0, 4, 8, 16, 32, 64, 128, 256, 512 ],
 	fonts: {
 		body: 'system-ui, -apple-system, BlinkMacSystemFont, "Segoe UI", Roboto, "Helvetica Neue", sans-serif',

--- a/tokens/valet-color.json
+++ b/tokens/valet-color.json
@@ -1,1919 +1,6164 @@
 {
-  "valet-color": {
-    "Black": {
-      "value": "#13191e",
-      "type": "color"
-    },
-    "pure-black": {
-      "value": "#000000",
-      "type": "color"
-    },
-    "pure-white": {
-      "value": "#ffffff",
-      "type": "color"
-    },
-    "Gold": {
-      "0": {
-        "value": "#fcfafa",
-        "type": "color"
-      },
-      "3": {
-        "value": "#f5f2f1",
-        "type": "color"
-      },
-      "7": {
-        "value": "#eeeae5",
-        "type": "color"
-      },
-      "10": {
-        "value": "#eae3da",
-        "type": "color"
-      },
-      "15": {
-        "value": "#e3d0b8",
-        "type": "color"
-      },
-      "20": {
-        "value": "#dfc39e",
-        "type": "color"
-      },
-      "25": {
-        "value": "#dcb480",
-        "type": "color"
-      },
-      "30": {
-        "value": "#d8a45f",
-        "type": "color"
-      },
-      "35": {
-        "value": "#da9a45",
-        "type": "color"
-      },
-      "40": {
-        "value": "#d29137",
-        "type": "color"
-      },
-      "45": {
-        "value": "#c5832a",
-        "type": "color"
-      },
-      "50": {
-        "value": "#ba7920",
-        "type": "color"
-      },
-      "55": {
-        "value": "#a66915",
-        "type": "color"
-      },
-      "60": {
-        "value": "#9a6014",
-        "type": "color"
-      },
-      "65": {
-        "value": "#8c5407",
-        "type": "color"
-      },
-      "70": {
-        "value": "#7a4909",
-        "type": "color"
-      },
-      "73": {
-        "value": "#6d4108",
-        "type": "color"
-      },
-      "75": {
-        "value": "#633a0a",
-        "type": "color"
-      },
-      "78": {
-        "value": "#583409",
-        "type": "color"
-      },
-      "80": {
-        "value": "#522e03",
-        "type": "color"
-      },
-      "83": {
-        "value": "#4a2903",
-        "type": "color"
-      },
-      "85": {
-        "value": "#3f2300",
-        "type": "color"
-      },
-      "88": {
-        "value": "#331c00",
-        "type": "color"
-      },
-      "90": {
-        "value": "#2d1803",
-        "type": "color"
-      },
-      "93": {
-        "value": "#211202",
-        "type": "color"
-      },
-      "95": {
-        "value": "#1a0e04",
-        "type": "color"
-      },
-      "100": {
-        "value": "#0f0000",
-        "type": "color"
-      }
-    },
-    "Gray": {
-      "0": {
-        "value": "#fbfbfb",
-        "type": "color"
-      },
-      "3": {
-        "value": "#f4f3f2",
-        "type": "color"
-      },
-      "7": {
-        "value": "#ebe9e8",
-        "type": "color"
-      },
-      "10": {
-        "value": "#e3e0df",
-        "type": "color"
-      },
-      "15": {
-        "value": "#d7d4d3",
-        "type": "color"
-      },
-      "20": {
-        "value": "#cbc7c6",
-        "type": "color"
-      },
-      "25": {
-        "value": "#bfbcbb",
-        "type": "color"
-      },
-      "30": {
-        "value": "#b3afae",
-        "type": "color"
-      },
-      "35": {
-        "value": "#a7a4a3",
-        "type": "color"
-      },
-      "40": {
-        "value": "#9b9796",
-        "type": "color"
-      },
-      "45": {
-        "value": "#8f8c8b",
-        "type": "color"
-      },
-      "50": {
-        "value": "#827f7e",
-        "type": "color"
-      },
-      "55": {
-        "value": "#767372",
-        "type": "color"
-      },
-      "60": {
-        "value": "#6a6766",
-        "type": "color"
-      },
-      "65": {
-        "value": "#5e5b5a",
-        "type": "color"
-      },
-      "70": {
-        "value": "#514e4d",
-        "type": "color"
-      },
-      "73": {
-        "value": "#4c4948",
-        "type": "color"
-      },
-      "75": {
-        "value": "#444140",
-        "type": "color"
-      },
-      "78": {
-        "value": "#3f3c3b",
-        "type": "color"
-      },
-      "80": {
-        "value": "#383635",
-        "type": "color"
-      },
-      "83": {
-        "value": "#32302f",
-        "type": "color"
-      },
-      "85": {
-        "value": "#2c2a29",
-        "type": "color"
-      },
-      "88": {
-        "value": "#282625",
-        "type": "color"
-      },
-      "90": {
-        "value": "#201e1d",
-        "type": "color"
-      },
-      "93": {
-        "value": "#1b1918",
-        "type": "color"
-      },
-      "95": {
-        "value": "#141110",
-        "type": "color"
-      },
-      "100": {
-        "value": "#080402",
-        "type": "color"
-      }
-    },
-    "Green": {
-      "0": {
-        "value": "#f5fbf7",
-        "type": "color"
-      },
-      "3": {
-        "value": "#e9f6ee",
-        "type": "color"
-      },
-      "7": {
-        "value": "#d7efdf",
-        "type": "color"
-      },
-      "10": {
-        "value": "#c6ead0",
-        "type": "color"
-      },
-      "15": {
-        "value": "#aae1b7",
-        "type": "color"
-      },
-      "20": {
-        "value": "#89daa0",
-        "type": "color"
-      },
-      "25": {
-        "value": "#6dd18b",
-        "type": "color"
-      },
-      "30": {
-        "value": "#4dc679",
-        "type": "color"
-      },
-      "35": {
-        "value": "#40ba6f",
-        "type": "color"
-      },
-      "40": {
-        "value": "#30ac63",
-        "type": "color"
-      },
-      "45": {
-        "value": "#1da158",
-        "type": "color"
-      },
-      "50": {
-        "value": "#01944d",
-        "type": "color"
-      },
-      "55": {
-        "value": "#008840",
-        "type": "color"
-      },
-      "60": {
-        "value": "#007934",
-        "type": "color"
-      },
-      "65": {
-        "value": "#006d29",
-        "type": "color"
-      },
-      "70": {
-        "value": "#00611e",
-        "type": "color"
-      },
-      "73": {
-        "value": "#005710",
-        "type": "color"
-      },
-      "75": {
-        "value": "#00510f",
-        "type": "color"
-      },
-      "78": {
-        "value": "#004c03",
-        "type": "color"
-      },
-      "80": {
-        "value": "#004502",
-        "type": "color"
-      },
-      "83": {
-        "value": "#003d00",
-        "type": "color"
-      },
-      "85": {
-        "value": "#003700",
-        "type": "color"
-      },
-      "88": {
-        "value": "#013300",
-        "type": "color"
-      },
-      "90": {
-        "value": "#012c00",
-        "type": "color"
-      },
-      "93": {
-        "value": "#012400",
-        "type": "color"
-      },
-      "95": {
-        "value": "#011b00",
-        "type": "color"
-      },
-      "100": {
-        "value": "#010800",
-        "type": "color"
-      }
-    },
-    "Blue": {
-      "0": {
-        "value": "#fafbff",
-        "type": "color"
-      },
-      "3": {
-        "value": "#ecf4f8",
-        "type": "color"
-      },
-      "7": {
-        "value": "#ddebf3",
-        "type": "color"
-      },
-      "10": {
-        "value": "#cde6eb",
-        "type": "color"
-      },
-      "15": {
-        "value": "#b2dde6",
-        "type": "color"
-      },
-      "20": {
-        "value": "#94d4de",
-        "type": "color"
-      },
-      "25": {
-        "value": "#77cad8",
-        "type": "color"
-      },
-      "30": {
-        "value": "#54c0cd",
-        "type": "color"
-      },
-      "35": {
-        "value": "#30b5c4",
-        "type": "color"
-      },
-      "40": {
-        "value": "#19a8b8",
-        "type": "color"
-      },
-      "45": {
-        "value": "#009bad",
-        "type": "color"
-      },
-      "50": {
-        "value": "#0190a0",
-        "type": "color"
-      },
-      "55": {
-        "value": "#008292",
-        "type": "color"
-      },
-      "60": {
-        "value": "#007586",
-        "type": "color"
-      },
-      "65": {
-        "value": "#006979",
-        "type": "color"
-      },
-      "70": {
-        "value": "#005b6d",
-        "type": "color"
-      },
-      "73": {
-        "value": "#005366",
-        "type": "color"
-      },
-      "75": {
-        "value": "#004d5f",
-        "type": "color"
-      },
-      "78": {
-        "value": "#004657",
-        "type": "color"
-      },
-      "80": {
-        "value": "#004252",
-        "type": "color"
-      },
-      "83": {
-        "value": "#00394d",
-        "type": "color"
-      },
-      "85": {
-        "value": "#003344",
-        "type": "color"
-      },
-      "88": {
-        "value": "#012e41",
-        "type": "color"
-      },
-      "90": {
-        "value": "#012839",
-        "type": "color"
-      },
-      "93": {
-        "value": "#002233",
-        "type": "color"
-      },
-      "95": {
-        "value": "#001c2a",
-        "type": "color"
-      },
-      "100": {
-        "value": "#000a23",
-        "type": "color"
-      }
-    },
-    "Pink": {
-      "0": {
-        "value": "#fff8f6",
-        "type": "color"
-      },
-      "3": {
-        "value": "#fff1f0",
-        "type": "color"
-      },
-      "7": {
-        "value": "#ffdedb",
-        "type": "color"
-      },
-      "10": {
-        "value": "#ffd6d2",
-        "type": "color"
-      },
-      "15": {
-        "value": "#ffc5c1",
-        "type": "color"
-      },
-      "20": {
-        "value": "#fbb7b4",
-        "type": "color"
-      },
-      "25": {
-        "value": "#efaba8",
-        "type": "color"
-      },
-      "30": {
-        "value": "#e29e9d",
-        "type": "color"
-      },
-      "35": {
-        "value": "#d49294",
-        "type": "color"
-      },
-      "40": {
-        "value": "#ca8588",
-        "type": "color"
-      },
-      "45": {
-        "value": "#bc7a7e",
-        "type": "color"
-      },
-      "50": {
-        "value": "#b06d74",
-        "type": "color"
-      },
-      "55": {
-        "value": "#a35f6a",
-        "type": "color"
-      },
-      "60": {
-        "value": "#95535d",
-        "type": "color"
-      },
-      "65": {
-        "value": "#894755",
-        "type": "color"
-      },
-      "70": {
-        "value": "#7c394a",
-        "type": "color"
-      },
-      "73": {
-        "value": "#763247",
-        "type": "color"
-      },
-      "75": {
-        "value": "#6d293e",
-        "type": "color"
-      },
-      "78": {
-        "value": "#66243a",
-        "type": "color"
-      },
-      "80": {
-        "value": "#5f1e34",
-        "type": "color"
-      },
-      "83": {
-        "value": "#5a1633",
-        "type": "color"
-      },
-      "85": {
-        "value": "#530e2b",
-        "type": "color"
-      },
-      "88": {
-        "value": "#4a0825",
-        "type": "color"
-      },
-      "90": {
-        "value": "#45001f",
-        "type": "color"
-      },
-      "93": {
-        "value": "#3d0015",
-        "type": "color"
-      },
-      "95": {
-        "value": "#350012",
-        "type": "color"
-      },
-      "100": {
-        "value": "#2e0003",
-        "type": "color"
-      }
-    },
-    "Salmon": {
-      "0": {
-        "value": "#fef8f8",
-        "type": "color"
-      },
-      "3": {
-        "value": "#feefeb",
-        "type": "color"
-      },
-      "7": {
-        "value": "#fedfd8",
-        "type": "color"
-      },
-      "10": {
-        "value": "#fed6ce",
-        "type": "color"
-      },
-      "15": {
-        "value": "#fec3b1",
-        "type": "color"
-      },
-      "20": {
-        "value": "#ffb296",
-        "type": "color"
-      },
-      "25": {
-        "value": "#ffa378",
-        "type": "color"
-      },
-      "30": {
-        "value": "#f9945e",
-        "type": "color"
-      },
-      "35": {
-        "value": "#ed8955",
-        "type": "color"
-      },
-      "40": {
-        "value": "#e07b4d",
-        "type": "color"
-      },
-      "45": {
-        "value": "#d27146",
-        "type": "color"
-      },
-      "50": {
-        "value": "#c5653f",
-        "type": "color"
-      },
-      "55": {
-        "value": "#b55638",
-        "type": "color"
-      },
-      "60": {
-        "value": "#a74930",
-        "type": "color"
-      },
-      "65": {
-        "value": "#993c2b",
-        "type": "color"
-      },
-      "70": {
-        "value": "#892f26",
-        "type": "color"
-      },
-      "73": {
-        "value": "#842724",
-        "type": "color"
-      },
-      "75": {
-        "value": "#7c1e1e",
-        "type": "color"
-      },
-      "78": {
-        "value": "#751515",
-        "type": "color"
-      },
-      "80": {
-        "value": "#6c0f17",
-        "type": "color"
-      },
-      "83": {
-        "value": "#630814",
-        "type": "color"
-      },
-      "85": {
-        "value": "#5e0010",
-        "type": "color"
-      },
-      "88": {
-        "value": "#570007",
-        "type": "color"
-      },
-      "90": {
-        "value": "#4e0000",
-        "type": "color"
-      },
-      "93": {
-        "value": "#420002",
-        "type": "color"
-      },
-      "95": {
-        "value": "#3e0001",
-        "type": "color"
-      },
-      "100": {
-        "value": "#340002",
-        "type": "color"
-      }
-    },
-    "Orange": {
-      "0": {
-        "value": "#fff9f1",
-        "type": "color"
-      },
-      "3": {
-        "value": "#ffefe5",
-        "type": "color"
-      },
-      "7": {
-        "value": "#ffe0cc",
-        "type": "color"
-      },
-      "10": {
-        "value": "#ffd7bd",
-        "type": "color"
-      },
-      "15": {
-        "value": "#ffc39f",
-        "type": "color"
-      },
-      "20": {
-        "value": "#ffb27e",
-        "type": "color"
-      },
-      "25": {
-        "value": "#fe9f5f",
-        "type": "color"
-      },
-      "30": {
-        "value": "#ff8b40",
-        "type": "color"
-      },
-      "35": {
-        "value": "#ff7b28",
-        "type": "color"
-      },
-      "40": {
-        "value": "#f46e15",
-        "type": "color"
-      },
-      "45": {
-        "value": "#e76205",
-        "type": "color"
-      },
-      "50": {
-        "value": "#d75001",
-        "type": "color"
-      },
-      "55": {
-        "value": "#c54900",
-        "type": "color"
-      },
-      "60": {
-        "value": "#b43c00",
-        "type": "color"
-      },
-      "65": {
-        "value": "#a53100",
-        "type": "color"
-      },
-      "70": {
-        "value": "#942601",
-        "type": "color"
-      },
-      "73": {
-        "value": "#831b01",
-        "type": "color"
-      },
-      "75": {
-        "value": "#811701",
-        "type": "color"
-      },
-      "78": {
-        "value": "#740e01",
-        "type": "color"
-      },
-      "80": {
-        "value": "#6f0801",
-        "type": "color"
-      },
-      "83": {
-        "value": "#650401",
-        "type": "color"
-      },
-      "85": {
-        "value": "#5f0000",
-        "type": "color"
-      },
-      "88": {
-        "value": "#520000",
-        "type": "color"
-      },
-      "90": {
-        "value": "#4e0000",
-        "type": "color"
-      },
-      "93": {
-        "value": "#420000",
-        "type": "color"
-      },
-      "95": {
-        "value": "#3c0000",
-        "type": "color"
-      },
-      "100": {
-        "value": "#320003",
-        "type": "color"
-      }
-    },
-    "Yellow": {
-      "0": {
-        "value": "#fff9f1",
-        "type": "color"
-      },
-      "3": {
-        "value": "#fff0e0",
-        "type": "color"
-      },
-      "7": {
-        "value": "#ffe2c2",
-        "type": "color"
-      },
-      "10": {
-        "value": "#ffd8a5",
-        "type": "color"
-      },
-      "15": {
-        "value": "#ffc876",
-        "type": "color"
-      },
-      "20": {
-        "value": "#ffb84a",
-        "type": "color"
-      },
-      "25": {
-        "value": "#ffa920",
-        "type": "color"
-      },
-      "30": {
-        "value": "#f09d01",
-        "type": "color"
-      },
-      "35": {
-        "value": "#e29101",
-        "type": "color"
-      },
-      "40": {
-        "value": "#d38500",
-        "type": "color"
-      },
-      "45": {
-        "value": "#c67a00",
-        "type": "color"
-      },
-      "50": {
-        "value": "#b86e01",
-        "type": "color"
-      },
-      "55": {
-        "value": "#a96100",
-        "type": "color"
-      },
-      "60": {
-        "value": "#985600",
-        "type": "color"
-      },
-      "65": {
-        "value": "#894b00",
-        "type": "color"
-      },
-      "70": {
-        "value": "#7b3f01",
-        "type": "color"
-      },
-      "73": {
-        "value": "#743901",
-        "type": "color"
-      },
-      "75": {
-        "value": "#683301",
-        "type": "color"
-      },
-      "78": {
-        "value": "#602d00",
-        "type": "color"
-      },
-      "80": {
-        "value": "#592800",
-        "type": "color"
-      },
-      "83": {
-        "value": "#522300",
-        "type": "color"
-      },
-      "85": {
-        "value": "#491d00",
-        "type": "color"
-      },
-      "88": {
-        "value": "#421700",
-        "type": "color"
-      },
-      "90": {
-        "value": "#3b1200",
-        "type": "color"
-      },
-      "93": {
-        "value": "#330a00",
-        "type": "color"
-      },
-      "95": {
-        "value": "#2b0400",
-        "type": "color"
-      },
-      "100": {
-        "value": "#230000",
-        "type": "color"
-      }
-    },
-    "Red": {
-      "0": {
-        "value": "#fff6f9",
-        "type": "color"
-      },
-      "3": {
-        "value": "#ffeceb",
-        "type": "color"
-      },
-      "7": {
-        "value": "#ffdedb",
-        "type": "color"
-      },
-      "10": {
-        "value": "#ffd5ce",
-        "type": "color"
-      },
-      "15": {
-        "value": "#ffc3b9",
-        "type": "color"
-      },
-      "20": {
-        "value": "#ffb0a1",
-        "type": "color"
-      },
-      "25": {
-        "value": "#fe9d8c",
-        "type": "color"
-      },
-      "30": {
-        "value": "#ff8872",
-        "type": "color"
-      },
-      "35": {
-        "value": "#ff745f",
-        "type": "color"
-      },
-      "40": {
-        "value": "#ff5f4d",
-        "type": "color"
-      },
-      "45": {
-        "value": "#f84d3c",
-        "type": "color"
-      },
-      "50": {
-        "value": "#e74135",
-        "type": "color"
-      },
-      "55": {
-        "value": "#d3372b",
-        "type": "color"
-      },
-      "60": {
-        "value": "#bf2a23",
-        "type": "color"
-      },
-      "65": {
-        "value": "#ad221f",
-        "type": "color"
-      },
-      "70": {
-        "value": "#9a1a19",
-        "type": "color"
-      },
-      "73": {
-        "value": "#8d1119",
-        "type": "color"
-      },
-      "75": {
-        "value": "#840b10",
-        "type": "color"
-      },
-      "78": {
-        "value": "#770d12",
-        "type": "color"
-      },
-      "80": {
-        "value": "#710208",
-        "type": "color"
-      },
-      "83": {
-        "value": "#6a0101",
-        "type": "color"
-      },
-      "85": {
-        "value": "#5e0000",
-        "type": "color"
-      },
-      "88": {
-        "value": "#570000",
-        "type": "color"
-      },
-      "90": {
-        "value": "#4a0001",
-        "type": "color"
-      },
-      "93": {
-        "value": "#420001",
-        "type": "color"
-      },
-      "95": {
-        "value": "#380001",
-        "type": "color"
-      },
-      "100": {
-        "value": "#2e0002",
-        "type": "color"
-      }
-    },
-    "Gradient": {
-      "neutral-light-1": {
-        "value": "linear-gradient(180deg, #fcfafa 0%, #f5f2f1 100%)",
-        "type": "color"
-      },
-      "neutral-light-2": {
-        "value": "linear-gradient(180deg, #f5f2f1 0%, #fcfafa 100%)",
-        "type": "color"
-      }
-    }
-  },
-  "productive": {
-    "background": {
-      "primary": {
-        "value": "{Gray.0}",
-        "type": "color",
-        "description": "Use as main application background"
-      },
-      "inverse": {
-        "value": "{Black}",
-        "type": "color",
-        "description": "Use as component background in high-contrast situations. "
-      },
-      "brand": {
-        "value": "{Gold.30}",
-        "type": "color"
-      }
-    },
-    "layer": {
-      "1": {
-        "value": "{Gray.3}",
-        "type": "color"
-      },
-      "2": {
-        "value": "{pure-white}",
-        "type": "color"
-      },
-      "3": {
-        "value": "{Gray.3}",
-        "type": "color"
-      },
-      "4": {
-        "value": "{pure-white}",
-        "type": "color"
-      },
-      "accent": {
-        "value": "{Gold.30}",
-        "type": "color"
-      }
-    },
-    "field": {
-      "1": {
-        "value": "{pure-white}",
-        "type": "color"
-      },
-      "2": {
-        "value": "{Gray.0}",
-        "type": "color"
-      },
-      "3": {
-        "value": "{Gray.3}",
-        "type": "color"
-      },
-      "4": {
-        "value": "{Gray.7}",
-        "type": "color"
-      }
-    },
-    "border": {
-      "1": {
-        "value": "{Gray.25}",
-        "type": "color"
-      },
-      "2": {
-        "value": "{Gray.10}",
-        "type": "color"
-      },
-      "3": {
-        "value": "{Gray.30}",
-        "type": "color"
-      },
-      "4": {
-        "value": "{Gray.25}",
-        "type": "color"
-      },
-      "accent": {
-        "value": "{Gold.50}",
-        "type": "color"
-      }
-    },
-    "text": {
-      "primary": {
-        "value": "{Black}",
-        "type": "color",
-        "description": "Use for headings"
-      },
-      "secondary": {
-        "value": "{Gray.70}",
-        "type": "color",
-        "description": "Use for body text "
-      },
-      "helper": {
-        "value": "{Gray.60}",
-        "type": "color",
-        "description": "Use for helper text"
-      },
-      "placeholder": {
-        "value": "{Gray.45}",
-        "type": "color",
-        "description": "Use for placeholder text in fields"
-      },
-      "disabled": {
-        "value": "{Gray.55}",
-        "type": "color"
-      },
-      "inverse": {
-        "value": "{Gray.0}",
-        "type": "color"
-      },
-      "interactive": {
-        "value": "{Gold.60}",
-        "type": "color"
-      }
-    },
-    "link": {
-      "default": {
-        "value": "{Gold.60}",
-        "type": "color",
-        "description": "Use for text links"
-      },
-      "hover": {
-        "value": "{Gold.70}",
-        "type": "color"
-      },
-      "active": {
-        "value": "{Gold.80}",
-        "type": "color"
-      },
-      "visited": {
-        "value": "{Gold.70}",
-        "type": "color"
-      }
-    },
-    "icon": {
-      "primary": {
-        "value": "{Gray.85}",
-        "type": "color"
-      },
-      "secondary": {
-        "value": "{Gray.50}",
-        "type": "color"
-      },
-      "helper": {
-        "value": "{Gray.40}",
-        "type": "color"
-      },
-      "inverse": {
-        "value": "{Gray.3}",
-        "type": "color"
-      },
-      "disabled": {
-        "value": "{Gray.45}",
-        "type": "color"
-      }
-    },
-    "button": {
-      "primary": {
-        "default": {
-          "value": "{Black}",
-          "type": "color"
-        },
-        "hover": {
-          "value": "{Gray.55}",
-          "type": "color"
-        }
-      },
-      "secondary": {
-        "default": {
-          "value": "{Gray.3}",
-          "type": "color"
-        },
-        "hover": {
-          "value": "{Gray.7}",
-          "type": "color"
-        }
-      },
-      "tertiary": {
-        "default": {
-          "value": "rgba(0,0,0,0)",
-          "type": "color"
-        },
-        "hover": {
-          "value": "{Gray.7}",
-          "type": "color"
-        }
-      }
-    },
-    "support": {
-      "background": {
-        "error": {
-          "value": "{Red.7}",
-          "type": "color"
-        },
-        "warning": {
-          "value": "{Yellow.7}",
-          "type": "color"
-        },
-        "info": {
-          "value": "{Blue.7}",
-          "type": "color"
-        },
-        "success": {
-          "value": "{Green.7}",
-          "type": "color"
-        }
-      },
-      "text": {
-        "error": {
-          "value": "{Red.85}",
-          "type": "color"
-        },
-        "warning": {
-          "value": "{Yellow.85}",
-          "type": "color"
-        },
-        "info": {
-          "value": "{Blue.85}",
-          "type": "color"
-        },
-        "success": {
-          "value": "{Green.85}",
-          "type": "color"
-        }
-      },
-      "icon": {
-        "error": {
-          "value": "{Red.50}",
-          "type": "color"
-        },
-        "warning": {
-          "value": "{Yellow.50}",
-          "type": "color"
-        },
-        "info": {
-          "value": "{Blue.50}",
-          "type": "color"
-        },
-        "success": {
-          "value": "{Green.50}",
-          "type": "color"
-        }
-      },
-      "accent": {
-        "error": {
-          "value": "{Red.35}",
-          "type": "color"
-        },
-        "warning": {
-          "value": "{Yellow.30}",
-          "type": "color"
-        },
-        "info": {
-          "value": "{Blue.35}",
-          "type": "color"
-        },
-        "success": {
-          "value": "{Green.35}",
-          "type": "color"
-        }
-      },
-      "link": {
-        "error": {
-          "default": {
-            "value": "{Red.60}",
-            "type": "color",
-            "description": "Use for text links"
-          },
-          "hover": {
-            "value": "{Red.70}",
-            "type": "color"
-          },
-          "active": {
-            "value": "{Red.80}",
-            "type": "color"
-          },
-          "visited": {
-            "value": "{Red.80}",
-            "type": "color"
-          }
-        },
-        "warning": {
-          "default": {
-            "value": "{Yellow.60}",
-            "type": "color",
-            "description": "Use for text links"
-          },
-          "hover": {
-            "value": "{Yellow.70}",
-            "type": "color"
-          },
-          "active": {
-            "value": "{Yellow.80}",
-            "type": "color"
-          },
-          "visited": {
-            "value": "{Yellow.70}",
-            "type": "color"
-          }
-        },
-        "info": {
-          "default": {
-            "value": "{Blue.60}",
-            "type": "color",
-            "description": "Use for text links"
-          },
-          "hover": {
-            "value": "{Blue.70}",
-            "type": "color"
-          },
-          "active": {
-            "value": "{Blue.80}",
-            "type": "color"
-          },
-          "visited": {
-            "value": "{Blue.70}",
-            "type": "color"
-          }
-        },
-        "success": {
-          "default": {
-            "value": "{Green.60}",
-            "type": "color",
-            "description": "Use for text links"
-          },
-          "hover": {
-            "value": "{Green.70}",
-            "type": "color"
-          },
-          "active": {
-            "value": "{Green.80}",
-            "type": "color"
-          },
-          "visited": {
-            "value": "{Green.70}",
-            "type": "color"
-          }
-        }
-      }
-    },
-    "focus": {
-      "default": {
-        "value": "#0000EE",
-        "type": "color"
-      },
-      "inset": {
-        "value": "#ffffff",
-        "type": "color"
-      }
-    },
-    "overlay": {
-      "value": "{Gray.55}",
-      "type": "color"
-    },
-    "interactive": {
-      "value": "{Gold.55}",
-      "type": "color"
-    },
-    "tag": {
-      "gray": {
-        "background": {
-          "value": "{Gray.7}",
-          "type": "color"
-        },
-        "text": {
-          "value": "{Gray.85}",
-          "type": "color"
-        },
-        "icon": {
-          "value": "{Gray.65}",
-          "type": "color"
-        },
-        "hover": {
-          "value": "{Gray.15}",
-          "type": "color"
-        },
-        "active": {
-          "value": "{Gray.20}",
-          "type": "color"
-        }
-      },
-      "blue": {
-        "background": {
-          "value": "{Blue.7}",
-          "type": "color"
-        },
-        "text": {
-          "value": "{Blue.85}",
-          "type": "color"
-        },
-        "icon": {
-          "value": "{Blue.65}",
-          "type": "color"
-        },
-        "hover": {
-          "value": "{Blue.15}",
-          "type": "color"
-        },
-        "active": {
-          "value": "{Blue.20}",
-          "type": "color"
-        }
-      },
-      "green": {
-        "background": {
-          "value": "{Green.7}",
-          "type": "color"
-        },
-        "text": {
-          "value": "{Green.85}",
-          "type": "color"
-        },
-        "icon": {
-          "value": "{Green.65}",
-          "type": "color"
-        },
-        "hover": {
-          "value": "{Green.15}",
-          "type": "color"
-        },
-        "active": {
-          "value": "{Green.20}",
-          "type": "color"
-        }
-      },
-      "red": {
-        "background": {
-          "value": "{Red.7}",
-          "type": "color"
-        },
-        "text": {
-          "value": "{Red.85}",
-          "type": "color"
-        },
-        "icon": {
-          "value": "{Red.65}",
-          "type": "color"
-        },
-        "hover": {
-          "value": "{Red.15}",
-          "type": "color"
-        },
-        "active": {
-          "value": "{Red.20}",
-          "type": "color"
-        }
-      },
-      "gold": {
-        "background": {
-          "value": "{Gold.7}",
-          "type": "color"
-        },
-        "text": {
-          "value": "{Gold.85}",
-          "type": "color"
-        },
-        "icon": {
-          "value": "{Gold.65}",
-          "type": "color"
-        },
-        "hover": {
-          "value": "{Gold.15}",
-          "type": "color"
-        },
-        "active": {
-          "value": "{Gold.20}",
-          "type": "color"
-        }
-      },
-      "yellow": {
-        "background": {
-          "value": "{Yellow.7}",
-          "type": "color"
-        },
-        "text": {
-          "value": "{Yellow.85}",
-          "type": "color"
-        },
-        "icon": {
-          "value": "{Yellow.65}",
-          "type": "color"
-        },
-        "hover": {
-          "value": "{Yellow.15}",
-          "type": "color"
-        },
-        "active": {
-          "value": "{Yellow.20}",
-          "type": "color"
-        }
-      },
-      "orange": {
-        "background": {
-          "value": "{Orange.7}",
-          "type": "color"
-        },
-        "text": {
-          "value": "{Orange.85}",
-          "type": "color"
-        },
-        "icon": {
-          "value": "{Orange.65}",
-          "type": "color"
-        },
-        "hover": {
-          "value": "{Orange.15}",
-          "type": "color"
-        },
-        "active": {
-          "value": "{Orange.20}",
-          "type": "color"
-        }
-      },
-      "salmon": {
-        "background": {
-          "value": "{Salmon.7}",
-          "type": "color"
-        },
-        "text": {
-          "value": "{Salmon.85}",
-          "type": "color"
-        },
-        "icon": {
-          "value": "{Salmon.65}",
-          "type": "color"
-        },
-        "hover": {
-          "value": "{Salmon.15}",
-          "type": "color"
-        },
-        "active": {
-          "value": "{Salmon.20}",
-          "type": "color"
-        }
-      },
-      "pink": {
-        "background": {
-          "value": "{Pink.7}",
-          "type": "color"
-        },
-        "text": {
-          "value": "{Pink.85}",
-          "type": "color"
-        },
-        "icon": {
-          "value": "{Pink.65}",
-          "type": "color"
-        },
-        "hover": {
-          "value": "{Pink.15}",
-          "type": "color"
-        },
-        "active": {
-          "value": "{Pink.20}",
-          "type": "color"
-        }
-      }
-    }
-  },
-  "expressive": {
-    "background": {
-      "primary": {
-        "value": "{Gray.0}",
-        "type": "color",
-        "description": "Use as main application background"
-      },
-      "inverse": {
-        "value": "{Black}",
-        "type": "color",
-        "description": "Use as component background in high-contrast situations. "
-      },
-      "brand": {
-        "value": "{Gold.30}",
-        "type": "color"
-      }
-    },
-    "layer": {
-      "1": {
-        "value": "{Gray.3}",
-        "type": "color"
-      },
-      "2": {
-        "value": "{pure-white}",
-        "type": "color"
-      },
-      "3": {
-        "value": "{Gray.3}",
-        "type": "color"
-      },
-      "4": {
-        "value": "{pure-white}",
-        "type": "color"
-      },
-      "accent": {
-        "value": "{Gold.30}",
-        "type": "color"
-      }
-    },
-    "field": {
-      "1": {
-        "value": "{pure-white}",
-        "type": "color"
-      },
-      "2": {
-        "value": "{Gray.0}",
-        "type": "color"
-      },
-      "3": {
-        "value": "{Gray.3}",
-        "type": "color"
-      },
-      "4": {
-        "value": "{Gray.7}",
-        "type": "color"
-      }
-    },
-    "border": {
-      "1": {
-        "value": "{Gray.25}",
-        "type": "color"
-      },
-      "2": {
-        "value": "{Gray.10}",
-        "type": "color"
-      },
-      "3": {
-        "value": "{Gray.30}",
-        "type": "color"
-      },
-      "4": {
-        "value": "{Gray.25}",
-        "type": "color"
-      },
-      "accent": {
-        "value": "{Gold.50}",
-        "type": "color"
-      }
-    },
-    "text": {
-      "primary": {
-        "value": "{Black}",
-        "type": "color",
-        "description": "Use for headings"
-      },
-      "secondary": {
-        "value": "{Gray.70}",
-        "type": "color",
-        "description": "Use for body text "
-      },
-      "helper": {
-        "value": "{Gray.60}",
-        "type": "color",
-        "description": "Use for helper text"
-      },
-      "placeholder": {
-        "value": "{Gray.45}",
-        "type": "color",
-        "description": "Use for placeholder text in fields"
-      },
-      "inverse": {
-        "value": "{Gray.0}",
-        "type": "color"
-      }
-    },
-    "link": {
-      "default": {
-        "value": "{Gold.60}",
-        "type": "color",
-        "description": "Use for text links"
-      },
-      "hover": {
-        "value": "{Gold.70}",
-        "type": "color"
-      },
-      "active": {
-        "value": "{Gold.80}",
-        "type": "color"
-      },
-      "visited": {
-        "value": "{Gold.70}",
-        "type": "color"
-      }
-    },
-    "icon": {
-      "primary": {
-        "value": "{Gray.85}",
-        "type": "color"
-      },
-      "secondary": {
-        "value": "{Gray.50}",
-        "type": "color"
-      },
-      "helper": {
-        "value": "{Gray.40}",
-        "type": "color"
-      },
-      "inverse": {
-        "value": "{Gray.3}",
-        "type": "color"
-      }
-    },
-    "button": {
-      "primary": {
-        "default": {
-          "value": "{Black}",
-          "type": "color"
-        },
-        "hover": {
-          "value": "{Gray.55}",
-          "type": "color"
-        }
-      },
-      "secondary": {
-        "default": {
-          "value": "{Gray.3}",
-          "type": "color"
-        },
-        "hover": {
-          "value": "{Gray.7}",
-          "type": "color"
-        }
-      },
-      "tertiary": {
-        "default": {
-          "value": "rgba(0,0,0,0)",
-          "type": "color"
-        },
-        "hover": {
-          "value": "{Gray.7}",
-          "type": "color"
-        }
-      }
-    },
-    "support": {
-      "background": {
-        "error": {
-          "value": "{Red.7}",
-          "type": "color"
-        },
-        "warning": {
-          "value": "{Yellow.7}",
-          "type": "color"
-        },
-        "info": {
-          "value": "{Blue.7}",
-          "type": "color"
-        },
-        "success": {
-          "value": "{Green.7}",
-          "type": "color"
-        }
-      },
-      "text": {
-        "error": {
-          "value": "{Red.85}",
-          "type": "color"
-        },
-        "warning": {
-          "value": "{Yellow.85}",
-          "type": "color"
-        },
-        "info": {
-          "value": "{Blue.85}",
-          "type": "color"
-        },
-        "success": {
-          "value": "{Green.85}",
-          "type": "color"
-        }
-      },
-      "icon": {
-        "error": {
-          "value": "{Red.50}",
-          "type": "color"
-        },
-        "warning": {
-          "value": "{Yellow.50}",
-          "type": "color"
-        },
-        "info": {
-          "value": "{Blue.50}",
-          "type": "color"
-        },
-        "success": {
-          "value": "{Green.50}",
-          "type": "color"
-        }
-      },
-      "accent": {
-        "error": {
-          "value": "{Red.35}",
-          "type": "color"
-        },
-        "warning": {
-          "value": "{Yellow.30}",
-          "type": "color"
-        },
-        "info": {
-          "value": "{Blue.35}",
-          "type": "color"
-        },
-        "success": {
-          "value": "{Green.35}",
-          "type": "color"
-        }
-      },
-      "link": {
-        "error": {
-          "default": {
-            "value": "{Red.60}",
-            "type": "color",
-            "description": "Use for text links"
-          },
-          "hover": {
-            "value": "{Red.70}",
-            "type": "color"
-          },
-          "active": {
-            "value": "{Red.80}",
-            "type": "color"
-          },
-          "visited": {
-            "value": "{Red.80}",
-            "type": "color"
-          }
-        },
-        "warning": {
-          "default": {
-            "value": "{Yellow.60}",
-            "type": "color",
-            "description": "Use for text links"
-          },
-          "hover": {
-            "value": "{Yellow.70}",
-            "type": "color"
-          },
-          "active": {
-            "value": "{Yellow.80}",
-            "type": "color"
-          },
-          "visited": {
-            "value": "{Yellow.70}",
-            "type": "color"
-          }
-        },
-        "info": {
-          "default": {
-            "value": "{Blue.60}",
-            "type": "color",
-            "description": "Use for text links"
-          },
-          "hover": {
-            "value": "{Blue.70}",
-            "type": "color"
-          },
-          "active": {
-            "value": "{Blue.80}",
-            "type": "color"
-          },
-          "visited": {
-            "value": "{Blue.70}",
-            "type": "color"
-          }
-        },
-        "success": {
-          "default": {
-            "value": "{Green.60}",
-            "type": "color",
-            "description": "Use for text links"
-          },
-          "hover": {
-            "value": "{Green.70}",
-            "type": "color"
-          },
-          "active": {
-            "value": "{Green.80}",
-            "type": "color"
-          },
-          "visited": {
-            "value": "{Green.70}",
-            "type": "color"
-          }
-        }
-      }
-    },
-    "focus": {
-      "default": {
-        "value": "#0000EE",
-        "type": "color"
-      },
-      "inset": {
-        "value": "#ffffff",
-        "type": "color"
-      }
-    },
-    "overlay": {
-      "value": "{Gray.55}",
-      "type": "color"
-    },
-    "interactive": {
-      "value": "{Gold.55}",
-      "type": "color"
-    }
-  },
-  "$themes": []
+	"valet-core": {
+		"rem": {
+			"value": "16",
+			"type": "other",
+			"description": "Use as the base rem value for calculations in Figma Tokens. In production all size values should be in rems, which is modifiable by the user. Since Figma Tokens doesn't support different units, we use this variable to do rem calculations. For our purposes, we're setting the rem value to 16px."
+		},
+		"fontSizes": {
+			"description": {
+				"value": "In production, all fontSize units are in rems.",
+				"type": "fontSizes"
+			},
+			"static": {
+				"1": {
+					"value": ".75 * {rem}",
+					"type": "fontSizes"
+				},
+				"2": {
+					"value": ".875 * {rem}",
+					"type": "fontSizes"
+				},
+				"3": {
+					"value": "1 * {rem}",
+					"type": "fontSizes"
+				},
+				"4": {
+					"value": "1.125 * {rem}",
+					"type": "fontSizes"
+				},
+				"5": {
+					"value": "1.25 * {rem}",
+					"type": "fontSizes"
+				},
+				"description": {
+					"value": "these are non-responsive font sizes used for body copy, helper text and other elements that don't need to respond to viewport width.",
+					"type": "fontSizes"
+				}
+			},
+			"figma": {
+				"1": {
+					"s": {
+						"value": "12.34",
+						"type": "other"
+					},
+					"m": {
+						"value": "11.07",
+						"type": "other"
+					},
+					"l": {
+						"value": "9.8",
+						"type": "other"
+					},
+					"xl": {
+						"value": "9.05",
+						"type": "other"
+					},
+					"max": {
+						"value": "11.07",
+						"type": "other"
+					}
+				},
+				"2": {
+					"s": {
+						"value": "13.17",
+						"type": "other"
+					},
+					"m": {
+						"value": "12.19",
+						"type": "other"
+					},
+					"l": {
+						"value": "11.17",
+						"type": "other"
+					},
+					"xl": {
+						"value": "10.55",
+						"type": "other"
+					},
+					"max": {
+						"value": "9.84",
+						"type": "other"
+					}
+				},
+				"3": {
+					"s": {
+						"value": "14.05",
+						"type": "other"
+					},
+					"m": {
+						"value": "13.42",
+						"type": "other"
+					},
+					"l": {
+						"value": "12.74",
+						"type": "other"
+					},
+					"xl": {
+						"value": "12.31",
+						"type": "other"
+					},
+					"max": {
+						"value": "11.81",
+						"type": "other"
+					}
+				},
+				"4": {
+					"s": {
+						"value": "15",
+						"type": "other"
+					},
+					"m": {
+						"value": "14.77",
+						"type": "other"
+					},
+					"l": {
+						"value": "14.52",
+						"type": "other"
+					},
+					"xl": {
+						"value": "14.36",
+						"type": "other"
+					},
+					"max": {
+						"value": "14.17",
+						"type": "other"
+					}
+				},
+				"5": {
+					"s": {
+						"value": "16",
+						"type": "other"
+					},
+					"m": {
+						"value": "16.25",
+						"type": "other"
+					},
+					"l": {
+						"value": "16.55",
+						"type": "other"
+					},
+					"xl": {
+						"value": "16.75",
+						"type": "other"
+					},
+					"max": {
+						"value": "17",
+						"type": "other"
+					}
+				},
+				"6": {
+					"s": {
+						"value": "17.07",
+						"type": "other"
+					},
+					"m": {
+						"value": "17.89",
+						"type": "other"
+					},
+					"l": {
+						"value": "18.86",
+						"type": "other"
+					},
+					"xl": {
+						"value": "19.53",
+						"type": "other"
+					},
+					"max": {
+						"value": "20.4",
+						"type": "other"
+					}
+				},
+				"7": {
+					"s": {
+						"value": "18.22",
+						"type": "other"
+					},
+					"m": {
+						"value": "19.69",
+						"type": "other"
+					},
+					"l": {
+						"value": "21.5",
+						"type": "other"
+					},
+					"xl": {
+						"value": "22.78",
+						"type": "other"
+					},
+					"max": {
+						"value": "24.48",
+						"type": "other"
+					}
+				},
+				"8": {
+					"s": {
+						"value": "19.44",
+						"type": "other"
+					},
+					"m": {
+						"value": "21.67",
+						"type": "other"
+					},
+					"l": {
+						"value": "24.51",
+						"type": "other"
+					},
+					"xl": {
+						"value": "26.57",
+						"type": "other"
+					},
+					"max": {
+						"value": "29.38",
+						"type": "other"
+					}
+				},
+				"9": {
+					"s": {
+						"value": "20.74",
+						"type": "other"
+					},
+					"m": {
+						"value": "23.85",
+						"type": "other"
+					},
+					"l": {
+						"value": "27.94",
+						"type": "other"
+					},
+					"xl": {
+						"value": "30.99",
+						"type": "other"
+					},
+					"max": {
+						"value": "35.25",
+						"type": "other"
+					}
+				},
+				"10": {
+					"s": {
+						"value": "22.13",
+						"type": "other"
+					},
+					"m": {
+						"value": "26.25",
+						"type": "other"
+					},
+					"l": {
+						"value": "31.85",
+						"type": "other"
+					},
+					"xl": {
+						"value": "36.15",
+						"type": "other"
+					},
+					"max": {
+						"value": "42.3",
+						"type": "other"
+					}
+				},
+				"11": {
+					"s": {
+						"value": "23.61",
+						"type": "other"
+					},
+					"m": {
+						"value": "28.9",
+						"type": "other"
+					},
+					"l": {
+						"value": "36.31",
+						"type": "other"
+					},
+					"xl": {
+						"value": "42.16",
+						"type": "other"
+					},
+					"max": {
+						"value": "50.76",
+						"type": "other"
+					}
+				},
+				"12": {
+					"s": {
+						"value": "25.19",
+						"type": "other"
+					},
+					"m": {
+						"value": "31.8",
+						"type": "other"
+					},
+					"l": {
+						"value": "41.39",
+						"type": "other"
+					},
+					"xl": {
+						"value": "49.17",
+						"type": "other"
+					},
+					"max": {
+						"value": "60.91",
+						"type": "other"
+					}
+				},
+				"13": {
+					"s": {
+						"value": "26.88",
+						"type": "other"
+					},
+					"m": {
+						"value": "35",
+						"type": "other"
+					},
+					"l": {
+						"value": "47.18",
+						"type": "other"
+					},
+					"xl": {
+						"value": "57.35",
+						"type": "other"
+					},
+					"max": {
+						"value": "73.1",
+						"type": "other"
+					}
+				},
+				"14": {
+					"s": {
+						"value": "28.68",
+						"type": "other"
+					},
+					"m": {
+						"value": "38.53",
+						"type": "other"
+					},
+					"l": {
+						"value": "53.78",
+						"type": "other"
+					},
+					"xl": {
+						"value": "66.9",
+						"type": "other"
+					},
+					"max": {
+						"value": "87.72",
+						"type": "other"
+					}
+				},
+				"15": {
+					"s": {
+						"value": "30.6",
+						"type": "other"
+					},
+					"m": {
+						"value": "42.41",
+						"type": "other"
+					},
+					"l": {
+						"value": "61.3",
+						"type": "other"
+					},
+					"xl": {
+						"value": "78.02",
+						"type": "other"
+					},
+					"max": {
+						"value": "105.26",
+						"type": "other"
+					}
+				},
+				"description": {
+					"value": "All of these fontSizes.figma tokens are used exclusively for convenience in Figma. We use them to generate the suite of styles we use in Figma and correspond to the screen size values in breakpoints. They are a representation of the dynamic sizes generated by the clamp functions in the fontSizes.dynamic object",
+					"type": "fontSizes"
+				}
+			},
+			"dynamic": {
+				"1": {
+					"value": "clamp(0.51rem, calc(0.83rem + -0.31vw), 0.77rem)",
+					"type": "fontSizes"
+				},
+				"2": {
+					"value": "clamp(0.62rem, calc(0.87rem + -0.25vw), 0.82rem)",
+					"type": "fontSizes"
+				},
+				"3": {
+					"value": "clamp(0.74rem, calc(0.91rem + -0.17vw), 0.88rem)",
+					"type": "fontSizes"
+				},
+				"4": {
+					"value": "clamp(0.89rem, calc(0.95rem + -0.06vw), 0.94rem)",
+					"type": "fontSizes"
+				},
+				"5": {
+					"value": "clamp(1.00rem, calc(0.98rem + 0.08vw), 1.06rem)",
+					"type": "fontSizes"
+				},
+				"6": {
+					"value": "clamp(1.07rem, calc(1.02rem + 0.25vw), 1.28rem)",
+					"type": "fontSizes"
+				},
+				"7": {
+					"value": "clamp(1.14rem, calc(1.04rem + 0.47vw), 1.53rem)",
+					"type": "fontSizes"
+				},
+				"8": {
+					"value": "clamp(1.22rem, calc(1.07rem + 0.75vw), 1.84rem)",
+					"type": "fontSizes"
+				},
+				"9": {
+					"value": "clamp(1.30rem, calc(1.08rem + 1.09vw), 2.20rem)",
+					"type": "fontSizes"
+				},
+				"10": {
+					"value": "clamp(1.38rem, calc(1.08rem + 1.52vw), 2.64rem)",
+					"type": "fontSizes"
+				},
+				"11": {
+					"value": "clamp(1.48rem, calc(1.07rem + 2.04vw), 3.17rem)",
+					"type": "fontSizes"
+				},
+				"12": {
+					"value": "clamp(1.57rem, calc(1.04rem + 2.69vw), 3.81rem)",
+					"type": "fontSizes"
+				},
+				"13": {
+					"value": "clamp(1.68rem, calc(0.98rem + 3.48vw), 4.57rem)",
+					"type": "fontSizes"
+				},
+				"14": {
+					"value": "clamp(1.79rem, calc(0.90rem + 4.45vw), 5.48rem)",
+					"type": "fontSizes"
+				},
+				"15": {
+					"value": "clamp(1.91rem, calc(0.79rem + 5.62vw), 6.58rem)",
+					"type": "fontSizes"
+				},
+				"description": {
+					"value": "These are the formulas that generate the responsive type sizes in production. Calculations like this aren't supported in Figma so we use the manually calculated fontSizes.figma tokens to generate a suite of styles that approximate the font size at our standard breakpoints.",
+					"type": "fontSizes"
+				}
+			}
+		},
+		"borderRadius": {
+			"1": {
+				"value": "{rem} * .25",
+				"type": "borderRadius"
+			},
+			"2": {
+				"value": "{rem} * .5",
+				"type": "borderRadius"
+			},
+			"3": {
+				"value": "{rem} * 1",
+				"type": "borderRadius"
+			},
+			"4": {
+				"value": "{rem} * 1.75",
+				"type": "borderRadius"
+			},
+			"5": {
+				"value": "{rem} * 2",
+				"type": "borderRadius"
+			},
+			"6": {
+				"value": "{rem} * 2.5",
+				"type": "borderRadius"
+			},
+			"7": {
+				"value": "{rem} * 3.5",
+				"type": "borderRadius"
+			},
+			"description": {
+				"value": "In production, all units are in rems.",
+				"type": "borderRadius"
+			}
+		},
+		"space": {
+			"description": {
+				"value": "In production, all spacing units are in rems",
+				"type": "spacing"
+			},
+			"static": {
+				"1": {
+					"value": ".25 * {rem}",
+					"type": "spacing"
+				},
+				"2": {
+					"value": ".5 * {rem}",
+					"type": "spacing"
+				},
+				"3": {
+					"value": ".75 * {rem}",
+					"type": "spacing"
+				},
+				"4": {
+					"value": "{rem}",
+					"type": "spacing"
+				},
+				"5": {
+					"value": "1.5 * {rem}",
+					"type": "spacing"
+				},
+				"6": {
+					"value": "2 * {rem}",
+					"type": "spacing"
+				},
+				"7": {
+					"value": "3.38 * {rem}",
+					"type": "spacing"
+				},
+				"8": {
+					"value": "5 * {rem}",
+					"type": "spacing"
+				},
+				"9": {
+					"value": "7.63 * {rem}",
+					"type": "spacing"
+				},
+				"10": {
+					"value": "11.38 * {rem}",
+					"type": "spacing"
+				},
+				"11": {
+					"value": "17 * {rem}",
+					"type": "spacing"
+				}
+			}
+		},
+		"shadow": {
+			"description": {
+				"value": "These are our 3 drop shadow styles. All number values here are in px.",
+				"type": "other"
+			},
+			"high": {
+				"value": [
+					{
+						"color": "#00000005",
+						"type": "dropShadow",
+						"x": "0",
+						"y": "2.767256498336792",
+						"blur": "2.2138051986694336",
+						"spread": "0"
+					},
+					{
+						"color": "#00000008",
+						"type": "dropShadow",
+						"x": "0",
+						"y": "6.650102138519287",
+						"blur": "5.32008171081543",
+						"spread": "0"
+					},
+					{
+						"color": "#0000000a",
+						"type": "dropShadow",
+						"x": "0",
+						"y": "12.521552085876465",
+						"blur": "10.017241477966309",
+						"spread": "0"
+					},
+					{
+						"color": "#0000000a",
+						"type": "dropShadow",
+						"x": "0",
+						"y": "22.3363094329834",
+						"blur": "17.869047164916992",
+						"spread": "0"
+					},
+					{
+						"color": "#0000000d",
+						"type": "dropShadow",
+						"x": "0",
+						"y": "41.777610778808594",
+						"blur": "33.422088623046875",
+						"spread": "0"
+					},
+					{
+						"color": "#00000012",
+						"type": "dropShadow",
+						"x": "0",
+						"y": "100",
+						"blur": "80",
+						"spread": "0"
+					}
+				],
+				"type": "boxShadow"
+			},
+			"medium": {
+				"value": [
+					{
+						"color": "#00000008",
+						"type": "dropShadow",
+						"x": "0",
+						"y": "1",
+						"blur": "2",
+						"spread": "0"
+					},
+					{
+						"color": "#00000012",
+						"type": "dropShadow",
+						"x": "0",
+						"y": "15",
+						"blur": "30",
+						"spread": "0"
+					}
+				],
+				"type": "boxShadow"
+			},
+			"low": {
+				"value": [
+					{
+						"color": "#00000026",
+						"type": "dropShadow",
+						"x": "0",
+						"y": "1",
+						"blur": "1",
+						"spread": "0"
+					},
+					{
+						"color": "#0000000d",
+						"type": "dropShadow",
+						"x": "0",
+						"y": "1",
+						"blur": "5",
+						"spread": "0"
+					}
+				],
+				"type": "boxShadow"
+			}
+		},
+		"fontFamilies": {
+			"sans": {
+				"value": "{default-fonts}",
+				"type": "fontFamilies",
+				"description": "Use as primary sans serif across applications"
+			},
+			"serif": {
+				"value": "{default-fonts}",
+				"type": "fontFamilies",
+				"description": "Use as primary text serif in long-form reading applications"
+			},
+			"display": {
+				"value": "{default-fonts}",
+				"type": "fontFamilies",
+				"description": "Use as primary brand display font"
+			},
+			"accent": {
+				"value": "{default-fonts}",
+				"type": "fontFamilies",
+				"description": "Use as accent font"
+			}
+		},
+		"lineHeights": {
+			"1": {
+				"value": "110%",
+				"type": "lineHeights",
+				"description": "Use only for display."
+			},
+			"2": {
+				"value": "120%",
+				"type": "lineHeights",
+				"description": "Use for larger headings."
+			},
+			"3": {
+				"value": "130%",
+				"type": "lineHeights",
+				"description": "Use for small and medium sized headings."
+			},
+			"4": {
+				"value": "140%",
+				"type": "lineHeights",
+				"description": "Use for body-sized text"
+			},
+			"5": {
+				"value": "150%",
+				"type": "lineHeights",
+				"description": "Use for body-sized text in long-form reading applications."
+			},
+			"description": {
+				"value": "In production units remain %",
+				"type": "lineHeights"
+			}
+		},
+		"fontWeights": {
+			"regular": {
+				"value": "Regular",
+				"type": "fontWeights"
+			},
+			"medium": {
+				"value": "Medium",
+				"type": "fontWeights"
+			},
+			"bold": {
+				"value": "Bold",
+				"type": "fontWeights"
+			},
+			"light": {
+				"value": "Light",
+				"type": "fontWeights"
+			}
+		},
+		"letterSpacing": {
+			"description": {
+				"value": "In production units remain %",
+				"type": "letterSpacing"
+			},
+			"none": {
+				"value": "0%",
+				"type": "letterSpacing"
+			},
+			"tight": {
+				"value": "-1%",
+				"type": "letterSpacing"
+			},
+			"loose": {
+				"value": "3%",
+				"type": "letterSpacing"
+			}
+		},
+		"paragraphSpacing": {
+			"description": {
+				"value": "In production, units are in rems",
+				"type": "paragraphSpacing"
+			},
+			"none": {
+				"value": "0",
+				"type": "paragraphSpacing"
+			}
+		},
+		"textCase": {
+			"none": {
+				"value": "none",
+				"type": "textCase"
+			},
+			"uppercase": {
+				"value": "uppercase",
+				"type": "textCase"
+			},
+			"capitalize": {
+				"value": "capitalize",
+				"type": "textCase"
+			}
+		},
+		"textDecoration": {
+			"none": {
+				"value": "none",
+				"type": "textDecoration"
+			},
+			"underline": {
+				"value": "underline",
+				"type": "textDecoration"
+			},
+			"strikethrough": {
+				"value": "line-through",
+				"type": "textDecoration"
+			}
+		},
+		"Black": {
+			"value": "#13191e",
+			"type": "color"
+		},
+		"pure-black": {
+			"value": "#000000",
+			"type": "color"
+		},
+		"pure-white": {
+			"value": "#ffffff",
+			"type": "color"
+		},
+		"Gold": {
+			"0": {
+				"value": "#fcfafa",
+				"type": "color"
+			},
+			"3": {
+				"value": "#f5f2f1",
+				"type": "color"
+			},
+			"7": {
+				"value": "#eeeae5",
+				"type": "color"
+			},
+			"10": {
+				"value": "#eae3da",
+				"type": "color"
+			},
+			"15": {
+				"value": "#e3d0b8",
+				"type": "color"
+			},
+			"20": {
+				"value": "#dfc39e",
+				"type": "color"
+			},
+			"25": {
+				"value": "#dcb480",
+				"type": "color"
+			},
+			"30": {
+				"value": "#d8a45f",
+				"type": "color"
+			},
+			"35": {
+				"value": "#da9a45",
+				"type": "color"
+			},
+			"40": {
+				"value": "#d29137",
+				"type": "color"
+			},
+			"45": {
+				"value": "#c5832a",
+				"type": "color"
+			},
+			"50": {
+				"value": "#ba7920",
+				"type": "color"
+			},
+			"55": {
+				"value": "#a66915",
+				"type": "color"
+			},
+			"60": {
+				"value": "#9a6014",
+				"type": "color"
+			},
+			"65": {
+				"value": "#8c5407",
+				"type": "color"
+			},
+			"70": {
+				"value": "#7a4909",
+				"type": "color"
+			},
+			"73": {
+				"value": "#6d4108",
+				"type": "color"
+			},
+			"75": {
+				"value": "#633a0a",
+				"type": "color"
+			},
+			"78": {
+				"value": "#583409",
+				"type": "color"
+			},
+			"80": {
+				"value": "#522e03",
+				"type": "color"
+			},
+			"83": {
+				"value": "#4a2903",
+				"type": "color"
+			},
+			"85": {
+				"value": "#3f2300",
+				"type": "color"
+			},
+			"88": {
+				"value": "#331c00",
+				"type": "color"
+			},
+			"90": {
+				"value": "#2d1803",
+				"type": "color"
+			},
+			"93": {
+				"value": "#211202",
+				"type": "color"
+			},
+			"95": {
+				"value": "#1a0e04",
+				"type": "color"
+			},
+			"100": {
+				"value": "#0f0000",
+				"type": "color"
+			}
+		},
+		"Gray": {
+			"0": {
+				"value": "#fbfbfb",
+				"type": "color"
+			},
+			"3": {
+				"value": "#f4f3f2",
+				"type": "color"
+			},
+			"7": {
+				"value": "#ebe9e8",
+				"type": "color"
+			},
+			"10": {
+				"value": "#e3e0df",
+				"type": "color"
+			},
+			"15": {
+				"value": "#d7d4d3",
+				"type": "color"
+			},
+			"20": {
+				"value": "#cbc7c6",
+				"type": "color"
+			},
+			"25": {
+				"value": "#bfbcbb",
+				"type": "color"
+			},
+			"30": {
+				"value": "#b3afae",
+				"type": "color"
+			},
+			"35": {
+				"value": "#a7a4a3",
+				"type": "color"
+			},
+			"40": {
+				"value": "#9b9796",
+				"type": "color"
+			},
+			"45": {
+				"value": "#8f8c8b",
+				"type": "color"
+			},
+			"50": {
+				"value": "#827f7e",
+				"type": "color"
+			},
+			"55": {
+				"value": "#767372",
+				"type": "color"
+			},
+			"60": {
+				"value": "#6a6766",
+				"type": "color"
+			},
+			"65": {
+				"value": "#5e5b5a",
+				"type": "color"
+			},
+			"70": {
+				"value": "#514e4d",
+				"type": "color"
+			},
+			"73": {
+				"value": "#4c4948",
+				"type": "color"
+			},
+			"75": {
+				"value": "#444140",
+				"type": "color"
+			},
+			"78": {
+				"value": "#3f3c3b",
+				"type": "color"
+			},
+			"80": {
+				"value": "#383635",
+				"type": "color"
+			},
+			"83": {
+				"value": "#32302f",
+				"type": "color"
+			},
+			"85": {
+				"value": "#2c2a29",
+				"type": "color"
+			},
+			"88": {
+				"value": "#282625",
+				"type": "color"
+			},
+			"90": {
+				"value": "#201e1d",
+				"type": "color"
+			},
+			"93": {
+				"value": "#1b1918",
+				"type": "color"
+			},
+			"95": {
+				"value": "#141110",
+				"type": "color"
+			},
+			"100": {
+				"value": "#080402",
+				"type": "color"
+			}
+		},
+		"Green": {
+			"0": {
+				"value": "#f5fbf7",
+				"type": "color"
+			},
+			"3": {
+				"value": "#e9f6ee",
+				"type": "color"
+			},
+			"7": {
+				"value": "#d7efdf",
+				"type": "color"
+			},
+			"10": {
+				"value": "#c6ead0",
+				"type": "color"
+			},
+			"15": {
+				"value": "#aae1b7",
+				"type": "color"
+			},
+			"20": {
+				"value": "#89daa0",
+				"type": "color"
+			},
+			"25": {
+				"value": "#6dd18b",
+				"type": "color"
+			},
+			"30": {
+				"value": "#4dc679",
+				"type": "color"
+			},
+			"35": {
+				"value": "#40ba6f",
+				"type": "color"
+			},
+			"40": {
+				"value": "#30ac63",
+				"type": "color"
+			},
+			"45": {
+				"value": "#1da158",
+				"type": "color"
+			},
+			"50": {
+				"value": "#01944d",
+				"type": "color"
+			},
+			"55": {
+				"value": "#008840",
+				"type": "color"
+			},
+			"60": {
+				"value": "#007934",
+				"type": "color"
+			},
+			"65": {
+				"value": "#006d29",
+				"type": "color"
+			},
+			"70": {
+				"value": "#00611e",
+				"type": "color"
+			},
+			"73": {
+				"value": "#005710",
+				"type": "color"
+			},
+			"75": {
+				"value": "#00510f",
+				"type": "color"
+			},
+			"78": {
+				"value": "#004c03",
+				"type": "color"
+			},
+			"80": {
+				"value": "#004502",
+				"type": "color"
+			},
+			"83": {
+				"value": "#003d00",
+				"type": "color"
+			},
+			"85": {
+				"value": "#003700",
+				"type": "color"
+			},
+			"88": {
+				"value": "#013300",
+				"type": "color"
+			},
+			"90": {
+				"value": "#012c00",
+				"type": "color"
+			},
+			"93": {
+				"value": "#012400",
+				"type": "color"
+			},
+			"95": {
+				"value": "#011b00",
+				"type": "color"
+			},
+			"100": {
+				"value": "#010800",
+				"type": "color"
+			}
+		},
+		"Blue": {
+			"0": {
+				"value": "#fafbff",
+				"type": "color"
+			},
+			"3": {
+				"value": "#ecf4f8",
+				"type": "color"
+			},
+			"7": {
+				"value": "#ddebf3",
+				"type": "color"
+			},
+			"10": {
+				"value": "#cde6eb",
+				"type": "color"
+			},
+			"15": {
+				"value": "#b2dde6",
+				"type": "color"
+			},
+			"20": {
+				"value": "#94d4de",
+				"type": "color"
+			},
+			"25": {
+				"value": "#77cad8",
+				"type": "color"
+			},
+			"30": {
+				"value": "#54c0cd",
+				"type": "color"
+			},
+			"35": {
+				"value": "#30b5c4",
+				"type": "color"
+			},
+			"40": {
+				"value": "#19a8b8",
+				"type": "color"
+			},
+			"45": {
+				"value": "#009bad",
+				"type": "color"
+			},
+			"50": {
+				"value": "#0190a0",
+				"type": "color"
+			},
+			"55": {
+				"value": "#008292",
+				"type": "color"
+			},
+			"60": {
+				"value": "#007586",
+				"type": "color"
+			},
+			"65": {
+				"value": "#006979",
+				"type": "color"
+			},
+			"70": {
+				"value": "#005b6d",
+				"type": "color"
+			},
+			"73": {
+				"value": "#005366",
+				"type": "color"
+			},
+			"75": {
+				"value": "#004d5f",
+				"type": "color"
+			},
+			"78": {
+				"value": "#004657",
+				"type": "color"
+			},
+			"80": {
+				"value": "#004252",
+				"type": "color"
+			},
+			"83": {
+				"value": "#00394d",
+				"type": "color"
+			},
+			"85": {
+				"value": "#003344",
+				"type": "color"
+			},
+			"88": {
+				"value": "#012e41",
+				"type": "color"
+			},
+			"90": {
+				"value": "#012839",
+				"type": "color"
+			},
+			"93": {
+				"value": "#002233",
+				"type": "color"
+			},
+			"95": {
+				"value": "#001c2a",
+				"type": "color"
+			},
+			"100": {
+				"value": "#000a23",
+				"type": "color"
+			}
+		},
+		"Pink": {
+			"0": {
+				"value": "#fff8f6",
+				"type": "color"
+			},
+			"3": {
+				"value": "#fff1f0",
+				"type": "color"
+			},
+			"7": {
+				"value": "#ffdedb",
+				"type": "color"
+			},
+			"10": {
+				"value": "#ffd6d2",
+				"type": "color"
+			},
+			"15": {
+				"value": "#ffc5c1",
+				"type": "color"
+			},
+			"20": {
+				"value": "#fbb7b4",
+				"type": "color"
+			},
+			"25": {
+				"value": "#efaba8",
+				"type": "color"
+			},
+			"30": {
+				"value": "#e29e9d",
+				"type": "color"
+			},
+			"35": {
+				"value": "#d49294",
+				"type": "color"
+			},
+			"40": {
+				"value": "#ca8588",
+				"type": "color"
+			},
+			"45": {
+				"value": "#bc7a7e",
+				"type": "color"
+			},
+			"50": {
+				"value": "#b06d74",
+				"type": "color"
+			},
+			"55": {
+				"value": "#a35f6a",
+				"type": "color"
+			},
+			"60": {
+				"value": "#95535d",
+				"type": "color"
+			},
+			"65": {
+				"value": "#894755",
+				"type": "color"
+			},
+			"70": {
+				"value": "#7c394a",
+				"type": "color"
+			},
+			"73": {
+				"value": "#763247",
+				"type": "color"
+			},
+			"75": {
+				"value": "#6d293e",
+				"type": "color"
+			},
+			"78": {
+				"value": "#66243a",
+				"type": "color"
+			},
+			"80": {
+				"value": "#5f1e34",
+				"type": "color"
+			},
+			"83": {
+				"value": "#5a1633",
+				"type": "color"
+			},
+			"85": {
+				"value": "#530e2b",
+				"type": "color"
+			},
+			"88": {
+				"value": "#4a0825",
+				"type": "color"
+			},
+			"90": {
+				"value": "#45001f",
+				"type": "color"
+			},
+			"93": {
+				"value": "#3d0015",
+				"type": "color"
+			},
+			"95": {
+				"value": "#350012",
+				"type": "color"
+			},
+			"100": {
+				"value": "#2e0003",
+				"type": "color"
+			}
+		},
+		"Salmon": {
+			"0": {
+				"value": "#fef8f8",
+				"type": "color"
+			},
+			"3": {
+				"value": "#feefeb",
+				"type": "color"
+			},
+			"7": {
+				"value": "#fedfd8",
+				"type": "color"
+			},
+			"10": {
+				"value": "#fed6ce",
+				"type": "color"
+			},
+			"15": {
+				"value": "#fec3b1",
+				"type": "color"
+			},
+			"20": {
+				"value": "#ffb296",
+				"type": "color"
+			},
+			"25": {
+				"value": "#ffa378",
+				"type": "color"
+			},
+			"30": {
+				"value": "#f9945e",
+				"type": "color"
+			},
+			"35": {
+				"value": "#ed8955",
+				"type": "color"
+			},
+			"40": {
+				"value": "#e07b4d",
+				"type": "color"
+			},
+			"45": {
+				"value": "#d27146",
+				"type": "color"
+			},
+			"50": {
+				"value": "#c5653f",
+				"type": "color"
+			},
+			"55": {
+				"value": "#b55638",
+				"type": "color"
+			},
+			"60": {
+				"value": "#a74930",
+				"type": "color"
+			},
+			"65": {
+				"value": "#993c2b",
+				"type": "color"
+			},
+			"70": {
+				"value": "#892f26",
+				"type": "color"
+			},
+			"73": {
+				"value": "#842724",
+				"type": "color"
+			},
+			"75": {
+				"value": "#7c1e1e",
+				"type": "color"
+			},
+			"78": {
+				"value": "#751515",
+				"type": "color"
+			},
+			"80": {
+				"value": "#6c0f17",
+				"type": "color"
+			},
+			"83": {
+				"value": "#630814",
+				"type": "color"
+			},
+			"85": {
+				"value": "#5e0010",
+				"type": "color"
+			},
+			"88": {
+				"value": "#570007",
+				"type": "color"
+			},
+			"90": {
+				"value": "#4e0000",
+				"type": "color"
+			},
+			"93": {
+				"value": "#420002",
+				"type": "color"
+			},
+			"95": {
+				"value": "#3e0001",
+				"type": "color"
+			},
+			"100": {
+				"value": "#340002",
+				"type": "color"
+			}
+		},
+		"Orange": {
+			"0": {
+				"value": "#fff9f1",
+				"type": "color"
+			},
+			"3": {
+				"value": "#ffefe5",
+				"type": "color"
+			},
+			"7": {
+				"value": "#ffe0cc",
+				"type": "color"
+			},
+			"10": {
+				"value": "#ffd7bd",
+				"type": "color"
+			},
+			"15": {
+				"value": "#ffc39f",
+				"type": "color"
+			},
+			"20": {
+				"value": "#ffb27e",
+				"type": "color"
+			},
+			"25": {
+				"value": "#fe9f5f",
+				"type": "color"
+			},
+			"30": {
+				"value": "#ff8b40",
+				"type": "color"
+			},
+			"35": {
+				"value": "#ff7b28",
+				"type": "color"
+			},
+			"40": {
+				"value": "#f46e15",
+				"type": "color"
+			},
+			"45": {
+				"value": "#e76205",
+				"type": "color"
+			},
+			"50": {
+				"value": "#d75001",
+				"type": "color"
+			},
+			"55": {
+				"value": "#c54900",
+				"type": "color"
+			},
+			"60": {
+				"value": "#b43c00",
+				"type": "color"
+			},
+			"65": {
+				"value": "#a53100",
+				"type": "color"
+			},
+			"70": {
+				"value": "#942601",
+				"type": "color"
+			},
+			"73": {
+				"value": "#831b01",
+				"type": "color"
+			},
+			"75": {
+				"value": "#811701",
+				"type": "color"
+			},
+			"78": {
+				"value": "#740e01",
+				"type": "color"
+			},
+			"80": {
+				"value": "#6f0801",
+				"type": "color"
+			},
+			"83": {
+				"value": "#650401",
+				"type": "color"
+			},
+			"85": {
+				"value": "#5f0000",
+				"type": "color"
+			},
+			"88": {
+				"value": "#520000",
+				"type": "color"
+			},
+			"90": {
+				"value": "#4e0000",
+				"type": "color"
+			},
+			"93": {
+				"value": "#420000",
+				"type": "color"
+			},
+			"95": {
+				"value": "#3c0000",
+				"type": "color"
+			},
+			"100": {
+				"value": "#320003",
+				"type": "color"
+			}
+		},
+		"Yellow": {
+			"0": {
+				"value": "#fff9f1",
+				"type": "color"
+			},
+			"3": {
+				"value": "#fff0e0",
+				"type": "color"
+			},
+			"7": {
+				"value": "#ffe2c2",
+				"type": "color"
+			},
+			"10": {
+				"value": "#ffd8a5",
+				"type": "color"
+			},
+			"15": {
+				"value": "#ffc876",
+				"type": "color"
+			},
+			"20": {
+				"value": "#ffb84a",
+				"type": "color"
+			},
+			"25": {
+				"value": "#ffa920",
+				"type": "color"
+			},
+			"30": {
+				"value": "#f09d01",
+				"type": "color"
+			},
+			"35": {
+				"value": "#e29101",
+				"type": "color"
+			},
+			"40": {
+				"value": "#d38500",
+				"type": "color"
+			},
+			"45": {
+				"value": "#c67a00",
+				"type": "color"
+			},
+			"50": {
+				"value": "#b86e01",
+				"type": "color"
+			},
+			"55": {
+				"value": "#a96100",
+				"type": "color"
+			},
+			"60": {
+				"value": "#985600",
+				"type": "color"
+			},
+			"65": {
+				"value": "#894b00",
+				"type": "color"
+			},
+			"70": {
+				"value": "#7b3f01",
+				"type": "color"
+			},
+			"73": {
+				"value": "#743901",
+				"type": "color"
+			},
+			"75": {
+				"value": "#683301",
+				"type": "color"
+			},
+			"78": {
+				"value": "#602d00",
+				"type": "color"
+			},
+			"80": {
+				"value": "#592800",
+				"type": "color"
+			},
+			"83": {
+				"value": "#522300",
+				"type": "color"
+			},
+			"85": {
+				"value": "#491d00",
+				"type": "color"
+			},
+			"88": {
+				"value": "#421700",
+				"type": "color"
+			},
+			"90": {
+				"value": "#3b1200",
+				"type": "color"
+			},
+			"93": {
+				"value": "#330a00",
+				"type": "color"
+			},
+			"95": {
+				"value": "#2b0400",
+				"type": "color"
+			},
+			"100": {
+				"value": "#230000",
+				"type": "color"
+			}
+		},
+		"Red": {
+			"0": {
+				"value": "#fff6f9",
+				"type": "color"
+			},
+			"3": {
+				"value": "#ffeceb",
+				"type": "color"
+			},
+			"7": {
+				"value": "#ffdedb",
+				"type": "color"
+			},
+			"10": {
+				"value": "#ffd5ce",
+				"type": "color"
+			},
+			"15": {
+				"value": "#ffc3b9",
+				"type": "color"
+			},
+			"20": {
+				"value": "#ffb0a1",
+				"type": "color"
+			},
+			"25": {
+				"value": "#fe9d8c",
+				"type": "color"
+			},
+			"30": {
+				"value": "#ff8872",
+				"type": "color"
+			},
+			"35": {
+				"value": "#ff745f",
+				"type": "color"
+			},
+			"40": {
+				"value": "#ff5f4d",
+				"type": "color"
+			},
+			"45": {
+				"value": "#f84d3c",
+				"type": "color"
+			},
+			"50": {
+				"value": "#e74135",
+				"type": "color"
+			},
+			"55": {
+				"value": "#d3372b",
+				"type": "color"
+			},
+			"60": {
+				"value": "#bf2a23",
+				"type": "color"
+			},
+			"65": {
+				"value": "#ad221f",
+				"type": "color"
+			},
+			"70": {
+				"value": "#9a1a19",
+				"type": "color"
+			},
+			"73": {
+				"value": "#8d1119",
+				"type": "color"
+			},
+			"75": {
+				"value": "#840b10",
+				"type": "color"
+			},
+			"78": {
+				"value": "#770d12",
+				"type": "color"
+			},
+			"80": {
+				"value": "#710208",
+				"type": "color"
+			},
+			"83": {
+				"value": "#6a0101",
+				"type": "color"
+			},
+			"85": {
+				"value": "#5e0000",
+				"type": "color"
+			},
+			"88": {
+				"value": "#570000",
+				"type": "color"
+			},
+			"90": {
+				"value": "#4a0001",
+				"type": "color"
+			},
+			"93": {
+				"value": "#420001",
+				"type": "color"
+			},
+			"95": {
+				"value": "#380001",
+				"type": "color"
+			},
+			"100": {
+				"value": "#2e0002",
+				"type": "color"
+			}
+		},
+		"Gradient": {
+			"neutral-light-1": {
+				"value": "linear-gradient(180deg, {Gold.0} 0%, {Gold.3} 100%)",
+				"type": "color"
+			},
+			"neutral-light-2": {
+				"value": "linear-gradient(180deg, {Gold.3} 0%, {Gold.0} 100%)",
+				"type": "color"
+			},
+			"neutral-light-3": {
+				"value": "radial-gradient(53.72% 53.72% at 50% 46.28%, {Gold.0} 0%, {Gold.3} 100%)",
+				"type": "color"
+			},
+			"neutral-light-4": {
+				"value": "radial-gradient(53.72% 53.72% at 50% 46.28%, {Gold.3} 0%, {Gold.0} 100%)",
+				"type": "color"
+			},
+			"colorful-light-1": {
+				"value": "linear-gradient(145.9deg, {Blue.10} 7.11%, rgba(255, 255, 255, 0) 90.25%), linear-gradient(294.32deg, {Green.7} -14.26%, rgba(255, 255, 255, 0) 62.44%), {Orange.3}",
+				"type": "color"
+			},
+			"colorful-light-2": {
+				"value": "linear-gradient(41.04deg, {Blue.7} 1.34%, rgba(255, 255, 255, 0) 42.39%), linear-gradient(201.1deg, {Yellow.3} 5.95%, rgba(255, 255, 255, 0) 73.3%), linear-gradient(119.18deg, {Green.7} -6.66%, rgba(255, 255, 255, 0) 39.22%), {Red.3}",
+				"type": "color"
+			},
+			"colorful-light-3": {
+				"value": "linear-gradient(270.31deg, {Blue.7} -11.36%, rgba(255, 255, 255, 0) 62.73%), linear-gradient(156.44deg, {Green.7} -16.49%, rgba(255, 255, 255, 0) 86.24%), {Yellow.3}",
+				"type": "color"
+			},
+			"colorful-light-4": {
+				"value": "linear-gradient(198.09deg, {Blue.7} 2.01%, rgba(235, 238, 242, 0) 43.18%, rgba(249, 234, 232, 0) 47.86%, {Yellow.3} 94.31%), linear-gradient(98.65deg, {Red.3} 0.58%, rgba(255, 233, 214, 0) 52.45%, rgba(255, 233, 219, 0) 53.76%, {Yellow.3} 105.86%), {Gold.3}",
+				"type": "color"
+			},
+			"colorful-dark-1": {
+				"value": "linear-gradient(71.44deg, {Red.95} 0%, rgba(62, 0, 16, 0) 25.96%, rgba(65, 0, 22, 0) 80.55%, {Pink.90} 102.88%), linear-gradient(110.82deg, {Blue.85} 0%, rgba(19, 25, 30, 0) 42.92%, rgba(8, 37, 11, 0) 76.58%, {Green.90} 100%), {Black}",
+				"type": "color"
+			},
+			"colorful-dark-2": {
+				"value": "linear-gradient(135deg, rgba(56, 0, 1, 0.5) 0%, rgba(62, 0, 16, 0) 49%, rgba(65, 0, 22, 0) 57.51%, rgba(69, 0, 31, 0.5) 100%), linear-gradient(45deg, rgba(0, 51, 68, 0.5) 0%, rgba(19, 25, 30, 0) 50.67%, rgba(8, 37, 11, 0) 54.43%, rgba(1, 44, 0, 0.5) 100%), {Black}",
+				"type": "color"
+			}
+		},
+		"default-fonts": {
+			"value": "-apple-system,BlinkMacSystemFont,\"Segoe UI\",Roboto,Oxygen-Sans,Ubuntu,Cantarell,\"Helvetica Neue\",sans-serif",
+			"type": "fontFamilies"
+		},
+		"breakpoints": {
+			"description": {
+				"value": "In production, units are in px for now. We will convert this to vw in the future",
+				"type": "other"
+			},
+			"S": {
+				"value": "320",
+				"type": "sizing",
+				"description": "< 655px"
+			},
+			"M": {
+				"value": "656",
+				"type": "sizing",
+				"description": "656–1047px"
+			},
+			"L": {
+				"value": "1048–1311px",
+				"type": "sizing"
+			},
+			"XL": {
+				"value": "1312",
+				"type": "sizing",
+				"description": "1312–1535px"
+			},
+			"XXL": {
+				"value": "1536",
+				"type": "sizing",
+				"description": "1536–1647px"
+			},
+			"MAX": {
+				"value": "1648",
+				"type": "sizing",
+				"description": "1648px +"
+			}
+		},
+		"alignment": {
+			"description": {
+				"value": "In production, units are in px for now. We will convert this to vw in the future",
+				"type": "other"
+			},
+			"center": {
+				"value": "416",
+				"type": "sizing",
+				"description": "min-width: 416px"
+			},
+			"wide": {
+				"value": "820",
+				"type": "sizing",
+				"description": "min-width: 820px"
+			},
+			"full": {
+				"value": "1583",
+				"type": "sizing",
+				"description": "max-width: 1583px"
+			}
+		}
+	},
+	"expressive-type-wpvip": {
+		"expressive": {
+			"body": {
+				"1-short": {
+					"value": {
+						"fontFamily": "{fontFamilies.sans}",
+						"fontWeight": "{fontWeights.regular}",
+						"lineHeight": "{lineHeights.4}",
+						"fontSize": "{fontSizes.static.2}"
+					},
+					"type": "typography"
+				},
+				"1-short-medium": {
+					"value": {
+						"fontFamily": "{fontFamilies.sans}",
+						"fontWeight": "{fontWeights.medium}",
+						"lineHeight": "{lineHeights.4}",
+						"fontSize": "{fontSizes.static.2}"
+					},
+					"type": "typography"
+				},
+				"1-short-caps": {
+					"value": {
+						"fontFamily": "{fontFamilies.sans}",
+						"fontWeight": "{fontWeights.regular}",
+						"lineHeight": "{lineHeights.4}",
+						"fontSize": "{fontSizes.static.2}",
+						"textCase": "uppercase"
+					},
+					"type": "typography"
+				},
+				"2-short": {
+					"value": {
+						"fontFamily": "{fontFamilies.sans}",
+						"fontWeight": "{fontWeights.regular}",
+						"lineHeight": "{lineHeights.4}",
+						"fontSize": "{fontSizes.static.3}"
+					},
+					"type": "typography"
+				},
+				"2-short-medium": {
+					"value": {
+						"fontFamily": "{fontFamilies.sans}",
+						"fontWeight": "{fontWeights.bold}",
+						"lineHeight": "{lineHeights.4}",
+						"fontSize": "{fontSizes.static.3}"
+					},
+					"type": "typography"
+				},
+				"3-short": {
+					"value": {
+						"fontFamily": "{fontFamilies.sans}",
+						"fontWeight": "{fontWeights.regular}",
+						"lineHeight": "{lineHeights.4}",
+						"fontSize": "{fontSizes.static.4}"
+					},
+					"type": "typography"
+				},
+				"4-short": {
+					"value": {
+						"fontFamily": "{fontFamilies.sans}",
+						"fontWeight": "{fontWeights.light}",
+						"lineHeight": "{lineHeights.4}",
+						"fontSize": "{fontSizes.static.5}"
+					},
+					"type": "typography"
+				},
+				"4-serif": {
+					"value": {
+						"fontFamily": "{fontFamilies.serif}",
+						"fontWeight": "{fontWeights.regular}",
+						"lineHeight": "{lineHeights.5}",
+						"fontSize": "{fontSizes.static.5}"
+					},
+					"type": "typography"
+				}
+			},
+			"heading": {
+				"1": {
+					"S": {
+						"value": {
+							"fontFamily": "{fontFamilies.sans}",
+							"fontWeight": "{fontWeights.regular}",
+							"lineHeight": "{lineHeights.3}",
+							"fontSize": "{fontSizes.figma.4.s}",
+							"letterSpacing": "{letterSpacing.tight}"
+						},
+						"type": "typography"
+					},
+					"M": {
+						"value": {
+							"fontFamily": "{fontFamilies.sans}",
+							"fontWeight": "{fontWeights.regular}",
+							"lineHeight": "{lineHeights.3}",
+							"fontSize": "{fontSizes.figma.4.m}",
+							"letterSpacing": "{letterSpacing.tight}"
+						},
+						"type": "typography"
+					},
+					"L": {
+						"value": {
+							"fontFamily": "{fontFamilies.sans}",
+							"fontWeight": "{fontWeights.regular}",
+							"lineHeight": "{lineHeights.3}",
+							"fontSize": "{fontSizes.figma.4.l}",
+							"letterSpacing": "{letterSpacing.tight}"
+						},
+						"type": "typography"
+					},
+					"XL": {
+						"value": {
+							"fontFamily": "{fontFamilies.sans}",
+							"fontWeight": "{fontWeights.regular}",
+							"lineHeight": "{lineHeights.3}",
+							"fontSize": "{fontSizes.figma.4.xl}",
+							"letterSpacing": "{letterSpacing.tight}"
+						},
+						"type": "typography"
+					},
+					"MAX": {
+						"value": {
+							"fontFamily": "{fontFamilies.sans}",
+							"fontWeight": "{fontWeights.regular}",
+							"lineHeight": "{lineHeights.3}",
+							"fontSize": "{fontSizes.figma.4.max}",
+							"letterSpacing": "{letterSpacing.tight}"
+						},
+						"type": "typography"
+					}
+				},
+				"2": {
+					"S": {
+						"value": {
+							"fontFamily": "{fontFamilies.sans}",
+							"fontWeight": "{fontWeights.regular}",
+							"lineHeight": "{lineHeights.2}",
+							"fontSize": "{fontSizes.figma.8.s}",
+							"letterSpacing": "{letterSpacing.tight}"
+						},
+						"type": "typography"
+					},
+					"M": {
+						"value": {
+							"fontFamily": "{fontFamilies.sans}",
+							"fontWeight": "{fontWeights.regular}",
+							"lineHeight": "{lineHeights.2}",
+							"fontSize": "{fontSizes.figma.8.m}",
+							"letterSpacing": "{letterSpacing.tight}"
+						},
+						"type": "typography"
+					},
+					"L": {
+						"value": {
+							"fontFamily": "{fontFamilies.sans}",
+							"fontWeight": "{fontWeights.regular}",
+							"lineHeight": "{lineHeights.2}",
+							"fontSize": "{fontSizes.figma.8.l}",
+							"letterSpacing": "{letterSpacing.tight}"
+						},
+						"type": "typography"
+					},
+					"XL": {
+						"value": {
+							"fontFamily": "{fontFamilies.sans}",
+							"fontWeight": "{fontWeights.regular}",
+							"lineHeight": "{lineHeights.2}",
+							"fontSize": "{fontSizes.figma.8.xl}",
+							"letterSpacing": "{letterSpacing.tight}"
+						},
+						"type": "typography"
+					},
+					"MAX": {
+						"value": {
+							"fontFamily": "{fontFamilies.sans}",
+							"fontWeight": "{fontWeights.regular}",
+							"lineHeight": "{lineHeights.2}",
+							"fontSize": "{fontSizes.figma.8.max}",
+							"letterSpacing": "{letterSpacing.tight}"
+						},
+						"type": "typography"
+					}
+				},
+				"3": {
+					"S": {
+						"value": {
+							"fontFamily": "{fontFamilies.sans}",
+							"fontWeight": "{fontWeights.regular}",
+							"lineHeight": "{lineHeights.3}",
+							"fontSize": "{fontSizes.figma.9.s}",
+							"letterSpacing": "{letterSpacing.tight}"
+						},
+						"type": "typography"
+					},
+					"M": {
+						"value": {
+							"fontFamily": "{fontFamilies.sans}",
+							"fontWeight": "{fontWeights.regular}",
+							"lineHeight": "{lineHeights.3}",
+							"fontSize": "{fontSizes.figma.9.m}",
+							"letterSpacing": "{letterSpacing.tight}"
+						},
+						"type": "typography"
+					},
+					"L": {
+						"value": {
+							"fontFamily": "{fontFamilies.sans}",
+							"fontWeight": "{fontWeights.regular}",
+							"lineHeight": "{lineHeights.3}",
+							"fontSize": "{fontSizes.figma.9.l}",
+							"letterSpacing": "{letterSpacing.tight}"
+						},
+						"type": "typography"
+					},
+					"XL": {
+						"value": {
+							"fontFamily": "{fontFamilies.sans}",
+							"fontWeight": "{fontWeights.regular}",
+							"lineHeight": "{lineHeights.3}",
+							"fontSize": "{fontSizes.figma.9.xl}",
+							"letterSpacing": "{letterSpacing.tight}"
+						},
+						"type": "typography"
+					},
+					"MAX": {
+						"value": {
+							"fontFamily": "{fontFamilies.sans}",
+							"fontWeight": "{fontWeights.regular}",
+							"lineHeight": "{lineHeights.3}",
+							"fontSize": "{fontSizes.figma.9.max}",
+							"letterSpacing": "{letterSpacing.tight}"
+						},
+						"type": "typography"
+					}
+				},
+				"4": {
+					"S": {
+						"value": {
+							"fontFamily": "{fontFamilies.sans}",
+							"fontWeight": "{fontWeights.regular}",
+							"lineHeight": "{lineHeights.2}",
+							"fontSize": "{fontSizes.figma.10.s}",
+							"letterSpacing": "{letterSpacing.tight}"
+						},
+						"type": "typography"
+					},
+					"M": {
+						"value": {
+							"fontFamily": "{fontFamilies.sans}",
+							"fontWeight": "{fontWeights.regular}",
+							"lineHeight": "{lineHeights.2}",
+							"fontSize": "{fontSizes.figma.10.m}",
+							"letterSpacing": "{letterSpacing.tight}"
+						},
+						"type": "typography"
+					},
+					"L": {
+						"value": {
+							"fontFamily": "{fontFamilies.sans}",
+							"fontWeight": "{fontWeights.regular}",
+							"lineHeight": "{lineHeights.2}",
+							"fontSize": "{fontSizes.figma.10.l}",
+							"letterSpacing": "{letterSpacing.tight}"
+						},
+						"type": "typography"
+					},
+					"XL": {
+						"value": {
+							"fontFamily": "{fontFamilies.sans}",
+							"fontWeight": "{fontWeights.regular}",
+							"lineHeight": "{lineHeights.2}",
+							"fontSize": "{fontSizes.figma.10.xl}",
+							"letterSpacing": "{letterSpacing.tight}"
+						},
+						"type": "typography"
+					},
+					"MAX": {
+						"value": {
+							"fontFamily": "{fontFamilies.sans}",
+							"fontWeight": "{fontWeights.regular}",
+							"lineHeight": "{lineHeights.2}",
+							"fontSize": "{fontSizes.figma.10.max}",
+							"letterSpacing": "{letterSpacing.tight}"
+						},
+						"type": "typography"
+					}
+				},
+				"5": {
+					"S": {
+						"value": {
+							"fontFamily": "{fontFamilies.sans}",
+							"fontWeight": "{fontWeights.regular}",
+							"lineHeight": "{lineHeights.1}",
+							"fontSize": "{fontSizes.figma.11.s}",
+							"letterSpacing": "{letterSpacing.tight}"
+						},
+						"type": "typography"
+					},
+					"M": {
+						"value": {
+							"fontFamily": "{fontFamilies.sans}",
+							"fontWeight": "{fontWeights.regular}",
+							"lineHeight": "{lineHeights.1}",
+							"fontSize": "{fontSizes.figma.11.m}",
+							"letterSpacing": "{letterSpacing.tight}"
+						},
+						"type": "typography"
+					},
+					"L": {
+						"value": {
+							"fontFamily": "{fontFamilies.sans}",
+							"fontWeight": "{fontWeights.regular}",
+							"lineHeight": "{lineHeights.1}",
+							"fontSize": "{fontSizes.figma.11.l}",
+							"letterSpacing": "{letterSpacing.tight}"
+						},
+						"type": "typography"
+					},
+					"XL": {
+						"value": {
+							"fontFamily": "{fontFamilies.sans}",
+							"fontWeight": "{fontWeights.regular}",
+							"lineHeight": "{lineHeights.1}",
+							"fontSize": "{fontSizes.figma.11.xl}",
+							"letterSpacing": "{letterSpacing.tight}"
+						},
+						"type": "typography"
+					},
+					"MAX": {
+						"value": {
+							"fontFamily": "{fontFamilies.sans}",
+							"fontWeight": "{fontWeights.regular}",
+							"lineHeight": "{lineHeights.1}",
+							"fontSize": "{fontSizes.figma.11.max}",
+							"letterSpacing": "{letterSpacing.tight}"
+						},
+						"type": "typography"
+					}
+				},
+				"6": {
+					"S": {
+						"value": {
+							"fontFamily": "{fontFamilies.sans}",
+							"fontWeight": "{fontWeights.regular}",
+							"lineHeight": "{lineHeights.1}",
+							"fontSize": "{fontSizes.figma.12.s}",
+							"letterSpacing": "{letterSpacing.tight}"
+						},
+						"type": "typography"
+					},
+					"M": {
+						"value": {
+							"fontFamily": "{fontFamilies.sans}",
+							"fontWeight": "{fontWeights.regular}",
+							"lineHeight": "{lineHeights.1}",
+							"fontSize": "{fontSizes.figma.12.m}",
+							"letterSpacing": "{letterSpacing.tight}"
+						},
+						"type": "typography"
+					},
+					"L": {
+						"value": {
+							"fontFamily": "{fontFamilies.sans}",
+							"fontWeight": "{fontWeights.regular}",
+							"lineHeight": "{lineHeights.1}",
+							"fontSize": "{fontSizes.figma.12.l}",
+							"letterSpacing": "{letterSpacing.tight}"
+						},
+						"type": "typography"
+					},
+					"XL": {
+						"value": {
+							"fontFamily": "{fontFamilies.sans}",
+							"fontWeight": "{fontWeights.regular}",
+							"lineHeight": "{lineHeights.1}",
+							"fontSize": "{fontSizes.figma.12.xl}",
+							"letterSpacing": "{letterSpacing.tight}"
+						},
+						"type": "typography"
+					},
+					"MAX": {
+						"value": {
+							"fontFamily": "{fontFamilies.sans}",
+							"fontWeight": "{fontWeights.regular}",
+							"lineHeight": "{lineHeights.1}",
+							"fontSize": "{fontSizes.figma.12.max}",
+							"letterSpacing": "{letterSpacing.tight}"
+						},
+						"type": "typography"
+					}
+				},
+				"7": {
+					"S": {
+						"value": {
+							"fontFamily": "{fontFamilies.sans}",
+							"fontWeight": "{fontWeights.regular}",
+							"lineHeight": "{lineHeights.1}",
+							"fontSize": "{fontSizes.figma.13.s}",
+							"letterSpacing": "{letterSpacing.tight}"
+						},
+						"type": "typography"
+					},
+					"M": {
+						"value": {
+							"fontFamily": "{fontFamilies.sans}",
+							"fontWeight": "{fontWeights.regular}",
+							"lineHeight": "{lineHeights.1}",
+							"fontSize": "{fontSizes.figma.13.m}",
+							"letterSpacing": "{letterSpacing.tight}"
+						},
+						"type": "typography"
+					},
+					"L": {
+						"value": {
+							"fontFamily": "{fontFamilies.sans}",
+							"fontWeight": "{fontWeights.regular}",
+							"lineHeight": "{lineHeights.1}",
+							"fontSize": "{fontSizes.figma.13.l}",
+							"letterSpacing": "{letterSpacing.tight}"
+						},
+						"type": "typography"
+					},
+					"XL": {
+						"value": {
+							"fontFamily": "{fontFamilies.sans}",
+							"fontWeight": "{fontWeights.regular}",
+							"lineHeight": "{lineHeights.1}",
+							"fontSize": "{fontSizes.figma.13.xl}",
+							"letterSpacing": "{letterSpacing.tight}"
+						},
+						"type": "typography"
+					},
+					"MAX": {
+						"value": {
+							"fontFamily": "{fontFamilies.sans}",
+							"fontWeight": "{fontWeights.regular}",
+							"lineHeight": "{lineHeights.1}",
+							"fontSize": "{fontSizes.figma.13.max}",
+							"letterSpacing": "{letterSpacing.tight}"
+						},
+						"type": "typography"
+					}
+				},
+				"1-light": {
+					"S": {
+						"value": {
+							"fontFamily": "{fontFamilies.sans}",
+							"fontWeight": "{fontWeights.light}",
+							"lineHeight": "{lineHeights.3}",
+							"fontSize": "{fontSizes.figma.4.s}",
+							"letterSpacing": "{letterSpacing.tight}"
+						},
+						"type": "typography"
+					},
+					"M": {
+						"value": {
+							"fontFamily": "{fontFamilies.sans}",
+							"fontWeight": "{fontWeights.light}",
+							"lineHeight": "{lineHeights.3}",
+							"fontSize": "{fontSizes.figma.4.m}",
+							"letterSpacing": "{letterSpacing.tight}"
+						},
+						"type": "typography"
+					},
+					"L": {
+						"value": {
+							"fontFamily": "{fontFamilies.sans}",
+							"fontWeight": "{fontWeights.light}",
+							"lineHeight": "{lineHeights.3}",
+							"fontSize": "{fontSizes.figma.4.l}",
+							"letterSpacing": "{letterSpacing.tight}"
+						},
+						"type": "typography"
+					},
+					"XL": {
+						"value": {
+							"fontFamily": "{fontFamilies.sans}",
+							"fontWeight": "{fontWeights.light}",
+							"lineHeight": "{lineHeights.3}",
+							"fontSize": "{fontSizes.figma.4.xl}",
+							"letterSpacing": "{letterSpacing.tight}"
+						},
+						"type": "typography"
+					},
+					"MAX": {
+						"value": {
+							"fontFamily": "{fontFamilies.sans}",
+							"fontWeight": "{fontWeights.light}",
+							"lineHeight": "{lineHeights.3}",
+							"fontSize": "{fontSizes.figma.4.max}",
+							"letterSpacing": "{letterSpacing.tight}"
+						},
+						"type": "typography"
+					}
+				},
+				"2-light": {
+					"S": {
+						"value": {
+							"fontFamily": "{fontFamilies.sans}",
+							"fontWeight": "{fontWeights.light}",
+							"lineHeight": "{lineHeights.2}",
+							"fontSize": "{fontSizes.figma.8.s}",
+							"letterSpacing": "{letterSpacing.tight}"
+						},
+						"type": "typography"
+					},
+					"M": {
+						"value": {
+							"fontFamily": "{fontFamilies.sans}",
+							"fontWeight": "{fontWeights.light}",
+							"lineHeight": "{lineHeights.2}",
+							"fontSize": "{fontSizes.figma.8.m}",
+							"letterSpacing": "{letterSpacing.tight}"
+						},
+						"type": "typography"
+					},
+					"L": {
+						"value": {
+							"fontFamily": "{fontFamilies.sans}",
+							"fontWeight": "{fontWeights.light}",
+							"lineHeight": "{lineHeights.2}",
+							"fontSize": "{fontSizes.figma.8.l}",
+							"letterSpacing": "{letterSpacing.tight}"
+						},
+						"type": "typography"
+					},
+					"XL": {
+						"value": {
+							"fontFamily": "{fontFamilies.sans}",
+							"fontWeight": "{fontWeights.light}",
+							"lineHeight": "{lineHeights.2}",
+							"fontSize": "{fontSizes.figma.8.xl}",
+							"letterSpacing": "{letterSpacing.tight}"
+						},
+						"type": "typography"
+					},
+					"MAX": {
+						"value": {
+							"fontFamily": "{fontFamilies.sans}",
+							"fontWeight": "{fontWeights.light}",
+							"lineHeight": "{lineHeights.2}",
+							"fontSize": "{fontSizes.figma.8.max}",
+							"letterSpacing": "{letterSpacing.tight}"
+						},
+						"type": "typography"
+					}
+				},
+				"3-light": {
+					"S": {
+						"value": {
+							"fontFamily": "{fontFamilies.sans}",
+							"fontWeight": "{fontWeights.light}",
+							"lineHeight": "{lineHeights.3}",
+							"fontSize": "{fontSizes.figma.9.s}",
+							"letterSpacing": "{letterSpacing.tight}"
+						},
+						"type": "typography"
+					},
+					"M": {
+						"value": {
+							"fontFamily": "{fontFamilies.sans}",
+							"fontWeight": "{fontWeights.light}",
+							"lineHeight": "{lineHeights.3}",
+							"fontSize": "{fontSizes.figma.9.m}",
+							"letterSpacing": "{letterSpacing.tight}"
+						},
+						"type": "typography"
+					},
+					"L": {
+						"value": {
+							"fontFamily": "{fontFamilies.sans}",
+							"fontWeight": "{fontWeights.light}",
+							"lineHeight": "{lineHeights.3}",
+							"fontSize": "{fontSizes.figma.9.l}",
+							"letterSpacing": "{letterSpacing.tight}"
+						},
+						"type": "typography"
+					},
+					"XL": {
+						"value": {
+							"fontFamily": "{fontFamilies.sans}",
+							"fontWeight": "{fontWeights.light}",
+							"lineHeight": "{lineHeights.3}",
+							"fontSize": "{fontSizes.figma.9.xl}",
+							"letterSpacing": "{letterSpacing.tight}"
+						},
+						"type": "typography"
+					},
+					"MAX": {
+						"value": {
+							"fontFamily": "{fontFamilies.sans}",
+							"fontWeight": "{fontWeights.light}",
+							"lineHeight": "{lineHeights.3}",
+							"fontSize": "{fontSizes.figma.9.max}",
+							"letterSpacing": "{letterSpacing.tight}"
+						},
+						"type": "typography"
+					}
+				},
+				"4-light": {
+					"S": {
+						"value": {
+							"fontFamily": "{fontFamilies.sans}",
+							"fontWeight": "{fontWeights.light}",
+							"lineHeight": "{lineHeights.2}",
+							"fontSize": "{fontSizes.figma.10.s}",
+							"letterSpacing": "{letterSpacing.tight}"
+						},
+						"type": "typography"
+					},
+					"M": {
+						"value": {
+							"fontFamily": "{fontFamilies.sans}",
+							"fontWeight": "{fontWeights.light}",
+							"lineHeight": "{lineHeights.2}",
+							"fontSize": "{fontSizes.figma.10.m}",
+							"letterSpacing": "{letterSpacing.tight}"
+						},
+						"type": "typography"
+					},
+					"L": {
+						"value": {
+							"fontFamily": "{fontFamilies.sans}",
+							"fontWeight": "{fontWeights.light}",
+							"lineHeight": "{lineHeights.2}",
+							"fontSize": "{fontSizes.figma.10.l}",
+							"letterSpacing": "{letterSpacing.tight}"
+						},
+						"type": "typography"
+					},
+					"XL": {
+						"value": {
+							"fontFamily": "{fontFamilies.sans}",
+							"fontWeight": "{fontWeights.light}",
+							"lineHeight": "{lineHeights.2}",
+							"fontSize": "{fontSizes.figma.10.xl}",
+							"letterSpacing": "{letterSpacing.tight}"
+						},
+						"type": "typography"
+					},
+					"MAX": {
+						"value": {
+							"fontFamily": "{fontFamilies.sans}",
+							"fontWeight": "{fontWeights.light}",
+							"lineHeight": "{lineHeights.2}",
+							"fontSize": "{fontSizes.figma.10.max}",
+							"letterSpacing": "{letterSpacing.tight}"
+						},
+						"type": "typography"
+					}
+				},
+				"5-light": {
+					"S": {
+						"value": {
+							"fontFamily": "{fontFamilies.sans}",
+							"fontWeight": "{fontWeights.light}",
+							"lineHeight": "{lineHeights.1}",
+							"fontSize": "{fontSizes.figma.11.s}",
+							"letterSpacing": "{letterSpacing.tight}"
+						},
+						"type": "typography"
+					},
+					"M": {
+						"value": {
+							"fontFamily": "{fontFamilies.sans}",
+							"fontWeight": "{fontWeights.light}",
+							"lineHeight": "{lineHeights.1}",
+							"fontSize": "{fontSizes.figma.11.m}",
+							"letterSpacing": "{letterSpacing.tight}"
+						},
+						"type": "typography"
+					},
+					"L": {
+						"value": {
+							"fontFamily": "{fontFamilies.sans}",
+							"fontWeight": "{fontWeights.light}",
+							"lineHeight": "{lineHeights.1}",
+							"fontSize": "{fontSizes.figma.11.l}",
+							"letterSpacing": "{letterSpacing.tight}"
+						},
+						"type": "typography"
+					},
+					"XL": {
+						"value": {
+							"fontFamily": "{fontFamilies.sans}",
+							"fontWeight": "{fontWeights.light}",
+							"lineHeight": "{lineHeights.1}",
+							"fontSize": "{fontSizes.figma.11.xl}",
+							"letterSpacing": "{letterSpacing.tight}"
+						},
+						"type": "typography"
+					},
+					"MAX": {
+						"value": {
+							"fontFamily": "{fontFamilies.sans}",
+							"fontWeight": "{fontWeights.light}",
+							"lineHeight": "{lineHeights.1}",
+							"fontSize": "{fontSizes.figma.11.max}",
+							"letterSpacing": "{letterSpacing.tight}"
+						},
+						"type": "typography"
+					}
+				},
+				"5-serif": {
+					"S": {
+						"value": {
+							"fontFamily": "{fontFamilies.display}",
+							"fontWeight": "{fontWeights.regular}",
+							"lineHeight": "{lineHeights.1}",
+							"fontSize": "{fontSizes.figma.11.s}",
+							"letterSpacing": "{letterSpacing.tight}"
+						},
+						"type": "typography"
+					},
+					"M": {
+						"value": {
+							"fontFamily": "{fontFamilies.display}",
+							"fontWeight": "{fontWeights.regular}",
+							"lineHeight": "{lineHeights.1}",
+							"fontSize": "{fontSizes.figma.11.m}",
+							"letterSpacing": "{letterSpacing.tight}"
+						},
+						"type": "typography"
+					},
+					"L": {
+						"value": {
+							"fontFamily": "{fontFamilies.display}",
+							"fontWeight": "{fontWeights.regular}",
+							"lineHeight": "{lineHeights.1}",
+							"fontSize": "{fontSizes.figma.11.l}",
+							"letterSpacing": "{letterSpacing.tight}"
+						},
+						"type": "typography"
+					},
+					"XL": {
+						"value": {
+							"fontFamily": "{fontFamilies.display}",
+							"fontWeight": "{fontWeights.regular}",
+							"lineHeight": "{lineHeights.1}",
+							"fontSize": "{fontSizes.figma.11.xl}",
+							"letterSpacing": "{letterSpacing.tight}"
+						},
+						"type": "typography"
+					},
+					"MAX": {
+						"value": {
+							"fontFamily": "{fontFamilies.display}",
+							"fontWeight": "{fontWeights.regular}",
+							"lineHeight": "{lineHeights.1}",
+							"fontSize": "{fontSizes.figma.11.max}",
+							"letterSpacing": "{letterSpacing.tight}"
+						},
+						"type": "typography"
+					}
+				},
+				"6-serif": {
+					"S": {
+						"value": {
+							"fontFamily": "{fontFamilies.display}",
+							"fontWeight": "{fontWeights.regular}",
+							"lineHeight": "{lineHeights.1}",
+							"fontSize": "{fontSizes.figma.12.s}",
+							"letterSpacing": "{letterSpacing.tight}"
+						},
+						"type": "typography"
+					},
+					"M": {
+						"value": {
+							"fontFamily": "{fontFamilies.display}",
+							"fontWeight": "{fontWeights.regular}",
+							"lineHeight": "{lineHeights.1}",
+							"fontSize": "{fontSizes.figma.12.m}",
+							"letterSpacing": "{letterSpacing.tight}"
+						},
+						"type": "typography"
+					},
+					"L": {
+						"value": {
+							"fontFamily": "{fontFamilies.display}",
+							"fontWeight": "{fontWeights.regular}",
+							"lineHeight": "{lineHeights.1}",
+							"fontSize": "{fontSizes.figma.12.l}",
+							"letterSpacing": "{letterSpacing.tight}"
+						},
+						"type": "typography"
+					},
+					"XL": {
+						"value": {
+							"fontFamily": "{fontFamilies.display}",
+							"fontWeight": "{fontWeights.regular}",
+							"lineHeight": "{lineHeights.1}",
+							"fontSize": "{fontSizes.figma.12.xl}",
+							"letterSpacing": "{letterSpacing.tight}"
+						},
+						"type": "typography"
+					},
+					"MAX": {
+						"value": {
+							"fontFamily": "{fontFamilies.display}",
+							"fontWeight": "{fontWeights.regular}",
+							"lineHeight": "{lineHeights.1}",
+							"fontSize": "{fontSizes.figma.12.max}",
+							"letterSpacing": "{letterSpacing.tight}"
+						},
+						"type": "typography"
+					}
+				},
+				"7-serif": {
+					"S": {
+						"value": {
+							"fontFamily": "{fontFamilies.display}",
+							"fontWeight": "{fontWeights.regular}",
+							"lineHeight": "{lineHeights.1}",
+							"fontSize": "{fontSizes.figma.13.s}",
+							"letterSpacing": "{letterSpacing.tight}"
+						},
+						"type": "typography"
+					},
+					"M": {
+						"value": {
+							"fontFamily": "{fontFamilies.display}",
+							"fontWeight": "{fontWeights.regular}",
+							"lineHeight": "{lineHeights.1}",
+							"fontSize": "{fontSizes.figma.13.m}",
+							"letterSpacing": "{letterSpacing.tight}"
+						},
+						"type": "typography"
+					},
+					"L": {
+						"value": {
+							"fontFamily": "{fontFamilies.display}",
+							"fontWeight": "{fontWeights.regular}",
+							"lineHeight": "{lineHeights.1}",
+							"fontSize": "{fontSizes.figma.13.l}",
+							"letterSpacing": "{letterSpacing.tight}"
+						},
+						"type": "typography"
+					},
+					"XL": {
+						"value": {
+							"fontFamily": "{fontFamilies.display}",
+							"fontWeight": "{fontWeights.regular}",
+							"lineHeight": "{lineHeights.1}",
+							"fontSize": "{fontSizes.figma.13.xl}",
+							"letterSpacing": "{letterSpacing.tight}"
+						},
+						"type": "typography"
+					},
+					"MAX": {
+						"value": {
+							"fontFamily": "{fontFamilies.display}",
+							"fontWeight": "{fontWeights.regular}",
+							"lineHeight": "{lineHeights.1}",
+							"fontSize": "{fontSizes.figma.13.max}",
+							"letterSpacing": "{letterSpacing.tight}"
+						},
+						"type": "typography"
+					}
+				}
+			},
+			"paragraph": {
+				"1": {
+					"S": {
+						"value": {
+							"fontFamily": "{fontFamilies.sans}",
+							"fontWeight": "{fontWeights.light}",
+							"lineHeight": "{lineHeights.4}",
+							"fontSize": "{fontSizes.figma.9.s}",
+							"letterSpacing": "{letterSpacing.tight}"
+						},
+						"type": "typography"
+					},
+					"M": {
+						"value": {
+							"fontFamily": "{fontFamilies.sans}",
+							"fontWeight": "{fontWeights.light}",
+							"lineHeight": "{lineHeights.4}",
+							"fontSize": "{fontSizes.figma.9.m}",
+							"letterSpacing": "{letterSpacing.tight}"
+						},
+						"type": "typography"
+					},
+					"L": {
+						"value": {
+							"fontFamily": "{fontFamilies.sans}",
+							"fontWeight": "{fontWeights.light}",
+							"lineHeight": "{lineHeights.4}",
+							"fontSize": "{fontSizes.figma.9.l}",
+							"letterSpacing": "{letterSpacing.tight}"
+						},
+						"type": "typography"
+					},
+					"XL": {
+						"value": {
+							"fontFamily": "{fontFamilies.sans}",
+							"fontWeight": "{fontWeights.light}",
+							"lineHeight": "{lineHeights.4}",
+							"fontSize": "{fontSizes.figma.9.xl}",
+							"letterSpacing": "{letterSpacing.tight}"
+						},
+						"type": "typography"
+					},
+					"MAX": {
+						"value": {
+							"fontFamily": "{fontFamilies.sans}",
+							"fontWeight": "{fontWeights.light}",
+							"lineHeight": "{lineHeights.4}",
+							"fontSize": "{fontSizes.figma.9.max}",
+							"letterSpacing": "{letterSpacing.tight}"
+						},
+						"type": "typography"
+					}
+				}
+			},
+			"quotation": {
+				"1": {
+					"S": {
+						"value": {
+							"fontFamily": "{fontFamilies.display}",
+							"fontWeight": "{fontWeights.regular}",
+							"lineHeight": "{lineHeights.4}",
+							"fontSize": "{fontSizes.figma.9.s}",
+							"letterSpacing": "{letterSpacing.tight}"
+						},
+						"type": "typography"
+					},
+					"M": {
+						"value": {
+							"fontFamily": "{fontFamilies.display}",
+							"fontWeight": "{fontWeights.regular}",
+							"lineHeight": "{lineHeights.4}",
+							"fontSize": "{fontSizes.figma.9.m}",
+							"letterSpacing": "{letterSpacing.tight}"
+						},
+						"type": "typography"
+					},
+					"L": {
+						"value": {
+							"fontFamily": "{fontFamilies.display}",
+							"fontWeight": "{fontWeights.regular}",
+							"lineHeight": "{lineHeights.4}",
+							"fontSize": "{fontSizes.figma.9.l}",
+							"letterSpacing": "{letterSpacing.tight}"
+						},
+						"type": "typography"
+					},
+					"XL": {
+						"value": {
+							"fontFamily": "{fontFamilies.display}",
+							"fontWeight": "{fontWeights.regular}",
+							"lineHeight": "{lineHeights.4}",
+							"fontSize": "{fontSizes.figma.9.xl}",
+							"letterSpacing": "{letterSpacing.tight}"
+						},
+						"type": "typography"
+					},
+					"MAX": {
+						"value": {
+							"fontFamily": "{fontFamilies.display}",
+							"fontWeight": "{fontWeights.regular}",
+							"lineHeight": "{lineHeights.4}",
+							"fontSize": "{fontSizes.figma.9.max}",
+							"letterSpacing": "{letterSpacing.tight}"
+						},
+						"type": "typography"
+					}
+				},
+				"2": {
+					"S": {
+						"value": {
+							"fontFamily": "{fontFamilies.display}",
+							"fontWeight": "{fontWeights.regular}",
+							"lineHeight": "{lineHeights.4}",
+							"fontSize": "{fontSizes.figma.10.s}",
+							"letterSpacing": "{letterSpacing.tight}"
+						},
+						"type": "typography"
+					},
+					"M": {
+						"value": {
+							"fontFamily": "{fontFamilies.display}",
+							"fontWeight": "{fontWeights.regular}",
+							"lineHeight": "{lineHeights.4}",
+							"fontSize": "{fontSizes.figma.10.m}",
+							"letterSpacing": "{letterSpacing.tight}"
+						},
+						"type": "typography"
+					},
+					"L": {
+						"value": {
+							"fontFamily": "{fontFamilies.display}",
+							"fontWeight": "{fontWeights.regular}",
+							"lineHeight": "{lineHeights.4}",
+							"fontSize": "{fontSizes.figma.10.l}",
+							"letterSpacing": "{letterSpacing.tight}"
+						},
+						"type": "typography"
+					},
+					"XL": {
+						"value": {
+							"fontFamily": "{fontFamilies.display}",
+							"fontWeight": "{fontWeights.regular}",
+							"lineHeight": "{lineHeights.4}",
+							"fontSize": "{fontSizes.figma.10.xl}",
+							"letterSpacing": "{letterSpacing.tight}"
+						},
+						"type": "typography"
+					},
+					"MAX": {
+						"value": {
+							"fontFamily": "{fontFamilies.display}",
+							"fontWeight": "{fontWeights.regular}",
+							"lineHeight": "{lineHeights.4}",
+							"fontSize": "{fontSizes.figma.10.max}",
+							"letterSpacing": "{letterSpacing.tight}"
+						},
+						"type": "typography"
+					}
+				},
+				"3": {
+					"S": {
+						"value": {
+							"fontFamily": "{fontFamilies.display}",
+							"fontWeight": "{fontWeights.regular}",
+							"lineHeight": "{lineHeights.3}",
+							"fontSize": "{fontSizes.figma.11.s}",
+							"letterSpacing": "{letterSpacing.tight}"
+						},
+						"type": "typography"
+					},
+					"M": {
+						"value": {
+							"fontFamily": "{fontFamilies.display}",
+							"fontWeight": "{fontWeights.regular}",
+							"lineHeight": "{lineHeights.3}",
+							"fontSize": "{fontSizes.figma.11.m}",
+							"letterSpacing": "{letterSpacing.tight}"
+						},
+						"type": "typography"
+					},
+					"L": {
+						"value": {
+							"fontFamily": "{fontFamilies.display}",
+							"fontWeight": "{fontWeights.regular}",
+							"lineHeight": "{lineHeights.3}",
+							"fontSize": "{fontSizes.figma.11.l}",
+							"letterSpacing": "{letterSpacing.tight}"
+						},
+						"type": "typography"
+					},
+					"XL": {
+						"value": {
+							"fontFamily": "{fontFamilies.display}",
+							"fontWeight": "{fontWeights.regular}",
+							"lineHeight": "{lineHeights.3}",
+							"fontSize": "{fontSizes.figma.11.xl}",
+							"letterSpacing": "{letterSpacing.tight}"
+						},
+						"type": "typography"
+					},
+					"MAX": {
+						"value": {
+							"fontFamily": "{fontFamilies.display}",
+							"fontWeight": "{fontWeights.regular}",
+							"lineHeight": "{lineHeights.3}",
+							"fontSize": "{fontSizes.figma.11.max}",
+							"letterSpacing": "{letterSpacing.tight}"
+						},
+						"type": "typography"
+					}
+				}
+			},
+			"caption": {
+				"1": {
+					"value": {
+						"fontFamily": "{fontFamilies.sans}",
+						"fontWeight": "{fontWeights.regular}",
+						"lineHeight": "{lineHeights.4}",
+						"fontSize": "{fontSizes.static.1}",
+						"letterSpacing": "{letterSpacing.loose}"
+					},
+					"type": "typography"
+				},
+				"2": {
+					"value": {
+						"fontFamily": "{fontFamilies.sans}",
+						"fontWeight": "{fontWeights.regular}",
+						"lineHeight": "{lineHeights.4}",
+						"fontSize": "{fontSizes.static.2}",
+						"letterSpacing": "{letterSpacing.loose}"
+					},
+					"type": "typography"
+				}
+			},
+			"code": {
+				"1": {
+					"value": {
+						"fontFamily": "{fontFamilies.sans}",
+						"fontWeight": "{fontWeights.regular}",
+						"lineHeight": "{lineHeights.4}",
+						"fontSize": "{fontSizes.static.2}"
+					},
+					"type": "typography"
+				},
+				"2": {
+					"value": {
+						"fontFamily": "{fontFamilies.sans}",
+						"fontWeight": "{fontWeights.regular}",
+						"lineHeight": "{lineHeights.4}",
+						"fontSize": "{fontSizes.static.3}"
+					},
+					"type": "typography"
+				}
+			},
+			"supporting": {
+				"helper-text": {
+					"1": {
+						"value": {
+							"fontFamily": "{fontFamilies.sans}",
+							"fontWeight": "{fontWeights.regular}",
+							"lineHeight": "{lineHeights.4}",
+							"fontSize": "{fontSizes.static.1}",
+							"letterSpacing": "{letterSpacing.loose}"
+						},
+						"type": "typography"
+					},
+					"1-caps": {
+						"value": {
+							"fontFamily": "{fontFamilies.sans}",
+							"fontWeight": "{fontWeights.regular}",
+							"lineHeight": "{lineHeights.4}",
+							"fontSize": "{fontSizes.static.1}",
+							"letterSpacing": "{letterSpacing.loose}",
+							"textCase": "{textCase.uppercase}"
+						},
+						"type": "typography"
+					}
+				},
+				"support-text": {
+					"1": {
+						"value": {
+							"fontFamily": "{fontFamilies.accent}",
+							"fontWeight": "{fontWeights.medium}",
+							"lineHeight": "{lineHeights.4}",
+							"fontSize": "{fontSizes.static.1}",
+							"letterSpacing": "{letterSpacing.loose}",
+							"textCase": "{textCase.uppercase}"
+						},
+						"type": "typography"
+					},
+					"2": {
+						"value": {
+							"fontFamily": "{fontFamilies.accent}",
+							"fontWeight": "{fontWeights.medium}",
+							"lineHeight": "{lineHeights.4}",
+							"fontSize": "{fontSizes.static.3}",
+							"letterSpacing": "{letterSpacing.loose}",
+							"textCase": "{textCase.uppercase}"
+						},
+						"type": "typography"
+					}
+				}
+			}
+		},
+		"fontFamilies": {
+			"sans": {
+				"value": "Aktiv Grotesk",
+				"type": "fontFamilies"
+			},
+			"serif": {
+				"value": "Ivar Text",
+				"type": "fontFamilies"
+			},
+			"display": {
+				"value": "Recoleta",
+				"type": "fontFamilies"
+			},
+			"accent": {
+				"value": "Aktiv Grotesk Ex",
+				"type": "fontFamilies"
+			}
+		}
+	},
+	"expressive-color-wpvip": {
+		"background": {
+			"primary": {
+				"value": "{Gold.3}",
+				"type": "color",
+				"description": "Use as main application background"
+			},
+			"inverse": {
+				"value": "{Black}",
+				"type": "color",
+				"description": "Use as component background in high-contrast situations. "
+			},
+			"brand": {
+				"value": "{Gold.30}",
+				"type": "color"
+			}
+		},
+		"layer": {
+			"1": {
+				"value": "{Gold.0}",
+				"type": "color"
+			},
+			"2": {
+				"value": "{Gradient.neutral-light-1}",
+				"type": "color"
+			},
+			"3": {
+				"value": "{Gold.0}",
+				"type": "color"
+			},
+			"4": {
+				"value": "{pure-white}",
+				"type": "color"
+			},
+			"accent": {
+				"neutral-1": {
+					"value": "{Gradient.neutral-light-1}",
+					"type": "color"
+				},
+				"neutral-2": {
+					"value": "{Gradient.neutral-light-2}",
+					"type": "color"
+				},
+				"neutral-3": {
+					"value": "{Gradient.neutral-light-3}",
+					"type": "color"
+				},
+				"neutral-4": {
+					"value": "{Gradient.neutral-light-4}",
+					"type": "color"
+				},
+				"brand": {
+					"value": "{Gold.30}",
+					"type": "color"
+				},
+				"gold": {
+					"value": "{Gold.20}",
+					"type": "color"
+				},
+				"pink": {
+					"value": "{Pink.20}",
+					"type": "color"
+				},
+				"red": {
+					"value": "{Red.30}",
+					"type": "color"
+				},
+				"salmon": {
+					"value": "{Salmon.25}",
+					"type": "color"
+				},
+				"orange": {
+					"value": "{Orange.25}",
+					"type": "color"
+				},
+				"yellow": {
+					"value": "{Yellow.20}",
+					"type": "color"
+				},
+				"green": {
+					"value": "{Green.25}",
+					"type": "color"
+				},
+				"blue": {
+					"value": "{Blue.25}",
+					"type": "color"
+				},
+				"colorful-1": {
+					"value": "{Gradient.colorful-light-1}",
+					"type": "color"
+				},
+				"colorful-2": {
+					"value": "{Gradient.colorful-light-2}",
+					"type": "color"
+				},
+				"colorful-3": {
+					"value": "{Gradient.colorful-light-3}",
+					"type": "color"
+				},
+				"colorful-4": {
+					"value": "{Gradient.colorful-light-4}",
+					"type": "color"
+				},
+				"dark-1": {
+					"value": "{Gradient.colorful-dark-1}",
+					"type": "color"
+				},
+				"dark-2": {
+					"value": "{Gradient.colorful-dark-2}",
+					"type": "color"
+				},
+				"black": {
+					"value": "{Black}",
+					"type": "color"
+				}
+			}
+		},
+		"field": {
+			"1": {
+				"value": "rgba(0,0,0,0)",
+				"type": "color"
+			},
+			"2": {
+				"value": "rgba(0,0,0,0)",
+				"type": "color"
+			},
+			"3": {
+				"value": "rgba(0,0,0,0)",
+				"type": "color"
+			},
+			"4": {
+				"value": "rgba(0,0,0,0)",
+				"type": "color"
+			}
+		},
+		"border": {
+			"1": {
+				"value": "{Black}",
+				"type": "color"
+			},
+			"2": {
+				"value": "{Gray.70}",
+				"type": "color"
+			},
+			"3": {
+				"value": "{Gray.25}",
+				"type": "color"
+			},
+			"4": {
+				"value": "{Gray.15}",
+				"type": "color"
+			},
+			"accent": {
+				"value": "{Gold.50}",
+				"type": "color"
+			}
+		},
+		"text": {
+			"primary": {
+				"value": "{Black}",
+				"type": "color",
+				"description": "Use for headings"
+			},
+			"secondary": {
+				"value": "{Gray.75}",
+				"type": "color",
+				"description": "Use for body text "
+			},
+			"helper": {
+				"value": "{Gray.60}",
+				"type": "color",
+				"description": "Use for helper text"
+			},
+			"placeholder": {
+				"value": "{Gray.45}",
+				"type": "color",
+				"description": "Use for placeholder text in fields"
+			},
+			"disabled": {
+				"value": "{Gray.25}",
+				"type": "color"
+			},
+			"inverse": {
+				"value": "{Gray.0}",
+				"type": "color"
+			},
+			"interactive": {
+				"value": "{Gold.60}",
+				"type": "color"
+			}
+		},
+		"link": {
+			"default": {
+				"value": "{Gold.60}",
+				"type": "color",
+				"description": "Use for text links"
+			},
+			"hover": {
+				"value": "{Gold.70}",
+				"type": "color"
+			},
+			"active": {
+				"value": "{Gold.80}",
+				"type": "color"
+			},
+			"visited": {
+				"value": "{Gold.70}",
+				"type": "color"
+			}
+		},
+		"icon": {
+			"primary": {
+				"value": "{Black}",
+				"type": "color"
+			},
+			"secondary": {
+				"value": "{Gray.60}",
+				"type": "color"
+			},
+			"helper": {
+				"value": "{Gray.40}",
+				"type": "color"
+			},
+			"inverse": {
+				"value": "{Gold.0}",
+				"type": "color"
+			},
+			"disabled": {
+				"value": "{Gray.25}",
+				"type": "color"
+			}
+		},
+		"button": {
+			"primary": {
+				"default": {
+					"value": "{Black}",
+					"type": "color"
+				},
+				"hover": {
+					"value": "{Gold.30}",
+					"type": "color"
+				},
+				"active": {
+					"value": "{Gold.50}",
+					"type": "color"
+				},
+				"disabled": {
+					"value": "{Gray.50}",
+					"type": "color"
+				}
+			},
+			"secondary": {
+				"default": {
+					"value": "rgba(0,0,0,0)",
+					"type": "color"
+				},
+				"hover": {
+					"value": "{Gold.30}",
+					"type": "color"
+				},
+				"active": {
+					"value": "{Gold.50}",
+					"type": "color"
+				},
+				"disabled": {
+					"value": "rgba(0,0,0,0)",
+					"type": "color"
+				}
+			},
+			"tertiary": {
+				"default": {
+					"value": "rgba(0,0,0,0)",
+					"type": "color"
+				},
+				"hover": {
+					"value": "{Gray.7}",
+					"type": "color"
+				},
+				"active": {
+					"value": "{Gray.25}",
+					"type": "color"
+				},
+				"disabled": {
+					"value": "rgba(0,0,0,0)",
+					"type": "color"
+				}
+			},
+			"display": {
+				"default": {
+					"value": "linear-gradient(55deg, {Gold.30} 10%, {Gold.20} 90%)",
+					"type": "color"
+				},
+				"hover": {
+					"value": "linear-gradient(55deg, {Gold.65} 10%, {Gold.45} 90%)",
+					"type": "color"
+				},
+				"active": {
+					"value": "{Gold.65}",
+					"type": "color"
+				},
+				"disabled": {
+					"value": "{Gray.50}",
+					"type": "color"
+				}
+			}
+		},
+		"support": {
+			"background": {
+				"error": {
+					"value": "{Red.7}",
+					"type": "color"
+				},
+				"warning": {
+					"value": "{Yellow.7}",
+					"type": "color"
+				},
+				"info": {
+					"value": "{Blue.7}",
+					"type": "color"
+				},
+				"success": {
+					"value": "{Green.7}",
+					"type": "color"
+				}
+			},
+			"text": {
+				"error": {
+					"value": "{Red.60}",
+					"type": "color"
+				},
+				"warning": {
+					"value": "{Yellow.60}",
+					"type": "color"
+				},
+				"info": {
+					"value": "{Blue.60}",
+					"type": "color"
+				},
+				"success": {
+					"value": "{Green.60}",
+					"type": "color"
+				}
+			},
+			"icon": {
+				"error": {
+					"value": "{Red.50}",
+					"type": "color"
+				},
+				"warning": {
+					"value": "{Yellow.50}",
+					"type": "color"
+				},
+				"info": {
+					"value": "{Blue.50}",
+					"type": "color"
+				},
+				"success": {
+					"value": "{Green.50}",
+					"type": "color"
+				}
+			},
+			"accent": {
+				"error": {
+					"value": "{Red.60}",
+					"type": "color"
+				},
+				"warning": {
+					"value": "{Yellow.60}",
+					"type": "color"
+				},
+				"info": {
+					"value": "{Blue.60}",
+					"type": "color"
+				},
+				"success": {
+					"value": "{Green.60}",
+					"type": "color"
+				}
+			},
+			"link": {
+				"error": {
+					"default": {
+						"value": "{Red.60}",
+						"type": "color",
+						"description": "Use for text links"
+					},
+					"hover": {
+						"value": "{Red.70}",
+						"type": "color"
+					},
+					"active": {
+						"value": "{Red.80}",
+						"type": "color"
+					},
+					"visited": {
+						"value": "{Red.80}",
+						"type": "color"
+					}
+				},
+				"warning": {
+					"default": {
+						"value": "{Yellow.60}",
+						"type": "color",
+						"description": "Use for text links"
+					},
+					"hover": {
+						"value": "{Yellow.70}",
+						"type": "color"
+					},
+					"active": {
+						"value": "{Yellow.80}",
+						"type": "color"
+					},
+					"visited": {
+						"value": "{Yellow.70}",
+						"type": "color"
+					}
+				},
+				"info": {
+					"default": {
+						"value": "{Blue.60}",
+						"type": "color",
+						"description": "Use for text links"
+					},
+					"hover": {
+						"value": "{Blue.70}",
+						"type": "color"
+					},
+					"active": {
+						"value": "{Blue.80}",
+						"type": "color"
+					},
+					"visited": {
+						"value": "{Blue.70}",
+						"type": "color"
+					}
+				},
+				"success": {
+					"default": {
+						"value": "{Green.60}",
+						"type": "color",
+						"description": "Use for text links"
+					},
+					"hover": {
+						"value": "{Green.70}",
+						"type": "color"
+					},
+					"active": {
+						"value": "{Green.80}",
+						"type": "color"
+					},
+					"visited": {
+						"value": "{Green.70}",
+						"type": "color"
+					}
+				}
+			}
+		},
+		"focus": {
+			"default": {
+				"value": "#0F62FE",
+				"type": "color"
+			},
+			"inset": {
+				"value": "#ffffff",
+				"type": "color"
+			}
+		},
+		"overlay": {
+			"value": "{Gray.55}",
+			"type": "color"
+		},
+		"interactive": {
+			"value": "{Gold.55}",
+			"type": "color"
+		},
+		"tag": {
+			"gray": {
+				"background": {
+					"value": "{Gray.7}",
+					"type": "color"
+				},
+				"text": {
+					"value": "{Black}",
+					"type": "color"
+				},
+				"icon": {
+					"value": "{Gray.65}",
+					"type": "color"
+				},
+				"hover": {
+					"value": "{Gray.15}",
+					"type": "color"
+				},
+				"active": {
+					"value": "{Gray.20}",
+					"type": "color"
+				}
+			},
+			"blue": {
+				"background": {
+					"value": "{Blue.7}",
+					"type": "color"
+				},
+				"text": {
+					"value": "{Black}",
+					"type": "color"
+				},
+				"icon": {
+					"value": "{Blue.65}",
+					"type": "color"
+				},
+				"hover": {
+					"value": "{Blue.15}",
+					"type": "color"
+				},
+				"active": {
+					"value": "{Blue.20}",
+					"type": "color"
+				}
+			},
+			"green": {
+				"background": {
+					"value": "{Green.7}",
+					"type": "color"
+				},
+				"text": {
+					"value": "{Black}",
+					"type": "color"
+				},
+				"icon": {
+					"value": "{Green.65}",
+					"type": "color"
+				},
+				"hover": {
+					"value": "{Green.15}",
+					"type": "color"
+				},
+				"active": {
+					"value": "{Green.20}",
+					"type": "color"
+				}
+			},
+			"red": {
+				"background": {
+					"value": "{Red.7}",
+					"type": "color"
+				},
+				"text": {
+					"value": "{Black}",
+					"type": "color"
+				},
+				"icon": {
+					"value": "{Red.65}",
+					"type": "color"
+				},
+				"hover": {
+					"value": "{Red.15}",
+					"type": "color"
+				},
+				"active": {
+					"value": "{Red.20}",
+					"type": "color"
+				}
+			},
+			"gold": {
+				"background": {
+					"value": "{Gold.7}",
+					"type": "color"
+				},
+				"text": {
+					"value": "{Black}",
+					"type": "color"
+				},
+				"icon": {
+					"value": "{Gold.65}",
+					"type": "color"
+				},
+				"hover": {
+					"value": "{Gold.15}",
+					"type": "color"
+				},
+				"active": {
+					"value": "{Gold.20}",
+					"type": "color"
+				}
+			},
+			"yellow": {
+				"background": {
+					"value": "{Yellow.7}",
+					"type": "color"
+				},
+				"text": {
+					"value": "{Black}",
+					"type": "color"
+				},
+				"icon": {
+					"value": "{Yellow.65}",
+					"type": "color"
+				},
+				"hover": {
+					"value": "{Yellow.15}",
+					"type": "color"
+				},
+				"active": {
+					"value": "{Yellow.20}",
+					"type": "color"
+				}
+			},
+			"orange": {
+				"background": {
+					"value": "{Orange.7}",
+					"type": "color"
+				},
+				"text": {
+					"value": "{Black}",
+					"type": "color"
+				},
+				"icon": {
+					"value": "{Orange.65}",
+					"type": "color"
+				},
+				"hover": {
+					"value": "{Orange.15}",
+					"type": "color"
+				},
+				"active": {
+					"value": "{Orange.20}",
+					"type": "color"
+				}
+			},
+			"salmon": {
+				"background": {
+					"value": "{Salmon.7}",
+					"type": "color"
+				},
+				"text": {
+					"value": "{Black}",
+					"type": "color"
+				},
+				"icon": {
+					"value": "{Salmon.65}",
+					"type": "color"
+				},
+				"hover": {
+					"value": "{Salmon.15}",
+					"type": "color"
+				},
+				"active": {
+					"value": "{Salmon.20}",
+					"type": "color"
+				}
+			},
+			"pink": {
+				"background": {
+					"value": "{Pink.7}",
+					"type": "color"
+				},
+				"text": {
+					"value": "{Black}",
+					"type": "color"
+				},
+				"icon": {
+					"value": "{Pink.65}",
+					"type": "color"
+				},
+				"hover": {
+					"value": "{Pink.15}",
+					"type": "color"
+				},
+				"active": {
+					"value": "{Pink.20}",
+					"type": "color"
+				}
+			}
+		}
+	},
+	"productive-color-wpvip": {
+		"background": {
+			"primary": {
+				"value": "{Gray.0}",
+				"type": "color",
+				"description": "Use as main application background"
+			},
+			"inverse": {
+				"value": "{Black}",
+				"type": "color",
+				"description": "Use as component background in high-contrast situations. "
+			},
+			"brand": {
+				"value": "{Gold.30}",
+				"type": "color"
+			}
+		},
+		"layer": {
+			"1": {
+				"value": "{Gray.3}",
+				"type": "color"
+			},
+			"2": {
+				"value": "{pure-white}",
+				"type": "color"
+			},
+			"3": {
+				"value": "{Gray.3}",
+				"type": "color"
+			},
+			"4": {
+				"value": "{pure-white}",
+				"type": "color"
+			},
+			"accent": {
+				"value": "{Gold.30}",
+				"type": "color"
+			}
+		},
+		"field": {
+			"1": {
+				"value": "{pure-white}",
+				"type": "color"
+			},
+			"2": {
+				"value": "{Gray.0}",
+				"type": "color"
+			},
+			"3": {
+				"value": "{Gray.3}",
+				"type": "color"
+			},
+			"4": {
+				"value": "{Gray.7}",
+				"type": "color"
+			}
+		},
+		"border": {
+			"1": {
+				"value": "{Gray.25}",
+				"type": "color"
+			},
+			"2": {
+				"value": "{Gray.10}",
+				"type": "color"
+			},
+			"3": {
+				"value": "{Gray.30}",
+				"type": "color"
+			},
+			"4": {
+				"value": "{Gray.25}",
+				"type": "color"
+			},
+			"accent": {
+				"value": "{Gold.50}",
+				"type": "color"
+			}
+		},
+		"text": {
+			"primary": {
+				"value": "{Black}",
+				"type": "color",
+				"description": "Use for headings"
+			},
+			"secondary": {
+				"value": "{Gray.70}",
+				"type": "color",
+				"description": "Use for body text "
+			},
+			"helper": {
+				"value": "{Gray.60}",
+				"type": "color",
+				"description": "Use for helper text"
+			},
+			"placeholder": {
+				"value": "{Gray.45}",
+				"type": "color",
+				"description": "Use for placeholder text in fields"
+			},
+			"disabled": {
+				"value": "{Gray.55}",
+				"type": "color"
+			},
+			"inverse": {
+				"value": "{Gray.0}",
+				"type": "color"
+			},
+			"interactive": {
+				"value": "{Gold.60}",
+				"type": "color"
+			}
+		},
+		"link": {
+			"default": {
+				"value": "{Gold.60}",
+				"type": "color",
+				"description": "Use for text links"
+			},
+			"hover": {
+				"value": "{Gold.70}",
+				"type": "color"
+			},
+			"active": {
+				"value": "{Gold.80}",
+				"type": "color"
+			},
+			"visited": {
+				"value": "{Gold.70}",
+				"type": "color"
+			}
+		},
+		"icon": {
+			"primary": {
+				"value": "{Gray.85}",
+				"type": "color"
+			},
+			"secondary": {
+				"value": "{Gray.50}",
+				"type": "color"
+			},
+			"helper": {
+				"value": "{Gray.40}",
+				"type": "color"
+			},
+			"inverse": {
+				"value": "{Gray.3}",
+				"type": "color"
+			},
+			"disabled": {
+				"value": "{Gray.45}",
+				"type": "color"
+			}
+		},
+		"button": {
+			"primary": {
+				"default": {
+					"value": "{Black}",
+					"type": "color"
+				},
+				"hover": {
+					"value": "{Gray.55}",
+					"type": "color"
+				}
+			},
+			"secondary": {
+				"default": {
+					"value": "{Gray.3}",
+					"type": "color"
+				},
+				"hover": {
+					"value": "{Gray.7}",
+					"type": "color"
+				}
+			},
+			"tertiary": {
+				"default": {
+					"value": "rgba(0,0,0,0)",
+					"type": "color"
+				},
+				"hover": {
+					"value": "{Gray.7}",
+					"type": "color"
+				}
+			}
+		},
+		"support": {
+			"background": {
+				"error": {
+					"value": "{Red.7}",
+					"type": "color"
+				},
+				"warning": {
+					"value": "{Yellow.7}",
+					"type": "color"
+				},
+				"info": {
+					"value": "{Blue.7}",
+					"type": "color"
+				},
+				"success": {
+					"value": "{Green.7}",
+					"type": "color"
+				}
+			},
+			"text": {
+				"error": {
+					"value": "{Red.85}",
+					"type": "color"
+				},
+				"warning": {
+					"value": "{Yellow.85}",
+					"type": "color"
+				},
+				"info": {
+					"value": "{Blue.85}",
+					"type": "color"
+				},
+				"success": {
+					"value": "{Green.85}",
+					"type": "color"
+				}
+			},
+			"icon": {
+				"error": {
+					"value": "{Red.50}",
+					"type": "color"
+				},
+				"warning": {
+					"value": "{Yellow.50}",
+					"type": "color"
+				},
+				"info": {
+					"value": "{Blue.50}",
+					"type": "color"
+				},
+				"success": {
+					"value": "{Green.50}",
+					"type": "color"
+				}
+			},
+			"accent": {
+				"error": {
+					"value": "{Red.35}",
+					"type": "color"
+				},
+				"warning": {
+					"value": "{Yellow.30}",
+					"type": "color"
+				},
+				"info": {
+					"value": "{Blue.35}",
+					"type": "color"
+				},
+				"success": {
+					"value": "{Green.35}",
+					"type": "color"
+				}
+			},
+			"link": {
+				"error": {
+					"default": {
+						"value": "{Red.60}",
+						"type": "color",
+						"description": "Use for text links"
+					},
+					"hover": {
+						"value": "{Red.70}",
+						"type": "color"
+					},
+					"active": {
+						"value": "{Red.80}",
+						"type": "color"
+					},
+					"visited": {
+						"value": "{Red.80}",
+						"type": "color"
+					}
+				},
+				"warning": {
+					"default": {
+						"value": "{Yellow.60}",
+						"type": "color",
+						"description": "Use for text links"
+					},
+					"hover": {
+						"value": "{Yellow.70}",
+						"type": "color"
+					},
+					"active": {
+						"value": "{Yellow.80}",
+						"type": "color"
+					},
+					"visited": {
+						"value": "{Yellow.70}",
+						"type": "color"
+					}
+				},
+				"info": {
+					"default": {
+						"value": "{Blue.60}",
+						"type": "color",
+						"description": "Use for text links"
+					},
+					"hover": {
+						"value": "{Blue.70}",
+						"type": "color"
+					},
+					"active": {
+						"value": "{Blue.80}",
+						"type": "color"
+					},
+					"visited": {
+						"value": "{Blue.70}",
+						"type": "color"
+					}
+				},
+				"success": {
+					"default": {
+						"value": "{Green.60}",
+						"type": "color",
+						"description": "Use for text links"
+					},
+					"hover": {
+						"value": "{Green.70}",
+						"type": "color"
+					},
+					"active": {
+						"value": "{Green.80}",
+						"type": "color"
+					},
+					"visited": {
+						"value": "{Green.70}",
+						"type": "color"
+					}
+				}
+			}
+		},
+		"focus": {
+			"default": {
+				"value": "#0F62FE",
+				"type": "color"
+			},
+			"inset": {
+				"value": "#ffffff",
+				"type": "color"
+			}
+		},
+		"overlay": {
+			"value": "{Gray.55}",
+			"type": "color"
+		},
+		"interactive": {
+			"value": "{Gold.55}",
+			"type": "color"
+		},
+		"tag": {
+			"gray": {
+				"background": {
+					"value": "{Gray.7}",
+					"type": "color"
+				},
+				"text": {
+					"value": "{Gray.85}",
+					"type": "color"
+				},
+				"icon": {
+					"value": "{Gray.65}",
+					"type": "color"
+				},
+				"hover": {
+					"value": "{Gray.15}",
+					"type": "color"
+				},
+				"active": {
+					"value": "{Gray.20}",
+					"type": "color"
+				}
+			},
+			"blue": {
+				"background": {
+					"value": "{Blue.7}",
+					"type": "color"
+				},
+				"text": {
+					"value": "{Blue.85}",
+					"type": "color"
+				},
+				"icon": {
+					"value": "{Blue.65}",
+					"type": "color"
+				},
+				"hover": {
+					"value": "{Blue.15}",
+					"type": "color"
+				},
+				"active": {
+					"value": "{Blue.20}",
+					"type": "color"
+				}
+			},
+			"green": {
+				"background": {
+					"value": "{Green.7}",
+					"type": "color"
+				},
+				"text": {
+					"value": "{Green.85}",
+					"type": "color"
+				},
+				"icon": {
+					"value": "{Green.65}",
+					"type": "color"
+				},
+				"hover": {
+					"value": "{Green.15}",
+					"type": "color"
+				},
+				"active": {
+					"value": "{Green.20}",
+					"type": "color"
+				}
+			},
+			"red": {
+				"background": {
+					"value": "{Red.7}",
+					"type": "color"
+				},
+				"text": {
+					"value": "{Red.85}",
+					"type": "color"
+				},
+				"icon": {
+					"value": "{Red.65}",
+					"type": "color"
+				},
+				"hover": {
+					"value": "{Red.15}",
+					"type": "color"
+				},
+				"active": {
+					"value": "{Red.20}",
+					"type": "color"
+				}
+			},
+			"gold": {
+				"background": {
+					"value": "{Gold.7}",
+					"type": "color"
+				},
+				"text": {
+					"value": "{Gold.85}",
+					"type": "color"
+				},
+				"icon": {
+					"value": "{Gold.65}",
+					"type": "color"
+				},
+				"hover": {
+					"value": "{Gold.15}",
+					"type": "color"
+				},
+				"active": {
+					"value": "{Gold.20}",
+					"type": "color"
+				}
+			},
+			"yellow": {
+				"background": {
+					"value": "{Yellow.7}",
+					"type": "color"
+				},
+				"text": {
+					"value": "{Yellow.85}",
+					"type": "color"
+				},
+				"icon": {
+					"value": "{Yellow.65}",
+					"type": "color"
+				},
+				"hover": {
+					"value": "{Yellow.15}",
+					"type": "color"
+				},
+				"active": {
+					"value": "{Yellow.20}",
+					"type": "color"
+				}
+			},
+			"orange": {
+				"background": {
+					"value": "{Orange.7}",
+					"type": "color"
+				},
+				"text": {
+					"value": "{Orange.85}",
+					"type": "color"
+				},
+				"icon": {
+					"value": "{Orange.65}",
+					"type": "color"
+				},
+				"hover": {
+					"value": "{Orange.15}",
+					"type": "color"
+				},
+				"active": {
+					"value": "{Orange.20}",
+					"type": "color"
+				}
+			},
+			"salmon": {
+				"background": {
+					"value": "{Salmon.7}",
+					"type": "color"
+				},
+				"text": {
+					"value": "{Salmon.85}",
+					"type": "color"
+				},
+				"icon": {
+					"value": "{Salmon.65}",
+					"type": "color"
+				},
+				"hover": {
+					"value": "{Salmon.15}",
+					"type": "color"
+				},
+				"active": {
+					"value": "{Salmon.20}",
+					"type": "color"
+				}
+			},
+			"pink": {
+				"background": {
+					"value": "{Pink.7}",
+					"type": "color"
+				},
+				"text": {
+					"value": "{Pink.85}",
+					"type": "color"
+				},
+				"icon": {
+					"value": "{Pink.65}",
+					"type": "color"
+				},
+				"hover": {
+					"value": "{Pink.15}",
+					"type": "color"
+				},
+				"active": {
+					"value": "{Pink.20}",
+					"type": "color"
+				}
+			}
+		}
+	},
+	"expressive-color-valet": {
+		"background": {
+			"primary": {
+				"value": "{Gray.3}",
+				"type": "color",
+				"description": "Use as main application background"
+			},
+			"inverse": {
+				"value": "{Black}",
+				"type": "color",
+				"description": "Use as component background in high-contrast situations. "
+			},
+			"brand": {
+				"value": "{Blue.30}",
+				"type": "color"
+			}
+		},
+		"layer": {
+			"1": {
+				"value": "{Gray.0}",
+				"type": "color"
+			},
+			"2": {
+				"value": "{Gray.3}",
+				"type": "color"
+			},
+			"3": {
+				"value": "{Gray.0}",
+				"type": "color"
+			},
+			"4": {
+				"value": "{pure-white}",
+				"type": "color"
+			},
+			"accent": {
+				"neutral-1": {
+					"value": "{Gradient.neutral-light-1}",
+					"type": "color"
+				},
+				"neutral-2": {
+					"value": "{Gradient.neutral-light-2}",
+					"type": "color"
+				},
+				"neutral-3": {
+					"value": "{Gradient.neutral-light-3}",
+					"type": "color"
+				},
+				"neutral-4": {
+					"value": "{Gradient.neutral-light-4}",
+					"type": "color"
+				},
+				"brand": {
+					"value": "{Blue.30}",
+					"type": "color"
+				},
+				"gold": {
+					"value": "{Gold.20}",
+					"type": "color"
+				},
+				"pink": {
+					"value": "{Pink.20}",
+					"type": "color"
+				},
+				"red": {
+					"value": "{Red.30}",
+					"type": "color"
+				},
+				"salmon": {
+					"value": "{Salmon.25}",
+					"type": "color"
+				},
+				"orange": {
+					"value": "{Orange.25}",
+					"type": "color"
+				},
+				"yellow": {
+					"value": "{Yellow.20}",
+					"type": "color"
+				},
+				"green": {
+					"value": "{Green.25}",
+					"type": "color"
+				},
+				"blue": {
+					"value": "{Blue.25}",
+					"type": "color"
+				},
+				"colorful-1": {
+					"value": "{Gradient.colorful-light-1}",
+					"type": "color"
+				},
+				"colorful-2": {
+					"value": "{Gradient.colorful-light-2}",
+					"type": "color"
+				},
+				"colorful-3": {
+					"value": "{Gradient.colorful-light-3}",
+					"type": "color"
+				},
+				"colorful-4": {
+					"value": "{Gradient.colorful-light-4}",
+					"type": "color"
+				},
+				"dark-1": {
+					"value": "{Gradient.colorful-dark-1}",
+					"type": "color"
+				},
+				"dark-2": {
+					"value": "{Gradient.colorful-dark-2}",
+					"type": "color"
+				},
+				"black": {
+					"value": "{Black}",
+					"type": "color"
+				}
+			}
+		},
+		"field": {
+			"1": {
+				"value": "rgba(0,0,0,0)",
+				"type": "color"
+			},
+			"2": {
+				"value": "rgba(0,0,0,0)",
+				"type": "color"
+			},
+			"3": {
+				"value": "rgba(0,0,0,0)",
+				"type": "color"
+			},
+			"4": {
+				"value": "rgba(0,0,0,0)",
+				"type": "color"
+			}
+		},
+		"border": {
+			"1": {
+				"value": "{Black}",
+				"type": "color"
+			},
+			"2": {
+				"value": "{Gray.70}",
+				"type": "color"
+			},
+			"3": {
+				"value": "{Gray.25}",
+				"type": "color"
+			},
+			"4": {
+				"value": "{Gray.15}",
+				"type": "color"
+			},
+			"accent": {
+				"value": "{Blue.50}",
+				"type": "color"
+			}
+		},
+		"text": {
+			"primary": {
+				"value": "{Black}",
+				"type": "color",
+				"description": "Use for headings"
+			},
+			"secondary": {
+				"value": "{Gray.75}",
+				"type": "color",
+				"description": "Use for body text "
+			},
+			"helper": {
+				"value": "{Gray.60}",
+				"type": "color",
+				"description": "Use for helper text"
+			},
+			"placeholder": {
+				"value": "{Gray.45}",
+				"type": "color",
+				"description": "Use for placeholder text in fields"
+			},
+			"disabled": {
+				"value": "{Gray.25}",
+				"type": "color"
+			},
+			"inverse": {
+				"value": "{Gray.0}",
+				"type": "color"
+			},
+			"interactive": {
+				"value": "{Blue.60}",
+				"type": "color"
+			}
+		},
+		"link": {
+			"default": {
+				"value": "{Blue.60}",
+				"type": "color",
+				"description": "Use for text links"
+			},
+			"hover": {
+				"value": "{Blue.70}",
+				"type": "color"
+			},
+			"active": {
+				"value": "{Blue.80}",
+				"type": "color"
+			},
+			"visited": {
+				"value": "{Blue.70}",
+				"type": "color"
+			}
+		},
+		"icon": {
+			"primary": {
+				"value": "{Black}",
+				"type": "color"
+			},
+			"secondary": {
+				"value": "{Gray.60}",
+				"type": "color"
+			},
+			"helper": {
+				"value": "{Gray.40}",
+				"type": "color"
+			},
+			"inverse": {
+				"value": "{Gray.0}",
+				"type": "color"
+			},
+			"disabled": {
+				"value": "{Gray.25}",
+				"type": "color"
+			}
+		},
+		"button": {
+			"primary": {
+				"default": {
+					"value": "{Black}",
+					"type": "color"
+				},
+				"hover": {
+					"value": "{Blue.30}",
+					"type": "color"
+				},
+				"active": {
+					"value": "{Blue.50}",
+					"type": "color"
+				},
+				"disabled": {
+					"value": "{Gray.50}",
+					"type": "color"
+				}
+			},
+			"secondary": {
+				"default": {
+					"value": "rgba(0,0,0,0)",
+					"type": "color"
+				},
+				"hover": {
+					"value": "{Blue.30}",
+					"type": "color"
+				},
+				"active": {
+					"value": "{Blue.50}",
+					"type": "color"
+				},
+				"disabled": {
+					"value": "rgba(0,0,0,0)",
+					"type": "color"
+				}
+			},
+			"tertiary": {
+				"default": {
+					"value": "rgba(0,0,0,0)",
+					"type": "color"
+				},
+				"hover": {
+					"value": "{Gray.7}",
+					"type": "color"
+				},
+				"active": {
+					"value": "{Gray.25}",
+					"type": "color"
+				},
+				"disabled": {
+					"value": "rgba(0,0,0,0)",
+					"type": "color"
+				}
+			},
+			"display": {
+				"default": {
+					"value": "linear-gradient(55deg, {Blue.30} 10%, {Blue.20} 90%)",
+					"type": "color"
+				},
+				"hover": {
+					"value": "linear-gradient(55deg, {Blue.65} 10%, {Blue.45} 90%)",
+					"type": "color"
+				},
+				"active": {
+					"value": "{Blue.65}",
+					"type": "color"
+				},
+				"disabled": {
+					"value": "{Gray.50}",
+					"type": "color"
+				}
+			}
+		},
+		"support": {
+			"background": {
+				"error": {
+					"value": "{Red.7}",
+					"type": "color"
+				},
+				"warning": {
+					"value": "{Yellow.7}",
+					"type": "color"
+				},
+				"info": {
+					"value": "{Blue.7}",
+					"type": "color"
+				},
+				"success": {
+					"value": "{Green.7}",
+					"type": "color"
+				}
+			},
+			"text": {
+				"error": {
+					"value": "{Red.60}",
+					"type": "color"
+				},
+				"warning": {
+					"value": "{Yellow.60}",
+					"type": "color"
+				},
+				"info": {
+					"value": "{Blue.60}",
+					"type": "color"
+				},
+				"success": {
+					"value": "{Green.60}",
+					"type": "color"
+				}
+			},
+			"icon": {
+				"error": {
+					"value": "{Red.50}",
+					"type": "color"
+				},
+				"warning": {
+					"value": "{Yellow.50}",
+					"type": "color"
+				},
+				"info": {
+					"value": "{Blue.50}",
+					"type": "color"
+				},
+				"success": {
+					"value": "{Green.50}",
+					"type": "color"
+				}
+			},
+			"accent": {
+				"error": {
+					"value": "{Red.60}",
+					"type": "color"
+				},
+				"warning": {
+					"value": "{Yellow.60}",
+					"type": "color"
+				},
+				"info": {
+					"value": "{Blue.60}",
+					"type": "color"
+				},
+				"success": {
+					"value": "{Green.60}",
+					"type": "color"
+				}
+			},
+			"link": {
+				"error": {
+					"default": {
+						"value": "{Red.60}",
+						"type": "color",
+						"description": "Use for text links"
+					},
+					"hover": {
+						"value": "{Red.70}",
+						"type": "color"
+					},
+					"active": {
+						"value": "{Red.80}",
+						"type": "color"
+					},
+					"visited": {
+						"value": "{Red.80}",
+						"type": "color"
+					}
+				},
+				"warning": {
+					"default": {
+						"value": "{Yellow.60}",
+						"type": "color",
+						"description": "Use for text links"
+					},
+					"hover": {
+						"value": "{Yellow.70}",
+						"type": "color"
+					},
+					"active": {
+						"value": "{Yellow.80}",
+						"type": "color"
+					},
+					"visited": {
+						"value": "{Yellow.70}",
+						"type": "color"
+					}
+				},
+				"info": {
+					"default": {
+						"value": "{Blue.60}",
+						"type": "color",
+						"description": "Use for text links"
+					},
+					"hover": {
+						"value": "{Blue.70}",
+						"type": "color"
+					},
+					"active": {
+						"value": "{Blue.80}",
+						"type": "color"
+					},
+					"visited": {
+						"value": "{Blue.70}",
+						"type": "color"
+					}
+				},
+				"success": {
+					"default": {
+						"value": "{Green.60}",
+						"type": "color",
+						"description": "Use for text links"
+					},
+					"hover": {
+						"value": "{Green.70}",
+						"type": "color"
+					},
+					"active": {
+						"value": "{Green.80}",
+						"type": "color"
+					},
+					"visited": {
+						"value": "{Green.70}",
+						"type": "color"
+					}
+				}
+			}
+		},
+		"focus": {
+			"default": {
+				"value": "#0F62FE",
+				"type": "color"
+			},
+			"inset": {
+				"value": "#ffffff",
+				"type": "color"
+			}
+		},
+		"overlay": {
+			"value": "{Gray.55}",
+			"type": "color"
+		},
+		"interactive": {
+			"value": "{Blue.55}",
+			"type": "color"
+		},
+		"tag": {
+			"gray": {
+				"background": {
+					"value": "{Gray.7}",
+					"type": "color"
+				},
+				"text": {
+					"value": "{Black}",
+					"type": "color"
+				},
+				"icon": {
+					"value": "{Gray.65}",
+					"type": "color"
+				},
+				"hover": {
+					"value": "{Gray.15}",
+					"type": "color"
+				},
+				"active": {
+					"value": "{Gray.20}",
+					"type": "color"
+				}
+			},
+			"blue": {
+				"background": {
+					"value": "{Blue.7}",
+					"type": "color"
+				},
+				"text": {
+					"value": "{Black}",
+					"type": "color"
+				},
+				"icon": {
+					"value": "{Blue.65}",
+					"type": "color"
+				},
+				"hover": {
+					"value": "{Blue.15}",
+					"type": "color"
+				},
+				"active": {
+					"value": "{Blue.20}",
+					"type": "color"
+				}
+			},
+			"green": {
+				"background": {
+					"value": "{Green.7}",
+					"type": "color"
+				},
+				"text": {
+					"value": "{Black}",
+					"type": "color"
+				},
+				"icon": {
+					"value": "{Green.65}",
+					"type": "color"
+				},
+				"hover": {
+					"value": "{Green.15}",
+					"type": "color"
+				},
+				"active": {
+					"value": "{Green.20}",
+					"type": "color"
+				}
+			},
+			"red": {
+				"background": {
+					"value": "{Red.7}",
+					"type": "color"
+				},
+				"text": {
+					"value": "{Black}",
+					"type": "color"
+				},
+				"icon": {
+					"value": "{Red.65}",
+					"type": "color"
+				},
+				"hover": {
+					"value": "{Red.15}",
+					"type": "color"
+				},
+				"active": {
+					"value": "{Red.20}",
+					"type": "color"
+				}
+			},
+			"gold": {
+				"background": {
+					"value": "{Gold.7}",
+					"type": "color"
+				},
+				"text": {
+					"value": "{Black}",
+					"type": "color"
+				},
+				"icon": {
+					"value": "{Gold.65}",
+					"type": "color"
+				},
+				"hover": {
+					"value": "{Gold.15}",
+					"type": "color"
+				},
+				"active": {
+					"value": "{Gold.20}",
+					"type": "color"
+				}
+			},
+			"yellow": {
+				"background": {
+					"value": "{Yellow.7}",
+					"type": "color"
+				},
+				"text": {
+					"value": "{Black}",
+					"type": "color"
+				},
+				"icon": {
+					"value": "{Yellow.65}",
+					"type": "color"
+				},
+				"hover": {
+					"value": "{Yellow.15}",
+					"type": "color"
+				},
+				"active": {
+					"value": "{Yellow.20}",
+					"type": "color"
+				}
+			},
+			"orange": {
+				"background": {
+					"value": "{Orange.7}",
+					"type": "color"
+				},
+				"text": {
+					"value": "{Black}",
+					"type": "color"
+				},
+				"icon": {
+					"value": "{Orange.65}",
+					"type": "color"
+				},
+				"hover": {
+					"value": "{Orange.15}",
+					"type": "color"
+				},
+				"active": {
+					"value": "{Orange.20}",
+					"type": "color"
+				}
+			},
+			"salmon": {
+				"background": {
+					"value": "{Salmon.7}",
+					"type": "color"
+				},
+				"text": {
+					"value": "{Black}",
+					"type": "color"
+				},
+				"icon": {
+					"value": "{Salmon.65}",
+					"type": "color"
+				},
+				"hover": {
+					"value": "{Salmon.15}",
+					"type": "color"
+				},
+				"active": {
+					"value": "{Salmon.20}",
+					"type": "color"
+				}
+			},
+			"pink": {
+				"background": {
+					"value": "{Pink.7}",
+					"type": "color"
+				},
+				"text": {
+					"value": "{Black}",
+					"type": "color"
+				},
+				"icon": {
+					"value": "{Pink.65}",
+					"type": "color"
+				},
+				"hover": {
+					"value": "{Pink.15}",
+					"type": "color"
+				},
+				"active": {
+					"value": "{Pink.20}",
+					"type": "color"
+				}
+			}
+		}
+	},
+	"expressive-type-valet": {
+		"expressive": {
+			"body": {
+				"1-short": {
+					"value": {
+						"fontFamily": "{fontFamilies.sans}",
+						"fontWeight": "{fontWeights.regular}",
+						"lineHeight": "{lineHeights.4}",
+						"fontSize": "{fontSizes.static.2}"
+					},
+					"type": "typography"
+				},
+				"1-short-medium": {
+					"value": {
+						"fontFamily": "{fontFamilies.sans}",
+						"fontWeight": "{fontWeights.medium}",
+						"lineHeight": "{lineHeights.4}",
+						"fontSize": "{fontSizes.static.2}"
+					},
+					"type": "typography"
+				},
+				"1-short-caps": {
+					"value": {
+						"fontFamily": "{fontFamilies.sans}",
+						"fontWeight": "{fontWeights.regular}",
+						"lineHeight": "{lineHeights.4}",
+						"fontSize": "{fontSizes.static.2}",
+						"textCase": "uppercase"
+					},
+					"type": "typography"
+				},
+				"2-short": {
+					"value": {
+						"fontFamily": "{fontFamilies.sans}",
+						"fontWeight": "{fontWeights.regular}",
+						"lineHeight": "{lineHeights.4}",
+						"fontSize": "{fontSizes.static.3}"
+					},
+					"type": "typography"
+				},
+				"2-short-medium": {
+					"value": {
+						"fontFamily": "{fontFamilies.sans}",
+						"fontWeight": "{fontWeights.bold}",
+						"lineHeight": "{lineHeights.4}",
+						"fontSize": "{fontSizes.static.3}"
+					},
+					"type": "typography"
+				},
+				"3-short": {
+					"value": {
+						"fontFamily": "{fontFamilies.sans}",
+						"fontWeight": "{fontWeights.regular}",
+						"lineHeight": "{lineHeights.4}",
+						"fontSize": "{fontSizes.static.4}"
+					},
+					"type": "typography"
+				},
+				"4-short": {
+					"value": {
+						"fontFamily": "{fontFamilies.sans}",
+						"fontWeight": "{fontWeights.light}",
+						"lineHeight": "{lineHeights.4}",
+						"fontSize": "{fontSizes.static.5}"
+					},
+					"type": "typography"
+				},
+				"4-serif": {
+					"value": {
+						"fontFamily": "{fontFamilies.serif}",
+						"fontWeight": "{fontWeights.regular}",
+						"lineHeight": "{lineHeights.5}",
+						"fontSize": "{fontSizes.static.5}"
+					},
+					"type": "typography"
+				}
+			},
+			"heading": {
+				"1": {
+					"S": {
+						"value": {
+							"fontFamily": "{fontFamilies.sans}",
+							"fontWeight": "{fontWeights.regular}",
+							"lineHeight": "{lineHeights.3}",
+							"fontSize": "{fontSizes.figma.4.s}",
+							"letterSpacing": "{letterSpacing.tight}"
+						},
+						"type": "typography"
+					},
+					"M": {
+						"value": {
+							"fontFamily": "{fontFamilies.sans}",
+							"fontWeight": "{fontWeights.regular}",
+							"lineHeight": "{lineHeights.3}",
+							"fontSize": "{fontSizes.figma.4.m}",
+							"letterSpacing": "{letterSpacing.tight}"
+						},
+						"type": "typography"
+					},
+					"L": {
+						"value": {
+							"fontFamily": "{fontFamilies.sans}",
+							"fontWeight": "{fontWeights.regular}",
+							"lineHeight": "{lineHeights.3}",
+							"fontSize": "{fontSizes.figma.4.l}",
+							"letterSpacing": "{letterSpacing.tight}"
+						},
+						"type": "typography"
+					},
+					"XL": {
+						"value": {
+							"fontFamily": "{fontFamilies.sans}",
+							"fontWeight": "{fontWeights.regular}",
+							"lineHeight": "{lineHeights.3}",
+							"fontSize": "{fontSizes.figma.4.xl}",
+							"letterSpacing": "{letterSpacing.tight}"
+						},
+						"type": "typography"
+					},
+					"MAX": {
+						"value": {
+							"fontFamily": "{fontFamilies.sans}",
+							"fontWeight": "{fontWeights.regular}",
+							"lineHeight": "{lineHeights.3}",
+							"fontSize": "{fontSizes.figma.4.max}",
+							"letterSpacing": "{letterSpacing.tight}"
+						},
+						"type": "typography"
+					}
+				},
+				"2": {
+					"S": {
+						"value": {
+							"fontFamily": "{fontFamilies.sans}",
+							"fontWeight": "{fontWeights.regular}",
+							"lineHeight": "{lineHeights.2}",
+							"fontSize": "{fontSizes.figma.8.s}",
+							"letterSpacing": "{letterSpacing.tight}"
+						},
+						"type": "typography"
+					},
+					"M": {
+						"value": {
+							"fontFamily": "{fontFamilies.sans}",
+							"fontWeight": "{fontWeights.regular}",
+							"lineHeight": "{lineHeights.2}",
+							"fontSize": "{fontSizes.figma.8.m}",
+							"letterSpacing": "{letterSpacing.tight}"
+						},
+						"type": "typography"
+					},
+					"L": {
+						"value": {
+							"fontFamily": "{fontFamilies.sans}",
+							"fontWeight": "{fontWeights.regular}",
+							"lineHeight": "{lineHeights.2}",
+							"fontSize": "{fontSizes.figma.8.l}",
+							"letterSpacing": "{letterSpacing.tight}"
+						},
+						"type": "typography"
+					},
+					"XL": {
+						"value": {
+							"fontFamily": "{fontFamilies.sans}",
+							"fontWeight": "{fontWeights.regular}",
+							"lineHeight": "{lineHeights.2}",
+							"fontSize": "{fontSizes.figma.8.xl}",
+							"letterSpacing": "{letterSpacing.tight}"
+						},
+						"type": "typography"
+					},
+					"MAX": {
+						"value": {
+							"fontFamily": "{fontFamilies.sans}",
+							"fontWeight": "{fontWeights.regular}",
+							"lineHeight": "{lineHeights.2}",
+							"fontSize": "{fontSizes.figma.8.max}",
+							"letterSpacing": "{letterSpacing.tight}"
+						},
+						"type": "typography"
+					}
+				},
+				"3": {
+					"S": {
+						"value": {
+							"fontFamily": "{fontFamilies.sans}",
+							"fontWeight": "{fontWeights.regular}",
+							"lineHeight": "{lineHeights.3}",
+							"fontSize": "{fontSizes.figma.9.s}",
+							"letterSpacing": "{letterSpacing.tight}"
+						},
+						"type": "typography"
+					},
+					"M": {
+						"value": {
+							"fontFamily": "{fontFamilies.sans}",
+							"fontWeight": "{fontWeights.regular}",
+							"lineHeight": "{lineHeights.3}",
+							"fontSize": "{fontSizes.figma.9.m}",
+							"letterSpacing": "{letterSpacing.tight}"
+						},
+						"type": "typography"
+					},
+					"L": {
+						"value": {
+							"fontFamily": "{fontFamilies.sans}",
+							"fontWeight": "{fontWeights.regular}",
+							"lineHeight": "{lineHeights.3}",
+							"fontSize": "{fontSizes.figma.9.l}",
+							"letterSpacing": "{letterSpacing.tight}"
+						},
+						"type": "typography"
+					},
+					"XL": {
+						"value": {
+							"fontFamily": "{fontFamilies.sans}",
+							"fontWeight": "{fontWeights.regular}",
+							"lineHeight": "{lineHeights.3}",
+							"fontSize": "{fontSizes.figma.9.xl}",
+							"letterSpacing": "{letterSpacing.tight}"
+						},
+						"type": "typography"
+					},
+					"MAX": {
+						"value": {
+							"fontFamily": "{fontFamilies.sans}",
+							"fontWeight": "{fontWeights.regular}",
+							"lineHeight": "{lineHeights.3}",
+							"fontSize": "{fontSizes.figma.9.max}",
+							"letterSpacing": "{letterSpacing.tight}"
+						},
+						"type": "typography"
+					}
+				},
+				"4": {
+					"S": {
+						"value": {
+							"fontFamily": "{fontFamilies.sans}",
+							"fontWeight": "{fontWeights.regular}",
+							"lineHeight": "{lineHeights.2}",
+							"fontSize": "{fontSizes.figma.10.s}",
+							"letterSpacing": "{letterSpacing.tight}"
+						},
+						"type": "typography"
+					},
+					"M": {
+						"value": {
+							"fontFamily": "{fontFamilies.sans}",
+							"fontWeight": "{fontWeights.regular}",
+							"lineHeight": "{lineHeights.2}",
+							"fontSize": "{fontSizes.figma.10.m}",
+							"letterSpacing": "{letterSpacing.tight}"
+						},
+						"type": "typography"
+					},
+					"L": {
+						"value": {
+							"fontFamily": "{fontFamilies.sans}",
+							"fontWeight": "{fontWeights.regular}",
+							"lineHeight": "{lineHeights.2}",
+							"fontSize": "{fontSizes.figma.10.l}",
+							"letterSpacing": "{letterSpacing.tight}"
+						},
+						"type": "typography"
+					},
+					"XL": {
+						"value": {
+							"fontFamily": "{fontFamilies.sans}",
+							"fontWeight": "{fontWeights.regular}",
+							"lineHeight": "{lineHeights.2}",
+							"fontSize": "{fontSizes.figma.10.xl}",
+							"letterSpacing": "{letterSpacing.tight}"
+						},
+						"type": "typography"
+					},
+					"MAX": {
+						"value": {
+							"fontFamily": "{fontFamilies.sans}",
+							"fontWeight": "{fontWeights.regular}",
+							"lineHeight": "{lineHeights.2}",
+							"fontSize": "{fontSizes.figma.10.max}",
+							"letterSpacing": "{letterSpacing.tight}"
+						},
+						"type": "typography"
+					}
+				},
+				"5": {
+					"S": {
+						"value": {
+							"fontFamily": "{fontFamilies.sans}",
+							"fontWeight": "{fontWeights.regular}",
+							"lineHeight": "{lineHeights.1}",
+							"fontSize": "{fontSizes.figma.11.s}",
+							"letterSpacing": "{letterSpacing.tight}"
+						},
+						"type": "typography"
+					},
+					"M": {
+						"value": {
+							"fontFamily": "{fontFamilies.sans}",
+							"fontWeight": "{fontWeights.regular}",
+							"lineHeight": "{lineHeights.1}",
+							"fontSize": "{fontSizes.figma.11.m}",
+							"letterSpacing": "{letterSpacing.tight}"
+						},
+						"type": "typography"
+					},
+					"L": {
+						"value": {
+							"fontFamily": "{fontFamilies.sans}",
+							"fontWeight": "{fontWeights.regular}",
+							"lineHeight": "{lineHeights.1}",
+							"fontSize": "{fontSizes.figma.11.l}",
+							"letterSpacing": "{letterSpacing.tight}"
+						},
+						"type": "typography"
+					},
+					"XL": {
+						"value": {
+							"fontFamily": "{fontFamilies.sans}",
+							"fontWeight": "{fontWeights.regular}",
+							"lineHeight": "{lineHeights.1}",
+							"fontSize": "{fontSizes.figma.11.xl}",
+							"letterSpacing": "{letterSpacing.tight}"
+						},
+						"type": "typography"
+					},
+					"MAX": {
+						"value": {
+							"fontFamily": "{fontFamilies.sans}",
+							"fontWeight": "{fontWeights.regular}",
+							"lineHeight": "{lineHeights.1}",
+							"fontSize": "{fontSizes.figma.11.max}",
+							"letterSpacing": "{letterSpacing.tight}"
+						},
+						"type": "typography"
+					}
+				},
+				"6": {
+					"S": {
+						"value": {
+							"fontFamily": "{fontFamilies.sans}",
+							"fontWeight": "{fontWeights.regular}",
+							"lineHeight": "{lineHeights.1}",
+							"fontSize": "{fontSizes.figma.12.s}",
+							"letterSpacing": "{letterSpacing.tight}"
+						},
+						"type": "typography"
+					},
+					"M": {
+						"value": {
+							"fontFamily": "{fontFamilies.sans}",
+							"fontWeight": "{fontWeights.regular}",
+							"lineHeight": "{lineHeights.1}",
+							"fontSize": "{fontSizes.figma.12.m}",
+							"letterSpacing": "{letterSpacing.tight}"
+						},
+						"type": "typography"
+					},
+					"L": {
+						"value": {
+							"fontFamily": "{fontFamilies.sans}",
+							"fontWeight": "{fontWeights.regular}",
+							"lineHeight": "{lineHeights.1}",
+							"fontSize": "{fontSizes.figma.12.l}",
+							"letterSpacing": "{letterSpacing.tight}"
+						},
+						"type": "typography"
+					},
+					"XL": {
+						"value": {
+							"fontFamily": "{fontFamilies.sans}",
+							"fontWeight": "{fontWeights.regular}",
+							"lineHeight": "{lineHeights.1}",
+							"fontSize": "{fontSizes.figma.12.xl}",
+							"letterSpacing": "{letterSpacing.tight}"
+						},
+						"type": "typography"
+					},
+					"MAX": {
+						"value": {
+							"fontFamily": "{fontFamilies.sans}",
+							"fontWeight": "{fontWeights.regular}",
+							"lineHeight": "{lineHeights.1}",
+							"fontSize": "{fontSizes.figma.12.max}",
+							"letterSpacing": "{letterSpacing.tight}"
+						},
+						"type": "typography"
+					}
+				},
+				"7": {
+					"S": {
+						"value": {
+							"fontFamily": "{fontFamilies.sans}",
+							"fontWeight": "{fontWeights.regular}",
+							"lineHeight": "{lineHeights.1}",
+							"fontSize": "{fontSizes.figma.13.s}",
+							"letterSpacing": "{letterSpacing.tight}"
+						},
+						"type": "typography"
+					},
+					"M": {
+						"value": {
+							"fontFamily": "{fontFamilies.sans}",
+							"fontWeight": "{fontWeights.regular}",
+							"lineHeight": "{lineHeights.1}",
+							"fontSize": "{fontSizes.figma.13.m}",
+							"letterSpacing": "{letterSpacing.tight}"
+						},
+						"type": "typography"
+					},
+					"L": {
+						"value": {
+							"fontFamily": "{fontFamilies.sans}",
+							"fontWeight": "{fontWeights.regular}",
+							"lineHeight": "{lineHeights.1}",
+							"fontSize": "{fontSizes.figma.13.l}",
+							"letterSpacing": "{letterSpacing.tight}"
+						},
+						"type": "typography"
+					},
+					"XL": {
+						"value": {
+							"fontFamily": "{fontFamilies.sans}",
+							"fontWeight": "{fontWeights.regular}",
+							"lineHeight": "{lineHeights.1}",
+							"fontSize": "{fontSizes.figma.13.xl}",
+							"letterSpacing": "{letterSpacing.tight}"
+						},
+						"type": "typography"
+					},
+					"MAX": {
+						"value": {
+							"fontFamily": "{fontFamilies.sans}",
+							"fontWeight": "{fontWeights.regular}",
+							"lineHeight": "{lineHeights.1}",
+							"fontSize": "{fontSizes.figma.13.max}",
+							"letterSpacing": "{letterSpacing.tight}"
+						},
+						"type": "typography"
+					}
+				},
+				"1-light": {
+					"S": {
+						"value": {
+							"fontFamily": "{fontFamilies.sans}",
+							"fontWeight": "{fontWeights.light}",
+							"lineHeight": "{lineHeights.3}",
+							"fontSize": "{fontSizes.figma.4.s}",
+							"letterSpacing": "{letterSpacing.tight}"
+						},
+						"type": "typography"
+					},
+					"M": {
+						"value": {
+							"fontFamily": "{fontFamilies.sans}",
+							"fontWeight": "{fontWeights.light}",
+							"lineHeight": "{lineHeights.3}",
+							"fontSize": "{fontSizes.figma.4.m}",
+							"letterSpacing": "{letterSpacing.tight}"
+						},
+						"type": "typography"
+					},
+					"L": {
+						"value": {
+							"fontFamily": "{fontFamilies.sans}",
+							"fontWeight": "{fontWeights.light}",
+							"lineHeight": "{lineHeights.3}",
+							"fontSize": "{fontSizes.figma.4.l}",
+							"letterSpacing": "{letterSpacing.tight}"
+						},
+						"type": "typography"
+					},
+					"XL": {
+						"value": {
+							"fontFamily": "{fontFamilies.sans}",
+							"fontWeight": "{fontWeights.light}",
+							"lineHeight": "{lineHeights.3}",
+							"fontSize": "{fontSizes.figma.4.xl}",
+							"letterSpacing": "{letterSpacing.tight}"
+						},
+						"type": "typography"
+					},
+					"MAX": {
+						"value": {
+							"fontFamily": "{fontFamilies.sans}",
+							"fontWeight": "{fontWeights.light}",
+							"lineHeight": "{lineHeights.3}",
+							"fontSize": "{fontSizes.figma.4.max}",
+							"letterSpacing": "{letterSpacing.tight}"
+						},
+						"type": "typography"
+					}
+				},
+				"2-light": {
+					"S": {
+						"value": {
+							"fontFamily": "{fontFamilies.sans}",
+							"fontWeight": "{fontWeights.light}",
+							"lineHeight": "{lineHeights.2}",
+							"fontSize": "{fontSizes.figma.8.s}",
+							"letterSpacing": "{letterSpacing.tight}"
+						},
+						"type": "typography"
+					},
+					"M": {
+						"value": {
+							"fontFamily": "{fontFamilies.sans}",
+							"fontWeight": "{fontWeights.light}",
+							"lineHeight": "{lineHeights.2}",
+							"fontSize": "{fontSizes.figma.8.m}",
+							"letterSpacing": "{letterSpacing.tight}"
+						},
+						"type": "typography"
+					},
+					"L": {
+						"value": {
+							"fontFamily": "{fontFamilies.sans}",
+							"fontWeight": "{fontWeights.light}",
+							"lineHeight": "{lineHeights.2}",
+							"fontSize": "{fontSizes.figma.8.l}",
+							"letterSpacing": "{letterSpacing.tight}"
+						},
+						"type": "typography"
+					},
+					"XL": {
+						"value": {
+							"fontFamily": "{fontFamilies.sans}",
+							"fontWeight": "{fontWeights.light}",
+							"lineHeight": "{lineHeights.2}",
+							"fontSize": "{fontSizes.figma.8.xl}",
+							"letterSpacing": "{letterSpacing.tight}"
+						},
+						"type": "typography"
+					},
+					"MAX": {
+						"value": {
+							"fontFamily": "{fontFamilies.sans}",
+							"fontWeight": "{fontWeights.light}",
+							"lineHeight": "{lineHeights.2}",
+							"fontSize": "{fontSizes.figma.8.max}",
+							"letterSpacing": "{letterSpacing.tight}"
+						},
+						"type": "typography"
+					}
+				},
+				"3-light": {
+					"S": {
+						"value": {
+							"fontFamily": "{fontFamilies.sans}",
+							"fontWeight": "{fontWeights.light}",
+							"lineHeight": "{lineHeights.3}",
+							"fontSize": "{fontSizes.figma.9.s}",
+							"letterSpacing": "{letterSpacing.tight}"
+						},
+						"type": "typography"
+					},
+					"M": {
+						"value": {
+							"fontFamily": "{fontFamilies.sans}",
+							"fontWeight": "{fontWeights.light}",
+							"lineHeight": "{lineHeights.3}",
+							"fontSize": "{fontSizes.figma.9.m}",
+							"letterSpacing": "{letterSpacing.tight}"
+						},
+						"type": "typography"
+					},
+					"L": {
+						"value": {
+							"fontFamily": "{fontFamilies.sans}",
+							"fontWeight": "{fontWeights.light}",
+							"lineHeight": "{lineHeights.3}",
+							"fontSize": "{fontSizes.figma.9.l}",
+							"letterSpacing": "{letterSpacing.tight}"
+						},
+						"type": "typography"
+					},
+					"XL": {
+						"value": {
+							"fontFamily": "{fontFamilies.sans}",
+							"fontWeight": "{fontWeights.light}",
+							"lineHeight": "{lineHeights.3}",
+							"fontSize": "{fontSizes.figma.9.xl}",
+							"letterSpacing": "{letterSpacing.tight}"
+						},
+						"type": "typography"
+					},
+					"MAX": {
+						"value": {
+							"fontFamily": "{fontFamilies.sans}",
+							"fontWeight": "{fontWeights.light}",
+							"lineHeight": "{lineHeights.3}",
+							"fontSize": "{fontSizes.figma.9.max}",
+							"letterSpacing": "{letterSpacing.tight}"
+						},
+						"type": "typography"
+					}
+				},
+				"4-light": {
+					"S": {
+						"value": {
+							"fontFamily": "{fontFamilies.sans}",
+							"fontWeight": "{fontWeights.light}",
+							"lineHeight": "{lineHeights.2}",
+							"fontSize": "{fontSizes.figma.10.s}",
+							"letterSpacing": "{letterSpacing.tight}"
+						},
+						"type": "typography"
+					},
+					"M": {
+						"value": {
+							"fontFamily": "{fontFamilies.sans}",
+							"fontWeight": "{fontWeights.light}",
+							"lineHeight": "{lineHeights.2}",
+							"fontSize": "{fontSizes.figma.10.m}",
+							"letterSpacing": "{letterSpacing.tight}"
+						},
+						"type": "typography"
+					},
+					"L": {
+						"value": {
+							"fontFamily": "{fontFamilies.sans}",
+							"fontWeight": "{fontWeights.light}",
+							"lineHeight": "{lineHeights.2}",
+							"fontSize": "{fontSizes.figma.10.l}",
+							"letterSpacing": "{letterSpacing.tight}"
+						},
+						"type": "typography"
+					},
+					"XL": {
+						"value": {
+							"fontFamily": "{fontFamilies.sans}",
+							"fontWeight": "{fontWeights.light}",
+							"lineHeight": "{lineHeights.2}",
+							"fontSize": "{fontSizes.figma.10.xl}",
+							"letterSpacing": "{letterSpacing.tight}"
+						},
+						"type": "typography"
+					},
+					"MAX": {
+						"value": {
+							"fontFamily": "{fontFamilies.sans}",
+							"fontWeight": "{fontWeights.light}",
+							"lineHeight": "{lineHeights.2}",
+							"fontSize": "{fontSizes.figma.10.max}",
+							"letterSpacing": "{letterSpacing.tight}"
+						},
+						"type": "typography"
+					}
+				},
+				"5-light": {
+					"S": {
+						"value": {
+							"fontFamily": "{fontFamilies.sans}",
+							"fontWeight": "{fontWeights.light}",
+							"lineHeight": "{lineHeights.1}",
+							"fontSize": "{fontSizes.figma.11.s}",
+							"letterSpacing": "{letterSpacing.tight}"
+						},
+						"type": "typography"
+					},
+					"M": {
+						"value": {
+							"fontFamily": "{fontFamilies.sans}",
+							"fontWeight": "{fontWeights.light}",
+							"lineHeight": "{lineHeights.1}",
+							"fontSize": "{fontSizes.figma.11.m}",
+							"letterSpacing": "{letterSpacing.tight}"
+						},
+						"type": "typography"
+					},
+					"L": {
+						"value": {
+							"fontFamily": "{fontFamilies.sans}",
+							"fontWeight": "{fontWeights.light}",
+							"lineHeight": "{lineHeights.1}",
+							"fontSize": "{fontSizes.figma.11.l}",
+							"letterSpacing": "{letterSpacing.tight}"
+						},
+						"type": "typography"
+					},
+					"XL": {
+						"value": {
+							"fontFamily": "{fontFamilies.sans}",
+							"fontWeight": "{fontWeights.light}",
+							"lineHeight": "{lineHeights.1}",
+							"fontSize": "{fontSizes.figma.11.xl}",
+							"letterSpacing": "{letterSpacing.tight}"
+						},
+						"type": "typography"
+					},
+					"MAX": {
+						"value": {
+							"fontFamily": "{fontFamilies.sans}",
+							"fontWeight": "{fontWeights.light}",
+							"lineHeight": "{lineHeights.1}",
+							"fontSize": "{fontSizes.figma.11.max}",
+							"letterSpacing": "{letterSpacing.tight}"
+						},
+						"type": "typography"
+					}
+				},
+				"5-serif": {
+					"S": {
+						"value": {
+							"fontFamily": "{fontFamilies.display}",
+							"fontWeight": "{fontWeights.regular}",
+							"lineHeight": "{lineHeights.1}",
+							"fontSize": "{fontSizes.figma.11.s}",
+							"letterSpacing": "{letterSpacing.tight}"
+						},
+						"type": "typography"
+					},
+					"M": {
+						"value": {
+							"fontFamily": "{fontFamilies.display}",
+							"fontWeight": "{fontWeights.regular}",
+							"lineHeight": "{lineHeights.1}",
+							"fontSize": "{fontSizes.figma.11.m}",
+							"letterSpacing": "{letterSpacing.tight}"
+						},
+						"type": "typography"
+					},
+					"L": {
+						"value": {
+							"fontFamily": "{fontFamilies.display}",
+							"fontWeight": "{fontWeights.regular}",
+							"lineHeight": "{lineHeights.1}",
+							"fontSize": "{fontSizes.figma.11.l}",
+							"letterSpacing": "{letterSpacing.tight}"
+						},
+						"type": "typography"
+					},
+					"XL": {
+						"value": {
+							"fontFamily": "{fontFamilies.display}",
+							"fontWeight": "{fontWeights.regular}",
+							"lineHeight": "{lineHeights.1}",
+							"fontSize": "{fontSizes.figma.11.xl}",
+							"letterSpacing": "{letterSpacing.tight}"
+						},
+						"type": "typography"
+					},
+					"MAX": {
+						"value": {
+							"fontFamily": "{fontFamilies.display}",
+							"fontWeight": "{fontWeights.regular}",
+							"lineHeight": "{lineHeights.1}",
+							"fontSize": "{fontSizes.figma.11.max}",
+							"letterSpacing": "{letterSpacing.tight}"
+						},
+						"type": "typography"
+					}
+				},
+				"6-serif": {
+					"S": {
+						"value": {
+							"fontFamily": "{fontFamilies.display}",
+							"fontWeight": "{fontWeights.regular}",
+							"lineHeight": "{lineHeights.1}",
+							"fontSize": "{fontSizes.figma.12.s}",
+							"letterSpacing": "{letterSpacing.tight}"
+						},
+						"type": "typography"
+					},
+					"M": {
+						"value": {
+							"fontFamily": "{fontFamilies.display}",
+							"fontWeight": "{fontWeights.regular}",
+							"lineHeight": "{lineHeights.1}",
+							"fontSize": "{fontSizes.figma.12.m}",
+							"letterSpacing": "{letterSpacing.tight}"
+						},
+						"type": "typography"
+					},
+					"L": {
+						"value": {
+							"fontFamily": "{fontFamilies.display}",
+							"fontWeight": "{fontWeights.regular}",
+							"lineHeight": "{lineHeights.1}",
+							"fontSize": "{fontSizes.figma.12.l}",
+							"letterSpacing": "{letterSpacing.tight}"
+						},
+						"type": "typography"
+					},
+					"XL": {
+						"value": {
+							"fontFamily": "{fontFamilies.display}",
+							"fontWeight": "{fontWeights.regular}",
+							"lineHeight": "{lineHeights.1}",
+							"fontSize": "{fontSizes.figma.12.xl}",
+							"letterSpacing": "{letterSpacing.tight}"
+						},
+						"type": "typography"
+					},
+					"MAX": {
+						"value": {
+							"fontFamily": "{fontFamilies.display}",
+							"fontWeight": "{fontWeights.regular}",
+							"lineHeight": "{lineHeights.1}",
+							"fontSize": "{fontSizes.figma.12.max}",
+							"letterSpacing": "{letterSpacing.tight}"
+						},
+						"type": "typography"
+					}
+				},
+				"7-serif": {
+					"S": {
+						"value": {
+							"fontFamily": "{fontFamilies.display}",
+							"fontWeight": "{fontWeights.regular}",
+							"lineHeight": "{lineHeights.1}",
+							"fontSize": "{fontSizes.figma.13.s}",
+							"letterSpacing": "{letterSpacing.tight}"
+						},
+						"type": "typography"
+					},
+					"M": {
+						"value": {
+							"fontFamily": "{fontFamilies.display}",
+							"fontWeight": "{fontWeights.regular}",
+							"lineHeight": "{lineHeights.1}",
+							"fontSize": "{fontSizes.figma.13.m}",
+							"letterSpacing": "{letterSpacing.tight}"
+						},
+						"type": "typography"
+					},
+					"L": {
+						"value": {
+							"fontFamily": "{fontFamilies.display}",
+							"fontWeight": "{fontWeights.regular}",
+							"lineHeight": "{lineHeights.1}",
+							"fontSize": "{fontSizes.figma.13.l}",
+							"letterSpacing": "{letterSpacing.tight}"
+						},
+						"type": "typography"
+					},
+					"XL": {
+						"value": {
+							"fontFamily": "{fontFamilies.display}",
+							"fontWeight": "{fontWeights.regular}",
+							"lineHeight": "{lineHeights.1}",
+							"fontSize": "{fontSizes.figma.13.xl}",
+							"letterSpacing": "{letterSpacing.tight}"
+						},
+						"type": "typography"
+					},
+					"MAX": {
+						"value": {
+							"fontFamily": "{fontFamilies.display}",
+							"fontWeight": "{fontWeights.regular}",
+							"lineHeight": "{lineHeights.1}",
+							"fontSize": "{fontSizes.figma.13.max}",
+							"letterSpacing": "{letterSpacing.tight}"
+						},
+						"type": "typography"
+					}
+				}
+			},
+			"paragraph": {
+				"1": {
+					"S": {
+						"value": {
+							"fontFamily": "{fontFamilies.sans}",
+							"fontWeight": "{fontWeights.light}",
+							"lineHeight": "{lineHeights.4}",
+							"fontSize": "{fontSizes.figma.9.s}",
+							"letterSpacing": "{letterSpacing.tight}"
+						},
+						"type": "typography"
+					},
+					"M": {
+						"value": {
+							"fontFamily": "{fontFamilies.sans}",
+							"fontWeight": "{fontWeights.light}",
+							"lineHeight": "{lineHeights.4}",
+							"fontSize": "{fontSizes.figma.9.m}",
+							"letterSpacing": "{letterSpacing.tight}"
+						},
+						"type": "typography"
+					},
+					"L": {
+						"value": {
+							"fontFamily": "{fontFamilies.sans}",
+							"fontWeight": "{fontWeights.light}",
+							"lineHeight": "{lineHeights.4}",
+							"fontSize": "{fontSizes.figma.9.l}",
+							"letterSpacing": "{letterSpacing.tight}"
+						},
+						"type": "typography"
+					},
+					"XL": {
+						"value": {
+							"fontFamily": "{fontFamilies.sans}",
+							"fontWeight": "{fontWeights.light}",
+							"lineHeight": "{lineHeights.4}",
+							"fontSize": "{fontSizes.figma.9.xl}",
+							"letterSpacing": "{letterSpacing.tight}"
+						},
+						"type": "typography"
+					},
+					"MAX": {
+						"value": {
+							"fontFamily": "{fontFamilies.sans}",
+							"fontWeight": "{fontWeights.light}",
+							"lineHeight": "{lineHeights.4}",
+							"fontSize": "{fontSizes.figma.9.max}",
+							"letterSpacing": "{letterSpacing.tight}"
+						},
+						"type": "typography"
+					}
+				}
+			},
+			"quotation": {
+				"1": {
+					"S": {
+						"value": {
+							"fontFamily": "{fontFamilies.display}",
+							"fontWeight": "{fontWeights.regular}",
+							"lineHeight": "{lineHeights.4}",
+							"fontSize": "{fontSizes.figma.9.s}",
+							"letterSpacing": "{letterSpacing.tight}"
+						},
+						"type": "typography"
+					},
+					"M": {
+						"value": {
+							"fontFamily": "{fontFamilies.display}",
+							"fontWeight": "{fontWeights.regular}",
+							"lineHeight": "{lineHeights.4}",
+							"fontSize": "{fontSizes.figma.9.m}",
+							"letterSpacing": "{letterSpacing.tight}"
+						},
+						"type": "typography"
+					},
+					"L": {
+						"value": {
+							"fontFamily": "{fontFamilies.display}",
+							"fontWeight": "{fontWeights.regular}",
+							"lineHeight": "{lineHeights.4}",
+							"fontSize": "{fontSizes.figma.9.l}",
+							"letterSpacing": "{letterSpacing.tight}"
+						},
+						"type": "typography"
+					},
+					"XL": {
+						"value": {
+							"fontFamily": "{fontFamilies.display}",
+							"fontWeight": "{fontWeights.regular}",
+							"lineHeight": "{lineHeights.4}",
+							"fontSize": "{fontSizes.figma.9.xl}",
+							"letterSpacing": "{letterSpacing.tight}"
+						},
+						"type": "typography"
+					},
+					"MAX": {
+						"value": {
+							"fontFamily": "{fontFamilies.display}",
+							"fontWeight": "{fontWeights.regular}",
+							"lineHeight": "{lineHeights.4}",
+							"fontSize": "{fontSizes.figma.9.max}",
+							"letterSpacing": "{letterSpacing.tight}"
+						},
+						"type": "typography"
+					}
+				},
+				"2": {
+					"S": {
+						"value": {
+							"fontFamily": "{fontFamilies.display}",
+							"fontWeight": "{fontWeights.regular}",
+							"lineHeight": "{lineHeights.4}",
+							"fontSize": "{fontSizes.figma.10.s}",
+							"letterSpacing": "{letterSpacing.tight}"
+						},
+						"type": "typography"
+					},
+					"M": {
+						"value": {
+							"fontFamily": "{fontFamilies.display}",
+							"fontWeight": "{fontWeights.regular}",
+							"lineHeight": "{lineHeights.4}",
+							"fontSize": "{fontSizes.figma.10.m}",
+							"letterSpacing": "{letterSpacing.tight}"
+						},
+						"type": "typography"
+					},
+					"L": {
+						"value": {
+							"fontFamily": "{fontFamilies.display}",
+							"fontWeight": "{fontWeights.regular}",
+							"lineHeight": "{lineHeights.4}",
+							"fontSize": "{fontSizes.figma.10.l}",
+							"letterSpacing": "{letterSpacing.tight}"
+						},
+						"type": "typography"
+					},
+					"XL": {
+						"value": {
+							"fontFamily": "{fontFamilies.display}",
+							"fontWeight": "{fontWeights.regular}",
+							"lineHeight": "{lineHeights.4}",
+							"fontSize": "{fontSizes.figma.10.xl}",
+							"letterSpacing": "{letterSpacing.tight}"
+						},
+						"type": "typography"
+					},
+					"MAX": {
+						"value": {
+							"fontFamily": "{fontFamilies.display}",
+							"fontWeight": "{fontWeights.regular}",
+							"lineHeight": "{lineHeights.4}",
+							"fontSize": "{fontSizes.figma.10.max}",
+							"letterSpacing": "{letterSpacing.tight}"
+						},
+						"type": "typography"
+					}
+				},
+				"3": {
+					"S": {
+						"value": {
+							"fontFamily": "{fontFamilies.display}",
+							"fontWeight": "{fontWeights.regular}",
+							"lineHeight": "{lineHeights.3}",
+							"fontSize": "{fontSizes.figma.11.s}",
+							"letterSpacing": "{letterSpacing.tight}"
+						},
+						"type": "typography"
+					},
+					"M": {
+						"value": {
+							"fontFamily": "{fontFamilies.display}",
+							"fontWeight": "{fontWeights.regular}",
+							"lineHeight": "{lineHeights.3}",
+							"fontSize": "{fontSizes.figma.11.m}",
+							"letterSpacing": "{letterSpacing.tight}"
+						},
+						"type": "typography"
+					},
+					"L": {
+						"value": {
+							"fontFamily": "{fontFamilies.display}",
+							"fontWeight": "{fontWeights.regular}",
+							"lineHeight": "{lineHeights.3}",
+							"fontSize": "{fontSizes.figma.11.l}",
+							"letterSpacing": "{letterSpacing.tight}"
+						},
+						"type": "typography"
+					},
+					"XL": {
+						"value": {
+							"fontFamily": "{fontFamilies.display}",
+							"fontWeight": "{fontWeights.regular}",
+							"lineHeight": "{lineHeights.3}",
+							"fontSize": "{fontSizes.figma.11.xl}",
+							"letterSpacing": "{letterSpacing.tight}"
+						},
+						"type": "typography"
+					},
+					"MAX": {
+						"value": {
+							"fontFamily": "{fontFamilies.display}",
+							"fontWeight": "{fontWeights.regular}",
+							"lineHeight": "{lineHeights.3}",
+							"fontSize": "{fontSizes.figma.11.max}",
+							"letterSpacing": "{letterSpacing.tight}"
+						},
+						"type": "typography"
+					}
+				}
+			},
+			"caption": {
+				"1": {
+					"value": {
+						"fontFamily": "{fontFamilies.sans}",
+						"fontWeight": "{fontWeights.regular}",
+						"lineHeight": "{lineHeights.4}",
+						"fontSize": "{fontSizes.static.1}",
+						"letterSpacing": "{letterSpacing.loose}"
+					},
+					"type": "typography"
+				},
+				"2": {
+					"value": {
+						"fontFamily": "{fontFamilies.sans}",
+						"fontWeight": "{fontWeights.regular}",
+						"lineHeight": "{lineHeights.4}",
+						"fontSize": "{fontSizes.static.2}",
+						"letterSpacing": "{letterSpacing.loose}"
+					},
+					"type": "typography"
+				}
+			},
+			"code": {
+				"1": {
+					"value": {
+						"fontFamily": "{fontFamilies.sans}",
+						"fontWeight": "{fontWeights.regular}",
+						"lineHeight": "{lineHeights.4}",
+						"fontSize": "{fontSizes.static.2}"
+					},
+					"type": "typography"
+				},
+				"2": {
+					"value": {
+						"fontFamily": "{fontFamilies.sans}",
+						"fontWeight": "{fontWeights.regular}",
+						"lineHeight": "{lineHeights.4}",
+						"fontSize": "{fontSizes.static.3}"
+					},
+					"type": "typography"
+				}
+			},
+			"supporting": {
+				"helper-text": {
+					"1": {
+						"value": {
+							"fontFamily": "{fontFamilies.sans}",
+							"fontWeight": "{fontWeights.regular}",
+							"lineHeight": "{lineHeights.4}",
+							"fontSize": "{fontSizes.static.1}",
+							"letterSpacing": "{letterSpacing.loose}"
+						},
+						"type": "typography"
+					},
+					"1-caps": {
+						"value": {
+							"fontFamily": "{fontFamilies.sans}",
+							"fontWeight": "{fontWeights.regular}",
+							"lineHeight": "{lineHeights.4}",
+							"fontSize": "{fontSizes.static.1}",
+							"letterSpacing": "{letterSpacing.loose}",
+							"textCase": "{textCase.uppercase}"
+						},
+						"type": "typography"
+					}
+				},
+				"support-text": {
+					"1": {
+						"value": {
+							"fontFamily": "{fontFamilies.accent}",
+							"fontWeight": "{fontWeights.medium}",
+							"lineHeight": "{lineHeights.4}",
+							"fontSize": "{fontSizes.static.1}",
+							"letterSpacing": "{letterSpacing.loose}",
+							"textCase": "{textCase.uppercase}"
+						},
+						"type": "typography"
+					},
+					"2": {
+						"value": {
+							"fontFamily": "{fontFamilies.accent}",
+							"fontWeight": "{fontWeights.medium}",
+							"lineHeight": "{lineHeights.4}",
+							"fontSize": "{fontSizes.static.3}",
+							"letterSpacing": "{letterSpacing.loose}",
+							"textCase": "{textCase.uppercase}"
+						},
+						"type": "typography"
+					}
+				}
+			}
+		},
+		"fontFamilies": {
+			"sans": {
+				"value": "{default-fonts}",
+				"type": "fontFamilies"
+			},
+			"serif": {
+				"value": "{default-fonts}",
+				"type": "fontFamilies"
+			},
+			"display": {
+				"value": "{default-fonts}",
+				"type": "fontFamilies"
+			},
+			"accent": {
+				"value": "{default-fonts}",
+				"type": "fontFamilies"
+			}
+		}
+	},
+	"$themes": [
+		{
+			"id": "97662160426568966100d2dccc5dfcdefeb5d921",
+			"name": "wpvip",
+			"selectedTokenSets": {
+				"valet-core": "source",
+				"expressive-type-wpvip": "enabled",
+				"productive-color-wpvip": "disabled",
+				"expressive-color-wpvip": "enabled",
+				"expressive-color-valet": "disabled",
+				"expressive-type-valet": "disabled"
+			},
+			"$figmaStyleReferences": {}
+		},
+		{
+			"id": "22bf7b17c2576c9ba4c472940aedcc3f3ae3618c",
+			"name": "valet",
+			"selectedTokenSets": {
+				"valet-core": "source",
+				"expressive-type-wpvip": "disabled",
+				"productive-color-wpvip": "disabled",
+				"expressive-color-wpvip": "disabled",
+				"expressive-color-valet": "enabled",
+				"expressive-type-valet": "enabled"
+			},
+			"$figmaStyleReferences": {}
+		}
+	]
 }


### PR DESCRIPTION
## Description

- Introducing a standard color for `outline` focused elements;
- Adding the disabled state for the Toggle (bugfix since we changed to the new implementation);
- Increasing opacity to `0.7` instead of `0.5`.

<img width="293" alt="image" src="https://user-images.githubusercontent.com/3402/180058523-76d50a49-7e23-4641-a691-06a31d397607.png">

<img width="1076" alt="image" src="https://user-images.githubusercontent.com/3402/180058563-3576d809-4129-48ca-8cc9-69b76c628b17.png">

<img width="327" alt="image" src="https://user-images.githubusercontent.com/3402/180058591-7cbd4e96-243b-401d-8d37-fc54f6edf557.png">


## Checklist

- [ ] This PR has good automated test coverage
- [x] The storybook for the component has been updated

## Steps to Test

1. Pull down PR.
2. `npm run dev`.
3. Open Storybook.
4. Open the [NewDialog](http://localhost:6006/?path=/story/newdialog--default) example, and check the button outline
5. Open the [Toggle](http://localhost:6006/?path=/story/toggle--primary) example, and check there is a new example for Disabled state
6. Open the [Button](http://localhost:6006/?path=/story/button--default) example and check there's the standard outline color of all examples above
