### PR TITLE
Add onClose exported to NewDialog Content

### DIFF
--- a/src/system/NewDialog/NewDialog.js
+++ b/src/system/NewDialog/NewDialog.js
@@ -31,7 +31,7 @@ export const NewDialog = ( {
 	open = undefined,
 	id = undefined,
 } ) => {
-	const [ isOpen, setIsOpen ] = React.useState( defaultOpen );
+	const [ isOpen, setIsOpen ] = React.useState( open || defaultOpen );
 
 	if ( disabled ) {
 		return;
@@ -40,11 +40,23 @@ export const NewDialog = ( {
 	// if content is a function, pass in onClose
 	const isContentFunction = typeof content === 'function';
 
+	const handleOnOpenChange = status => {
+		setIsOpen( status );
+
+		if ( onOpenChange ) {
+			onOpenChange( status );
+		}
+	};
+
+	React.useEffect( () => {
+		handleOnOpenChange( open );
+	}, [ open ] );
+
 	return (
 		<DialogPrimitive.Root
 			id={ id }
-			open={ open || isOpen }
-			onOpenChange={ onOpenChange || setIsOpen }
+			open={ isOpen }
+			onOpenChange={ handleOnOpenChange }
 			defaultOpen={ defaultOpen }
 			allowPinchZoom={ allowPinchZoom }
 		>

--- a/src/system/NewDialog/NewDialog.js
+++ b/src/system/NewDialog/NewDialog.js
@@ -3,6 +3,7 @@
 /**
  * External dependencies
  */
+import React from 'react';
 import PropTypes from 'prop-types';
 import * as DialogPrimitive from '@radix-ui/react-dialog';
 /**
@@ -30,15 +31,20 @@ export const NewDialog = ( {
 	open = undefined,
 	id = undefined,
 } ) => {
+	const [ isOpen, setIsOpen ] = React.useState( defaultOpen );
+
 	if ( disabled ) {
 		return;
 	}
 
+	// if content is a function, pass in onClose
+	const isContentFunction = typeof content === 'function';
+
 	return (
 		<DialogPrimitive.Root
 			id={ id }
-			open={ open }
-			onOpenChange={ onOpenChange }
+			open={ open || isOpen }
+			onOpenChange={ onOpenChange || setIsOpen }
 			defaultOpen={ defaultOpen }
 			allowPinchZoom={ allowPinchZoom }
 		>
@@ -55,7 +61,9 @@ export const NewDialog = ( {
 					<DialogTitle title={ title } hidden={ ! showHeading } />
 					<DialogDescription description={ description } hidden={ ! showHeading } />
 
-					<div role="document">{ content }</div>
+					<div role="document">
+						{ isContentFunction ? content( { onClose: () => setIsOpen( false ) } ) : content }
+					</div>
 				</DialogPrimitive.Content>
 			</DialogPrimitive.Portal>
 		</DialogPrimitive.Root>
@@ -66,7 +74,7 @@ NewDialog.propTypes = {
 	trigger: PropTypes.node.isRequired,
 	title: PropTypes.node.isRequired,
 	description: PropTypes.node.isRequired,
-	content: PropTypes.node,
+	content: PropTypes.oneOfType( [ PropTypes.node, PropTypes.func ] ),
 	showHeading: PropTypes.bool,
 	disabled: PropTypes.bool,
 	style: PropTypes.oneOfType( [ PropTypes.object, PropTypes.func ] ),

--- a/src/system/NewDialog/NewDialog.stories.jsx
+++ b/src/system/NewDialog/NewDialog.stories.jsx
@@ -152,7 +152,10 @@ export const CustomStateManagement = () => {
 				{ ...defaultProps }
 				open={ open }
 				onOpenChange={ status => {
+					// eslint-disable-next-line no-console
 					console.log( 'New status changed', status );
+
+					setOpen( !! open );
 				} }
 				trigger={ <Button>Trigger Dialog</Button> }
 				content={

--- a/src/system/NewDialog/NewDialog.stories.jsx
+++ b/src/system/NewDialog/NewDialog.stories.jsx
@@ -176,7 +176,7 @@ export const CustomOnClose = () => {
 				trigger={ <Button>Trigger Dialog</Button> }
 				content={ ( { onClose } ) => (
 					<div sx={ { mt: 2 } }>
-						<Button onClick={ () => onClose() }>Close here instead</Button>
+						<Button onClick={ onClose }>Close here instead</Button>
 					</div>
 				) }
 			/>

--- a/src/system/NewDialog/NewDialog.stories.jsx
+++ b/src/system/NewDialog/NewDialog.stories.jsx
@@ -89,6 +89,7 @@ export const HiddenHeadings = () => (
 		/>
 	</>
 );
+
 export const CustomStyling = () => (
 	<>
 		<Text sx={ { fontSize: 3, mb: 3 } }>Custom Styling on Dialog Content</Text>
@@ -136,6 +137,7 @@ export const CustomClose = () => (
 		/>
 	</>
 );
+
 export const CustomStateManagement = () => {
 	const [ open, setOpen ] = useState( false );
 	return (
@@ -152,10 +154,31 @@ export const CustomStateManagement = () => {
 				onOpenChange={ setOpen }
 				trigger={ <Button>Trigger Dialog</Button> }
 				content={
-					<div>
+					<div sx={ { mt: 2 } }>
 						<Button onClick={ () => setOpen( false ) }>Close here instead</Button>
 					</div>
 				}
+			/>
+		</>
+	);
+};
+
+export const CustomOnClose = () => {
+	return (
+		<>
+			<Text sx={ { fontSize: 3, mb: 3 } }>
+				This example shows how you can use the content as a function to use the onClose method (same
+				behavior as the original Dialog component).
+			</Text>
+
+			<NewDialog.Root
+				{ ...defaultProps }
+				trigger={ <Button>Trigger Dialog</Button> }
+				content={ ( { onClose } ) => (
+					<div sx={ { mt: 2 } }>
+						<Button onClick={ () => onClose() }>Close here instead</Button>
+					</div>
+				) }
 			/>
 		</>
 	);

--- a/src/system/NewDialog/NewDialog.stories.jsx
+++ b/src/system/NewDialog/NewDialog.stories.jsx
@@ -151,11 +151,15 @@ export const CustomStateManagement = () => {
 			<NewDialog.Root
 				{ ...defaultProps }
 				open={ open }
-				onOpenChange={ setOpen }
+				onOpenChange={ status => {
+					console.log( 'New status changed', status );
+				} }
 				trigger={ <Button>Trigger Dialog</Button> }
 				content={
 					<div sx={ { mt: 2 } }>
-						<Button onClick={ () => setOpen( false ) }>Close here instead</Button>
+						<NewDialog.Close>
+							<Button>Close here instead</Button>
+						</NewDialog.Close>
 					</div>
 				}
 			/>


### PR DESCRIPTION
## Description

The current implementation of our Dialog has this feature where you can close the dialog using a function on the Dialog content property.

You can check the StoryBook example in the changed files to understand better.

## Checklist

- [ ] This PR has good automated test coverage
- [x] The storybook for the component has been updated

## Steps to Test

1. Pull down PR.
2. `npm run dev`.
3. Open https://deploy-preview-96--vip-design-system-components.netlify.app/?path=/story/newdialog--custom-on-close
4. Check the example works as expected, controlling the dialog using the exported `onClose`.
