### PR TITLE
Add/toggle hover dialog document

### DIFF
--- a/src/system/Form/Toggle.js
+++ b/src/system/Form/Toggle.js
@@ -23,6 +23,7 @@ export const Toggle = ( {
 		className={ classNames( 'vip-toggle-component', className ) }
 		sx={ {
 			all: 'unset',
+			cursor: 'pointer',
 			position: 'relative',
 			width: 40,
 			height: 20,

--- a/src/system/NewDialog/NewDialog.js
+++ b/src/system/NewDialog/NewDialog.js
@@ -56,7 +56,7 @@ export const NewDialog = ( {
 					<DialogTitle title={ title } hidden={ ! showHeading } />
 					<DialogDescription description={ description } hidden={ ! showHeading } />
 
-					{ content }
+					<div role="document">{ content }</div>
 				</DialogPrimitive.Content>
 			</DialogPrimitive.Portal>
 		</DialogPrimitive.Root>

--- a/src/system/NewDialog/NewDialog.stories.jsx
+++ b/src/system/NewDialog/NewDialog.stories.jsx
@@ -61,6 +61,10 @@ export const HiddenHeadings = () => (
 						<Input type="text" name="username" id="username" />
 						<Button type="submit">Submit</Button>
 					</form>
+
+					<h3>Continue here</h3>
+
+					<p>This is an example.</p>
 				</div>
 			}
 		/>


### PR DESCRIPTION
## Description

- Adds a cursor pointer to the Toggle component (Required to have a hover state);
- Adds a `role="document"` attribute to the Dialog content. This is to avoid having developers to remember to add this `role` for Dialogs with more than just a form.

## Checklist

- [ ] This PR has good automated test coverage
- [ ] The storybook for the component has been updated

## Steps to Test — Toggle

1. Pull down PR.
2. `npm run dev`.
3. Open the [Toggle Example](http://localhost:6006/?path=/story/toggle--primary)
4. When HOVERING the Toggle you should see a cursor pointer (hand)

## Steps to Test — Dialog

1. Pull down PR.
2. `npm run dev`.
3. Open the [NewDialog Example](http://localhost:6006/?path=/story/newdialog--default)
4. Inspect the Dialog. The content wrapper div should have a `role="document"` for all dialogs.

