### PR TITLE
Adds new NewConfirmationDialog component 🥳 

### DIFF
--- a/src/system/NewConfirmationDialog/NewConfirmationDialog.js
+++ b/src/system/NewConfirmationDialog/NewConfirmationDialog.js
@@ -1,0 +1,93 @@
+/** @jsxImportSource theme-ui */
+
+/**
+ * External dependencies
+ */
+import classNames from 'classnames';
+import PropTypes from 'prop-types';
+import React from 'react';
+
+/**
+ * Internal dependencies
+ */
+import { NewDialog, Box, Flex, Button } from '..';
+
+const NewConfirmationDialogContent = ( {
+	label = 'Confirm',
+	onConfirm,
+	onClose,
+	className = null,
+} ) => (
+	<Box className={ classNames( 'vip-confirmation-dialog-component', className ) }>
+		<Flex sx={ { justifyContent: 'flex-end', mt: 4 } }>
+			<Button variant="secondary" sx={ { mr: 2 } } onClick={ onClose }>
+				Cancel
+			</Button>
+			<NewDialog.Close>
+				<Button
+					variant="danger"
+					onClick={ () => {
+						onConfirm();
+						onClose();
+					} }
+				>
+					{ label }
+				</Button>
+			</NewDialog.Close>
+		</Flex>
+	</Box>
+);
+
+NewConfirmationDialogContent.propTypes = {
+	body: PropTypes.node,
+	label: PropTypes.string,
+	onClose: PropTypes.func,
+	onConfirm: PropTypes.func,
+	className: PropTypes.any,
+};
+
+const NewConfirmationDialog = ( {
+	trigger,
+	onConfirm,
+	needsConfirm = true,
+	label,
+	title,
+	body = '',
+} ) => {
+	const [ open, setOpen ] = React.useState( false );
+	const directTrigger = React.cloneElement( trigger, { onClick: onConfirm } );
+
+	if ( ! needsConfirm ) {
+		return directTrigger;
+	}
+
+	return (
+		<NewDialog.Root
+			open={ open }
+			onOpenChange={ setOpen }
+			sx={ { maxWidth: 680 } }
+			title={ title }
+			description={ ( body = '' ) }
+			content={
+				<NewConfirmationDialogContent
+					onClose={ () => setOpen( false ) }
+					onConfirm={ onConfirm }
+					body={ body }
+					label={ label }
+				/>
+			}
+			trigger={ trigger }
+		/>
+	);
+};
+
+NewConfirmationDialog.propTypes = {
+	needsConfirm: PropTypes.bool,
+	trigger: PropTypes.node,
+	onConfirm: PropTypes.func,
+	title: PropTypes.node,
+	body: PropTypes.node,
+	label: PropTypes.node,
+};
+
+export { NewConfirmationDialog };

