### PR TITLE
Allow custom state management to NewDialog

### DIFF
--- a/src/system/NewDialog/NewDialog.js
+++ b/src/system/NewDialog/NewDialog.js
@@ -26,13 +26,22 @@ export const NewDialog = ( {
 	// Radix Specific Properties
 	defaultOpen = false,
 	allowPinchZoom = false,
+	onOpenChange = undefined,
+	open = undefined,
+	id = undefined,
 } ) => {
 	if ( disabled ) {
 		return;
 	}
 
 	return (
-		<DialogPrimitive.Root defaultOpen={ defaultOpen } allowPinchZoom={ allowPinchZoom }>
+		<DialogPrimitive.Root
+			id={ id }
+			open={ open }
+			onOpenChange={ onOpenChange }
+			defaultOpen={ defaultOpen }
+			allowPinchZoom={ allowPinchZoom }
+		>
 			{ trigger && <DialogPrimitive.Trigger asChild>{ trigger }</DialogPrimitive.Trigger> }
 
 			<DialogPrimitive.Portal>
@@ -64,6 +73,9 @@ NewDialog.propTypes = {
 
 	// Radix DialogPrimitive.Root properties
 	// https://www.radix-ui.com/docs/primitives/components/dialog#root
+	id: PropTypes.string,
+	open: PropTypes.bool,
 	defaultOpen: PropTypes.bool,
 	allowPinchZoom: PropTypes.bool,
+	onOpenChange: PropTypes.func,
 };

--- a/src/system/NewDialog/NewDialog.stories.jsx
+++ b/src/system/NewDialog/NewDialog.stories.jsx
@@ -146,7 +146,7 @@ export const CustomStateManagement = () => {
 				<strong>onOpenChange</strong> attribute.
 			</Text>
 
-			<NewDialog
+			<NewDialog.Root
 				{ ...defaultProps }
 				open={ open }
 				onOpenChange={ setOpen }

--- a/src/system/NewDialog/NewDialog.stories.jsx
+++ b/src/system/NewDialog/NewDialog.stories.jsx
@@ -1,6 +1,11 @@
 /** @jsxImportSource theme-ui */
 
 /**
+ * External dependencies
+ */
+import { useState } from 'react';
+
+/**
 /**
  * Internal dependencies
  */
@@ -131,3 +136,27 @@ export const CustomClose = () => (
 		/>
 	</>
 );
+export const CustomStateManagement = () => {
+	const [ open, setOpen ] = useState( false );
+	return (
+		<>
+			<Text sx={ { fontSize: 3, mb: 3 } }>
+				This example shows how you can create a custom state management. To achieve accessibility,
+				you need to control the <strong>open</strong> state, but also keep consistency using the{ ' ' }
+				<strong>onOpenChange</strong> attribute.
+			</Text>
+
+			<NewDialog
+				{ ...defaultProps }
+				open={ open }
+				onOpenChange={ setOpen }
+				trigger={ <Button>Trigger Dialog</Button> }
+				content={
+					<div>
+						<Button onClick={ () => setOpen( false ) }>Close here instead</Button>
+					</div>
+				}
+			/>
+		</>
+	);
+};


### PR DESCRIPTION
## Description

To allow a custom state management of the Dialog (open / close) from a function instead of using `<NewDialog.Close>`, we need to expose the `open` and the `onOpenChange` properties.

This PR has a useful example for developers showing how to create a custom management dialog.

## Checklist

- [ ] This PR has good automated test coverage
- [x] The storybook for the component has been updated

## Steps to Test

1. Pull down PR.
2. `npm run dev`.
3. Open Storybook.
4. Check the [new example with a custom state management](https://deploy-preview-91--vip-design-system-components.netlify.app/?path=/story/newdialog--custom-state-management), and ESC key still works, focus management still works.