### PR TITLE
Add buttonVariant to NewConfirmationDialog

### DIFF
--- a/src/system/NewConfirmationDialog/NewConfirmationDialog.js
+++ b/src/system/NewConfirmationDialog/NewConfirmationDialog.js
@@ -14,6 +14,7 @@ import { NewDialog, Box, Flex, Button } from '..';
 
 const NewConfirmationDialogContent = ( {
 	label = 'Confirm',
+	buttonVariant = 'danger',
 	onConfirm,
 	onClose,
 	className = null,
@@ -25,7 +26,7 @@ const NewConfirmationDialogContent = ( {
 			</Button>
 			<NewDialog.Close>
 				<Button
-					variant="danger"
+					variant={ buttonVariant }
 					onClick={ () => {
 						onConfirm();
 						onClose();
@@ -41,6 +42,7 @@ const NewConfirmationDialogContent = ( {
 NewConfirmationDialogContent.propTypes = {
 	body: PropTypes.node,
 	label: PropTypes.string,
+	buttonVariant: PropTypes.string,
 	onClose: PropTypes.func,
 	onConfirm: PropTypes.func,
 	className: PropTypes.any,
@@ -51,6 +53,7 @@ const NewConfirmationDialog = ( {
 	onConfirm,
 	needsConfirm = true,
 	label,
+	buttonVariant,
 	title,
 	body = '',
 } ) => {
@@ -74,6 +77,7 @@ const NewConfirmationDialog = ( {
 					onConfirm={ onConfirm }
 					body={ body }
 					label={ label }
+					buttonVariant={ buttonVariant }
 				/>
 			}
 			trigger={ trigger }
@@ -88,6 +92,7 @@ NewConfirmationDialog.propTypes = {
 	title: PropTypes.node.isRequired,
 	body: PropTypes.node,
 	label: PropTypes.node,
+	buttonVariant: PropTypes.string,
 };
 
 export { NewConfirmationDialog };

--- a/src/system/NewConfirmationDialog/NewConfirmationDialog.stories.jsx
+++ b/src/system/NewConfirmationDialog/NewConfirmationDialog.stories.jsx
@@ -18,6 +18,7 @@ export const Default = () => {
 			<p>Confirm that your name is John doe?</p>
 			<NewConfirmationDialog
 				title={ 'Are you John Doe?' }
+				buttonVariant="danger"
 				description={ 'Please confirm that your name is John Doe.' }
 				trigger={ ConfirmationTrigger }
 				body="A modal is used to perform more detailed actions that don&lsquo;t necessarily need the context


### PR DESCRIPTION
## Description

Add Confirm button `variant` to the NewConfirmationDialog, instead of having `danger` variant fixed.

## Checklist

- [ ] This PR has good automated test coverage
- [ ] The storybook for the component has been updated

## Steps to Test

Outline the steps to test and verify the PR here.

Example:

1. Pull down PR.
1. `npm run dev`.
1. Open Storybook - https://deploy-preview-101--vip-design-system-components.netlify.app/?path=/story/confirmationdialog--default
1. Open ConfirmationDialog / Default.
1. Click on "Dangerous Action".
1. Confirm button should appear with red color.