--- a/src/system/NewConfirmationDialog/NewConfirmationDialog.js
+++ b/src/system/NewConfirmationDialog/NewConfirmationDialog.js
@@ -67,7 +67,7 @@ const NewConfirmationDialog = ( {
 			onOpenChange={ setOpen }
 			sx={ { maxWidth: 680 } }
 			title={ title }
-			description={ ( body = '' ) }
+			description={ body }
 			content={
 				<NewConfirmationDialogContent
 					onClose={ () => setOpen( false ) }

--- a/src/system/NewConfirmationDialog/NewConfirmationDialog.stories.jsx
+++ b/src/system/NewConfirmationDialog/NewConfirmationDialog.stories.jsx
@@ -1,0 +1,32 @@
+/**
+ * Internal dependencies
+ */
+import React from 'react';
+import { Box, NewConfirmationDialog, Button } from '..';
+
+export default {
+	title: 'NewConfirmationDialog',
+	component: NewConfirmationDialog,
+};
+
+const ConfirmationTrigger = <Button sx={ { mr: 3 } }>Click to answer</Button>;
+
+export const Default = () => {
+	const [ answer, setAnswer ] = React.useState( '🤔' );
+	return (
+		<Box>
+			<p>Confirm that your name is John doe?</p>
+			<NewConfirmationDialog
+				title={ 'Are you John Doe?' }
+				description={ 'Please confirm that your name is John Doe.' }
+				trigger={ ConfirmationTrigger }
+				body="A modal is used to perform more detailed actions that don&lsquo;t necessarily need the context
+					behind."
+				onConfirm={ () => setAnswer( '👍' ) }
+				needsConfirm={ true }
+			/>
+
+			<p>Answer: { answer }</p>
+		</Box>
+	);
+};

--- a/src/system/NewConfirmationDialog/NewConfirmationDialog.test.js
+++ b/src/system/NewConfirmationDialog/NewConfirmationDialog.test.js
@@ -1,0 +1,39 @@
+/**
+ * External dependencies
+ */
+import { fireEvent, render, screen } from '@testing-library/react';
+import { axe } from 'jest-axe';
+
+/**
+ * Internal dependencies
+ */
+import { NewConfirmationDialog } from './NewConfirmationDialog';
+
+const defaultProps = {
+	needsConfirm: true,
+	title: 'My Custom Title',
+	body: 'My Custom Text',
+	label: 'Submit this!',
+	trigger: <button>Trigger</button>,
+};
+
+const getButton = () => screen.getByText( 'Trigger' );
+const getConfirmButton = () => screen.getByText( defaultProps.label );
+const getTitle = () => screen.getByRole( 'heading', { level: 2 } );
+
+describe( '<NewConfirmationDialog />', () => {
+	it( 'renders the NewConfirmationDialog component', async () => {
+		const { container } = render( <NewConfirmationDialog { ...defaultProps } /> );
+
+		expect( getButton() ).toBeInTheDocument();
+
+		fireEvent.click( getButton() );
+
+		expect( getTitle() ).toHaveTextContent( defaultProps.title );
+
+		expect( getConfirmButton() ).toBeInTheDocument();
+
+		// Check for accessibility issues
+		await expect( await axe( container ) ).toHaveNoViolations();
+	} );
+} );

--- a/src/system/NewConfirmationDialog/index.js
+++ b/src/system/NewConfirmationDialog/index.js
@@ -1,0 +1,6 @@
+/**
+ * Internal dependencies
+ */
+import { NewConfirmationDialog } from './NewConfirmationDialog';
+
+export { NewConfirmationDialog };

--- a/src/system/index.js
+++ b/src/system/index.js
@@ -20,6 +20,7 @@ import {
 
 import * as NewDialog from './NewDialog';
 import { ConfirmationDialog } from './ConfirmationDialog';
+import { NewConfirmationDialog } from './NewConfirmationDialog';
 import { Flex } from './Flex';
 import {
 	Input,
@@ -70,6 +71,7 @@ export {
 	DialogContent,
 	DialogTrigger,
 	ConfirmationDialog,
+	NewConfirmationDialog,
 	Grid,
 	Flex,
 	Notice,


### PR DESCRIPTION
## Description

![aEMfVx36HP](https://user-images.githubusercontent.com/3402/183921563-1f5c6f56-9d61-4fdf-9fe6-5ac8bb8145bb.gif)


Adding a new component: src/system/NewConfirmationDialog/NewConfirmationDialog.js

This is a new version of the `ConfirmationDialog`. Following the same idea as the `NewDialog`, we are creating a new component to avoid breaking the clients of the vip-design-system.

## Checklist

- [x] This PR has good automated test coverage
- [x] The storybook for the component has been updated

## Steps to Test

1. Pull down PR.
2. `npm run dev`.
3. Go to http://localhost:6006/?path=/story/newconfirmationdialog--default
4. Verify the Dialog works and it has the same accessibility as the NewDialog component. Focus is on the Close button, user can navigate using the keyboard, can close using ESC key, and focus is back to the trigger.
