### PR TITLE
Fix Dialog heading big spacing

### DIFF
--- a/src/system/NewDialog/DialogContent.js
+++ b/src/system/NewDialog/DialogContent.js
@@ -11,7 +11,7 @@ export const contentStyles = {
 	width: '90vw',
 	maxWidth: '640px',
 	maxHeight: '85vh',
-	padding: 25,
+	padding: 20,
 	'&:focus': { outline: 'none' },
 	'> h1, > h2': { marginTop: '0 !important' },
 };

--- a/src/system/NewDialog/DialogContent.js
+++ b/src/system/NewDialog/DialogContent.js
@@ -11,7 +11,7 @@ export const contentStyles = {
 	width: '90vw',
 	maxWidth: '640px',
 	maxHeight: '85vh',
-	padding: 20,
+	padding: 32,
 	'&:focus': { outline: 'none' },
 	'> h1, > h2': { marginTop: '0 !important' },
 };

--- a/src/system/NewDialog/DialogDescription.js
+++ b/src/system/NewDialog/DialogDescription.js
@@ -21,7 +21,7 @@ export const DialogDescription = React.forwardRef(
 		}
 
 		return (
-			<DialogPrimitive.Description { ...rest } ref={ forwardedRef }>
+			<DialogPrimitive.Description { ...rest } ref={ forwardedRef } sx={ { margin: 0 } }>
 				{ text }
 			</DialogPrimitive.Description>
 		);

--- a/src/system/NewDialog/DialogTitle.js
+++ b/src/system/NewDialog/DialogTitle.js
@@ -18,7 +18,7 @@ export const DialogTitle = ( { title, hidden = false } ) => {
 		titleNode = <ScreenReaderText>{ titleNode }</ScreenReaderText>;
 	}
 
-	return <DialogPrimitive.Title>{ titleNode }</DialogPrimitive.Title>;
+	return <DialogPrimitive.Title sx={ { margin: 0 } }>{ titleNode }</DialogPrimitive.Title>;
 };
 
 DialogTitle.propTypes = {

--- a/src/system/NewDialog/NewDialog.stories.jsx
+++ b/src/system/NewDialog/NewDialog.stories.jsx
@@ -34,6 +34,20 @@ export const AutoOpen = () => (
 		<NewDialog
 			{ ...defaultProps }
 			defaultOpen={ true }
+			content={
+				<div>
+					<h3>Test</h3>
+					<p>
+						Lorem Ipsum is simply dummy text of the printing and typesetting industry. Lorem Ipsum
+						has been the industry's standard dummy text ever since the 1500s, when an unknown
+						printer took a galley of type and scrambled it to make a type specimen book. It has
+						survived not only five centuries, but also the leap into electronic typesetting,
+						remaining essentially unchanged. It was popularised in the 1960s with the release of
+						Letraset sheets containing Lorem Ipsum passages, and more recently with desktop
+						publishing software like Aldus PageMaker including versions of Lorem Ipsum.
+					</p>
+				</div>
+			}
 			trigger={ <ScreenReaderText>hey</ScreenReaderText> }
 		/>
 	</>

--- a/src/system/NewDialog/NewDialog.stories.jsx
+++ b/src/system/NewDialog/NewDialog.stories.jsx
@@ -39,12 +39,12 @@ export const AutoOpen = () => (
 					<h3>Test</h3>
 					<p>
 						Lorem Ipsum is simply dummy text of the printing and typesetting industry. Lorem Ipsum
-						has been the industry's standard dummy text ever since the 1500s, when an unknown
-						printer took a galley of type and scrambled it to make a type specimen book. It has
-						survived not only five centuries, but also the leap into electronic typesetting,
-						remaining essentially unchanged. It was popularised in the 1960s with the release of
-						Letraset sheets containing Lorem Ipsum passages, and more recently with desktop
-						publishing software like Aldus PageMaker including versions of Lorem Ipsum.
+						has been the industry standard dummy text ever since the 1500s, when an unknown printer
+						took a galley of type and scrambled it to make a type specimen book. It has survived not
+						only five centuries, but also the leap into electronic typesetting, remaining
+						essentially unchanged. It was popularised in the 1960s with the release of Letraset
+						sheets containing Lorem Ipsum passages, and more recently with desktop publishing
+						software like Aldus PageMaker including versions of Lorem Ipsum.
 					</p>
 				</div>
 			}


### PR DESCRIPTION
## Description

Reduces the size of the spacing between the dialog headings.

## Checklist

- [ ] This PR has good automated test coverage
- [ ] The storybook for the component has been updated

## Steps to Test

1. Pull down PR.
2. `npm run dev`.
3. Open http://localhost:6006/?path=/story/newdialog--auto-open
4. Check that the headings have margin 0.
