### PR TITLE
Adds new component: Dropdown

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -40,6 +40,7 @@
 				"@babel/preset-react": "^7.12.13",
 				"@babel/runtime": "7.14.0",
 				"@mdx-js/react": "^2.1.1",
+				"@radix-ui/react-icons": "^1.1.1",
 				"@storybook/addon-a11y": "^6.5.9",
 				"@storybook/addon-actions": "^6.5.9",
 				"@storybook/addon-controls": "^6.5.9",
@@ -5200,6 +5201,15 @@
 			},
 			"peerDependencies": {
 				"react": "^16.8 || ^17.0 || ^18.0"
+			}
+		},
+		"node_modules/@radix-ui/react-icons": {
+			"version": "1.1.1",
+			"resolved": "https://registry.npmjs.org/@radix-ui/react-icons/-/react-icons-1.1.1.tgz",
+			"integrity": "sha512-xc3wQC59rsFylVbSusQCrrM+6695ppF730Q6yqzhRdqDcRNWIm2R6ngpzBoSOQMcwnq4p805F+Gr7xo4fmtN1A==",
+			"dev": true,
+			"peerDependencies": {
+				"react": "^16.x || ^17.x || ^18.x"
 			}
 		},
 		"node_modules/@radix-ui/react-radio-group": {
@@ -39604,6 +39614,13 @@
 					}
 				}
 			}
+		},
+		"@radix-ui/react-icons": {
+			"version": "1.1.1",
+			"resolved": "https://registry.npmjs.org/@radix-ui/react-icons/-/react-icons-1.1.1.tgz",
+			"integrity": "sha512-xc3wQC59rsFylVbSusQCrrM+6695ppF730Q6yqzhRdqDcRNWIm2R6ngpzBoSOQMcwnq4p805F+Gr7xo4fmtN1A==",
+			"dev": true,
+			"requires": {}
 		},
 		"@radix-ui/react-radio-group": {
 			"version": "1.0.0",

--- a/package.json
+++ b/package.json
@@ -88,6 +88,7 @@
 		"@babel/preset-react": "^7.12.13",
 		"@babel/runtime": "7.14.0",
 		"@mdx-js/react": "^2.1.1",
+		"@radix-ui/react-icons": "^1.1.1",
 		"@storybook/addon-a11y": "^6.5.9",
 		"@storybook/addon-actions": "^6.5.9",
 		"@storybook/addon-controls": "^6.5.9",

--- a/src/system/Dropdown/Dropdown.js
+++ b/src/system/Dropdown/Dropdown.js
@@ -1,0 +1,52 @@
+/** @jsxImportSource theme-ui */
+
+/**
+ * External dependencies
+ */
+import * as DropdownMenuPrimitive from '@radix-ui/react-dropdown-menu';
+import PropTypes from 'prop-types';
+
+/**
+ * Internal dependencies
+ */
+import { DropdownContent } from './DropdownContent';
+
+const DropdownMenu = DropdownMenuPrimitive.Root;
+const DropdownTrigger = DropdownMenuPrimitive.Trigger;
+const DropdownRadioGroup = DropdownMenuPrimitive.RadioGroup;
+const DropdownItemIndicator = DropdownMenuPrimitive.DropdownMenuItemIndicator;
+const DropdownLabel = DropdownMenuPrimitive.DropdownMenuLabel;
+const DropdownSeparator = DropdownMenuPrimitive.DropdownMenuSeparator;
+const DropdownSub = DropdownMenuPrimitive.DropdownMenuSub;
+const DropdownSubTrigger = DropdownMenuPrimitive.DropdownMenuSubTrigger;
+const DropdownSubContent = DropdownMenuPrimitive.DropdownMenuSubContent;
+
+export const Dropdown = ( { trigger, children } ) => (
+	<DropdownMenu>
+		<DropdownTrigger asChild>{ trigger }</DropdownTrigger>
+
+		<DropdownMenuPrimitive.Portal>
+			<DropdownContent>
+				{ children }
+				<DropdownMenuPrimitive.Arrow sx={ { fill: 'white' } } />
+			</DropdownContent>
+		</DropdownMenuPrimitive.Portal>
+	</DropdownMenu>
+);
+
+Dropdown.propTypes = {
+	trigger: PropTypes.node.isRequired,
+	children: PropTypes.node.isRequired,
+};
+
+// Exports
+export {
+	DropdownTrigger,
+	DropdownRadioGroup,
+	DropdownItemIndicator,
+	DropdownLabel,
+	DropdownSeparator,
+	DropdownSub,
+	DropdownSubTrigger,
+	DropdownSubContent,
+};

--- a/src/system/Dropdown/Dropdown.js
+++ b/src/system/Dropdown/Dropdown.js
@@ -3,6 +3,7 @@
 /**
  * External dependencies
  */
+import React from 'react';
 import * as DropdownMenuPrimitive from '@radix-ui/react-dropdown-menu';
 import PropTypes from 'prop-types';
 
@@ -21,18 +22,31 @@ const DropdownSub = DropdownMenuPrimitive.DropdownMenuSub;
 const DropdownSubTrigger = DropdownMenuPrimitive.DropdownMenuSubTrigger;
 const DropdownSubContent = DropdownMenuPrimitive.DropdownMenuSubContent;
 
-export const Dropdown = ( { trigger, children } ) => (
-	<DropdownMenu>
-		<DropdownTrigger asChild>{ trigger }</DropdownTrigger>
+export const Dropdown = ( { trigger, children } ) => {
+	const firstChild = React.useMemo(
+		() =>
+			React.isValidElement( children ) ? React.Children.only( children )?.type?.displayName : '',
+		[ children ]
+	);
 
-		<DropdownMenuPrimitive.Portal>
-			<DropdownContent>
-				{ children }
-				<DropdownMenuPrimitive.Arrow sx={ { fill: 'white' } } />
-			</DropdownContent>
-		</DropdownMenuPrimitive.Portal>
-	</DropdownMenu>
-);
+	return (
+		<DropdownMenu>
+			<DropdownTrigger asChild>{ trigger }</DropdownTrigger>
+
+			<DropdownMenuPrimitive.Portal>
+				{ /* User can customize the content */ }
+				{ firstChild === 'DropdownContent' ? (
+					children
+				) : (
+					<DropdownContent>
+						{ children }
+						<DropdownMenuPrimitive.Arrow sx={ { fill: 'white' } } />
+					</DropdownContent>
+				) }
+			</DropdownMenuPrimitive.Portal>
+		</DropdownMenu>
+	);
+};
 
 Dropdown.propTypes = {
 	trigger: PropTypes.node.isRequired,

--- a/src/system/Dropdown/Dropdown.stories.jsx
+++ b/src/system/Dropdown/Dropdown.stories.jsx
@@ -1,0 +1,115 @@
+/** @jsxImportSource theme-ui */
+
+/**
+ * External dependencies
+ */
+import React from 'react';
+import { DotFilledIcon, CheckIcon, ChevronRightIcon } from '@radix-ui/react-icons';
+
+/**
+ /**
+* Internal dependencies
+*/
+
+import * as Dropdown from '.';
+import { Button } from '../Button';
+
+export default {
+	title: 'Dropdown',
+	component: Dropdown.Root,
+};
+
+export const Default = () => (
+	<>
+		<Dropdown.Root trigger={ <Button>Open</Button> }>
+			<Dropdown.Item>All</Dropdown.Item>
+			<Dropdown.Item>Completed</Dropdown.Item>
+			<Dropdown.Item>Running</Dropdown.Item>
+			<Dropdown.Item>Cancelled</Dropdown.Item>
+			<Dropdown.Separator />
+			<Dropdown.Item>Errored</Dropdown.Item>
+		</Dropdown.Root>
+
+		<p>
+			This component is based on the Radix Dropdown. You can find all available options, props and
+			features in the{ ' ' }
+			<a
+				href="https://www.radix-ui.com/docs/primitives/components/dropdown-menu"
+				target="_blank"
+				rel="noopener noreferrer"
+			>
+				Dropdown Documentation page.
+			</a>
+		</p>
+	</>
+);
+
+export const ComplexOptions = () => {
+	const [ bookmarksChecked, setBookmarksChecked ] = React.useState( true );
+	const [ urlsChecked, setUrlsChecked ] = React.useState( false );
+	const [ person, setPerson ] = React.useState( 'pedro' );
+
+	return (
+		<>
+			<Dropdown.Root trigger={ <Button>See options</Button> }>
+				<Dropdown.Item>New Tab</Dropdown.Item>
+				<Dropdown.Item>New Window</Dropdown.Item>
+				<Dropdown.Item disabled>New Private Window</Dropdown.Item>
+				<Dropdown.Sub>
+					<Dropdown.SubTrigger>
+						More Tools
+						<ChevronRightIcon />
+					</Dropdown.SubTrigger>
+					<Dropdown.SubContent sideOffset={ 2 } alignOffset={ -5 }>
+						<Dropdown.Item>Save Page As…</Dropdown.Item>
+						<Dropdown.Item>Create Shortcut…</Dropdown.Item>
+						<Dropdown.Item>Name Window…</Dropdown.Item>
+						<Dropdown.Separator />
+						<Dropdown.Item>Developer Tools</Dropdown.Item>
+					</Dropdown.SubContent>
+				</Dropdown.Sub>
+				<Dropdown.Separator />
+				<Dropdown.CheckboxItem checked={ bookmarksChecked } onCheckedChange={ setBookmarksChecked }>
+					<Dropdown.ItemIndicator>
+						<CheckIcon />
+					</Dropdown.ItemIndicator>
+					Show Bookmarks
+				</Dropdown.CheckboxItem>
+				<Dropdown.CheckboxItem checked={ urlsChecked } onCheckedChange={ setUrlsChecked }>
+					<Dropdown.ItemIndicator>
+						<CheckIcon />
+					</Dropdown.ItemIndicator>
+					Show Full URLs
+				</Dropdown.CheckboxItem>
+				<Dropdown.Separator />
+				<Dropdown.Label>People</Dropdown.Label>
+				<Dropdown.RadioGroup value={ person } onValueChange={ setPerson }>
+					<Dropdown.RadioItem value="pedro">
+						<Dropdown.ItemIndicator>
+							<DotFilledIcon />
+						</Dropdown.ItemIndicator>
+						Pedro Duarte
+					</Dropdown.RadioItem>
+					<Dropdown.RadioItem value="colm">
+						<Dropdown.ItemIndicator>
+							<DotFilledIcon />
+						</Dropdown.ItemIndicator>
+						Colm Tuite
+					</Dropdown.RadioItem>
+				</Dropdown.RadioGroup>
+			</Dropdown.Root>
+
+			<p>
+				This component is based on the Radix Dropdown. You can find all available options, props and
+				features in the{ ' ' }
+				<a
+					href="https://www.radix-ui.com/docs/primitives/components/dropdown-menu"
+					target="_blank"
+					rel="noopener noreferrer"
+				>
+					Dropdown Documentation page.
+				</a>
+			</p>
+		</>
+	);
+};

--- a/src/system/Dropdown/Dropdown.stories.jsx
+++ b/src/system/Dropdown/Dropdown.stories.jsx
@@ -13,6 +13,7 @@ import { DotFilledIcon, CheckIcon, ChevronRightIcon } from '@radix-ui/react-icon
 
 import * as Dropdown from '.';
 import { Button } from '../Button';
+import { NewConfirmationDialog } from '../NewConfirmationDialog';
 
 export default {
 	title: 'Dropdown',
@@ -110,6 +111,47 @@ export const ComplexOptions = () => {
 					Dropdown Documentation page.
 				</a>
 			</p>
+		</>
+	);
+};
+
+export const WithDialogState = () => {
+	const [ alertOpen, setAlertOpen ] = React.useState( false );
+	const [ menuOpen, setMenuOpen ] = React.useState( false );
+	const triggerRef = React.useRef();
+	return (
+		<>
+			<p>
+				In this example, you can see how to trigger a Dialog from the Dropdown and still keep the
+				focus back to the dropdown once the Dialog is closed. This example is important to keep
+				accessibility.
+			</p>
+
+			<Dropdown.Root
+				open={ menuOpen }
+				onOpenChange={ setMenuOpen }
+				trigger={ <Button ref={ triggerRef }>Open</Button> }
+			>
+				<Dropdown.Content hidden={ alertOpen }>
+					<Dropdown.Item>Copy</Dropdown.Item>
+
+					<NewConfirmationDialog
+						title={ 'Are you sure?' }
+						description={ 'Please confirm that' }
+						body="Bla bleh."
+						needsConfirm={ true }
+						open={ alertOpen }
+						onOpenChange={ setAlertOpen }
+						onConfirm={ () => {
+							setMenuOpen( false );
+							triggerRef.current.focus();
+						} }
+						trigger={
+							<Dropdown.Item onSelect={ event => event.preventDefault() }>Click here</Dropdown.Item>
+						}
+					/>
+				</Dropdown.Content>
+			</Dropdown.Root>
 		</>
 	);
 };

--- a/src/system/Dropdown/Dropdown.test.js
+++ b/src/system/Dropdown/Dropdown.test.js
@@ -1,0 +1,33 @@
+/**
+ * External dependencies
+ */
+import { fireEvent, render, screen } from '@testing-library/react';
+import { axe } from 'jest-axe';
+
+/**
+ * Internal dependencies
+ */
+import * as Dropdown from '.';
+
+const defaultProps = {
+	trigger: <button>Trigger</button>,
+};
+
+const getButton = () => screen.getByRole( 'button', { name: 'Trigger' } );
+
+describe( '<Dropdown />', () => {
+	it( 'renders the Dropdown component', async () => {
+		const { container } = render(
+			<Dropdown.Root { ...defaultProps }>
+				<Dropdown.Item>My Item</Dropdown.Item>
+			</Dropdown.Root>
+		);
+
+		expect( getButton() ).toBeInTheDocument();
+
+		fireEvent.click( getButton() );
+
+		// Check for accessibility issues
+		await expect( await axe( container ) ).toHaveNoViolations();
+	} );
+} );

--- a/src/system/Dropdown/DropdownContent.js
+++ b/src/system/Dropdown/DropdownContent.js
@@ -1,0 +1,30 @@
+/** @jsxImportSource theme-ui */
+
+/**
+ * External dependencies
+ */
+import React from 'react';
+import * as DropdownMenuPrimitive from '@radix-ui/react-dropdown-menu';
+
+export const styles = {
+	minWidth: 220,
+	borderRadius: 6,
+	backgroundColor: 'background',
+	boxShadow: 'high',
+	px: 2,
+	py: 1,
+};
+
+export const DropdownContent = React.forwardRef( ( props, forwardRef ) => (
+	<DropdownMenuPrimitive.DropdownMenuContent ref={ forwardRef } sx={ styles } { ...props } />
+) );
+
+DropdownContent.displayName = 'DropdownContent';
+
+export const DropdownSubContent = React.forwardRef( ( props, forwardRef ) => (
+	<DropdownMenuPrimitive.Portal>
+		<DropdownMenuPrimitive.DropdownMenuSubContent ref={ forwardRef } sx={ styles } { ...props } />
+	</DropdownMenuPrimitive.Portal>
+) );
+
+DropdownSubContent.displayName = 'DropdownSubContent';

--- a/src/system/Dropdown/DropdownItem.js
+++ b/src/system/Dropdown/DropdownItem.js
@@ -6,7 +6,7 @@
 import React from 'react';
 import * as DropdownMenuPrimitive from '@radix-ui/react-dropdown-menu';
 
-export const dropdownItemStyles = {
+export const styles = {
 	unset: 'all',
 	cursor: 'pointer',
 	display: 'flex',
@@ -37,23 +37,19 @@ export const dropdownItemStyles = {
 };
 
 export const DropdownItem = React.forwardRef( ( props, forwardRef ) => (
-	<DropdownMenuPrimitive.DropdownMenuItem
-		ref={ forwardRef }
-		sx={ dropdownItemStyles }
-		{ ...props }
-	/>
+	<DropdownMenuPrimitive.DropdownMenuItem ref={ forwardRef } sx={ styles } { ...props } />
 ) );
 
 DropdownItem.displayName = 'DropdownItem';
 
 export const DropdownCheckboxItem = React.forwardRef( ( props, forwardRef ) => (
-	<DropdownMenuPrimitive.CheckboxItem ref={ forwardRef } sx={ dropdownItemStyles } { ...props } />
+	<DropdownMenuPrimitive.CheckboxItem ref={ forwardRef } sx={ styles } { ...props } />
 ) );
 
 DropdownCheckboxItem.displayName = 'DropdownCheckboxItem';
 
 export const DropdownRadioItem = React.forwardRef( ( props, forwardRef ) => (
-	<DropdownMenuPrimitive.RadioItem ref={ forwardRef } sx={ dropdownItemStyles } { ...props } />
+	<DropdownMenuPrimitive.RadioItem ref={ forwardRef } sx={ styles } { ...props } />
 ) );
 
 DropdownRadioItem.displayName = 'DropdownRadioItem';
@@ -62,7 +58,7 @@ export const DropdownSubTrigger = React.forwardRef( ( props, forwardRef ) => (
 	<DropdownMenuPrimitive.SubTrigger
 		ref={ forwardRef }
 		sx={ {
-			...dropdownItemStyles,
+			...styles,
 			...{
 				'&[data-state="open"]': {
 					background: 'highlight',

--- a/src/system/Dropdown/DropdownItem.js
+++ b/src/system/Dropdown/DropdownItem.js
@@ -1,0 +1,77 @@
+/** @jsxImportSource theme-ui */
+
+/**
+ * External dependencies
+ */
+import React from 'react';
+import * as DropdownMenuPrimitive from '@radix-ui/react-dropdown-menu';
+
+export const dropdownItemStyles = {
+	unset: 'all',
+	cursor: 'pointer',
+	display: 'flex',
+	alignItems: 'center',
+	flexDirection: 'row',
+	textAlign: 'left',
+	height: 25,
+	textDecoration: 'none',
+	position: 'relative',
+	m: 0,
+	color: 'heading',
+	px: 2,
+	paddingLeft: 10,
+	py: 1,
+	'&:hover, &:focus': {
+		backgroundColor: 'hover',
+	},
+
+	'&[data-disabled]': {
+		color: 'muted',
+		pointerEvents: 'none',
+	},
+
+	'&[data-highlighted]': {
+		backgroundColor: 'hover',
+		color: 'primary',
+	},
+};
+
+export const DropdownItem = React.forwardRef( ( props, forwardRef ) => (
+	<DropdownMenuPrimitive.DropdownMenuItem
+		ref={ forwardRef }
+		sx={ dropdownItemStyles }
+		{ ...props }
+	/>
+) );
+
+DropdownItem.displayName = 'DropdownItem';
+
+export const DropdownCheckboxItem = React.forwardRef( ( props, forwardRef ) => (
+	<DropdownMenuPrimitive.CheckboxItem ref={ forwardRef } sx={ dropdownItemStyles } { ...props } />
+) );
+
+DropdownCheckboxItem.displayName = 'DropdownCheckboxItem';
+
+export const DropdownRadioItem = React.forwardRef( ( props, forwardRef ) => (
+	<DropdownMenuPrimitive.RadioItem ref={ forwardRef } sx={ dropdownItemStyles } { ...props } />
+) );
+
+DropdownRadioItem.displayName = 'DropdownRadioItem';
+
+export const DropdownSubTrigger = React.forwardRef( ( props, forwardRef ) => (
+	<DropdownMenuPrimitive.SubTrigger
+		ref={ forwardRef }
+		sx={ {
+			...dropdownItemStyles,
+			...{
+				'&[data-state="open"]': {
+					background: 'highlight',
+					color: 'primary',
+				},
+			},
+		} }
+		{ ...props }
+	/>
+) );
+
+DropdownSubTrigger.displayName = 'DropdownSubTrigger';

--- a/src/system/Dropdown/DropdownLabel.js
+++ b/src/system/Dropdown/DropdownLabel.js
@@ -1,0 +1,20 @@
+/** @jsxImportSource theme-ui */
+
+/**
+ * External dependencies
+ */
+import React from 'react';
+import * as DropdownMenuPrimitive from '@radix-ui/react-dropdown-menu';
+
+export const styles = {
+	paddingLeft: 10,
+	fontSize: 12,
+	lineHeight: '25px',
+	color: 'muted',
+};
+
+export const DropdownLabel = React.forwardRef( ( props, forwardRef ) => (
+	<DropdownMenuPrimitive.DropdownMenuLabel ref={ forwardRef } sx={ styles } { ...props } />
+) );
+
+DropdownLabel.displayName = 'DropdownLabel';

--- a/src/system/Dropdown/DropdownSeparator.js
+++ b/src/system/Dropdown/DropdownSeparator.js
@@ -1,0 +1,19 @@
+/** @jsxImportSource theme-ui */
+
+/**
+ * External dependencies
+ */
+import React from 'react';
+import * as DropdownMenuPrimitive from '@radix-ui/react-dropdown-menu';
+
+export const styles = {
+	height: '1px',
+	backgroundColor: 'border',
+	my: '5px',
+};
+
+export const DropdownSeparator = React.forwardRef( ( props, forwardRef ) => (
+	<DropdownMenuPrimitive.DropdownMenuSeparator ref={ forwardRef } sx={ styles } { ...props } />
+) );
+
+DropdownSeparator.displayName = 'DropdownSeparator';

--- a/src/system/Dropdown/index.js
+++ b/src/system/Dropdown/index.js
@@ -1,0 +1,52 @@
+/** @jsxImportSource theme-ui */
+/**
+ * Internal dependencies
+ */
+import {
+	Dropdown,
+	DropdownTrigger,
+	DropdownRadioGroup,
+	DropdownItemIndicator,
+	DropdownSub,
+} from './Dropdown';
+
+import {
+	DropdownItem,
+	DropdownCheckboxItem,
+	DropdownRadioItem,
+	DropdownSubTrigger,
+} from './DropdownItem';
+
+import { DropdownSeparator } from './DropdownSeparator';
+import { DropdownSubContent } from './DropdownContent';
+import { DropdownLabel } from './DropdownLabel';
+
+const Root = Dropdown;
+const Trigger = DropdownTrigger;
+const Item = DropdownItem;
+const CheckboxItem = DropdownCheckboxItem;
+const RadioGroup = DropdownRadioGroup;
+const RadioItem = DropdownRadioItem;
+const ItemIndicator = DropdownItemIndicator;
+const Label = DropdownLabel;
+const Separator = DropdownSeparator;
+const Sub = DropdownSub;
+const SubTrigger = DropdownSubTrigger;
+const SubContent = DropdownSubContent;
+
+export {
+	Root,
+	Trigger,
+	Item,
+	CheckboxItem,
+	RadioGroup,
+	RadioItem,
+	ItemIndicator,
+	Label,
+	Separator,
+	Sub,
+	SubTrigger,
+	SubContent,
+};
+
+export default Dropdown;

--- a/src/system/Dropdown/index.js
+++ b/src/system/Dropdown/index.js
@@ -18,10 +18,11 @@ import {
 } from './DropdownItem';
 
 import { DropdownSeparator } from './DropdownSeparator';
-import { DropdownSubContent } from './DropdownContent';
+import { DropdownSubContent, DropdownContent } from './DropdownContent';
 import { DropdownLabel } from './DropdownLabel';
 
 const Root = Dropdown;
+const Content = DropdownContent;
 const Trigger = DropdownTrigger;
 const Item = DropdownItem;
 const CheckboxItem = DropdownCheckboxItem;
@@ -37,6 +38,7 @@ const SubContent = DropdownSubContent;
 export {
 	Root,
 	Trigger,
+	Content,
 	Item,
 	CheckboxItem,
 	RadioGroup,

--- a/src/system/NewDialog/DialogContent.js
+++ b/src/system/NewDialog/DialogContent.js
@@ -13,6 +13,5 @@ export const contentStyles = {
 	maxWidth: '640px',
 	maxHeight: '85vh',
 	padding: 32,
-	'&:focus': { outline: 'none' },
 	'> h1, > h2': { marginTop: '0 !important' },
 };

--- a/src/system/index.js
+++ b/src/system/index.js
@@ -19,6 +19,7 @@ import {
 } from './Dialog';
 
 import * as NewDialog from './NewDialog';
+import * as Dropdown from './Dropdown';
 import { ConfirmationDialog } from './ConfirmationDialog';
 import { NewConfirmationDialog } from './NewConfirmationDialog';
 import { Flex } from './Flex';
@@ -64,6 +65,7 @@ export {
 	Code,
 	Dialog,
 	NewDialog,
+	Dropdown,
 	DialogButton,
 	DialogMenu,
 	DialogMenuItem,

--- a/src/system/theme/index.js
+++ b/src/system/theme/index.js
@@ -54,7 +54,7 @@ const textStyles = {
 
 const outline = {
 	outlineStyle: 'solid',
-	outlineColor: '#f5f5f5',
+	outlineColor: '#ffffff',
 	outlineWidth: '1px',
 	boxShadow: `0 0 0 1px ${ getColor( 'focus', 'inset' ) }, 0 0 0 3px ${ getColor( 'focus' ) }`,
 };

--- a/src/system/theme/index.js
+++ b/src/system/theme/index.js
@@ -54,7 +54,7 @@ const textStyles = {
 
 const outline = {
 	outlineStyle: 'solid',
-	outlineColor: '#ffffff',
+	outlineColor: '#f5f5f5',
 	outlineWidth: '1px',
 	boxShadow: `0 0 0 1px ${ getColor( 'focus', 'inset' ) }, 0 0 0 3px ${ getColor( 'focus' ) }`,
 };


### PR DESCRIPTION
## Description

Adding the `Dropdown` new component 🥳 . This component should replace all `DialogMenu` with all his children: `DialogMenuItem`, etc.

![CvH80UXKrf](https://user-images.githubusercontent.com/3402/186517692-5c5aab2a-2ef1-43be-9c98-6d9b417429a4.gif)

The new component provides:

- [Full documented API from Radix](https://www.radix-ui.com/docs/primitives/components/dropdown-menu)
- A11Y capabilities
- Dark mode support
- Support to Sub menus
- Support to Checkbox items
- Support to open a Modal and keep focus after the Dialog is closed (pending Story)

## Checklist

- [ ] This PR has good automated test coverage
- [x] The storybook for the component has been updated

## Steps to Test

1. Pull down PR.
2. `npm run dev`.
3. Open Storybook.
4. Check how the Dropdown behaves similarly to the <Dialog> component, but with accessibility. You can use a keyboard, and navigate using sub-menus, etc.

