### PR TITLE
Mixed fixes related to focus management and dark mode support

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -1,12 +1,12 @@
 {
 	"name": "@automattic/vip-design-system",
-	"version": "0.18.2-0",
+	"version": "0.18.3-0",
 	"lockfileVersion": 2,
 	"requires": true,
 	"packages": {
 		"": {
 			"name": "@automattic/vip-design-system",
-			"version": "0.18.2-0",
+			"version": "0.18.3-0",
 			"dependencies": {
 				"@radix-ui/react-checkbox": "^1.0.0",
 				"@radix-ui/react-dialog": "^1.0.0",

--- a/package-lock.json
+++ b/package-lock.json
@@ -1,12 +1,12 @@
 {
 	"name": "@automattic/vip-design-system",
-	"version": "0.18.5-0",
+	"version": "0.19.0",
 	"lockfileVersion": 2,
 	"requires": true,
 	"packages": {
 		"": {
 			"name": "@automattic/vip-design-system",
-			"version": "0.18.5-0",
+			"version": "0.19.0",
 			"dependencies": {
 				"@radix-ui/react-checkbox": "^1.0.0",
 				"@radix-ui/react-dialog": "^1.0.0",

--- a/package-lock.json
+++ b/package-lock.json
@@ -1,12 +1,12 @@
 {
 	"name": "@automattic/vip-design-system",
-	"version": "0.18.4-0",
+	"version": "0.18.5-0",
 	"lockfileVersion": 2,
 	"requires": true,
 	"packages": {
 		"": {
 			"name": "@automattic/vip-design-system",
-			"version": "0.18.4-0",
+			"version": "0.18.5-0",
 			"dependencies": {
 				"@radix-ui/react-checkbox": "^1.0.0",
 				"@radix-ui/react-dialog": "^1.0.0",

--- a/package-lock.json
+++ b/package-lock.json
@@ -1,12 +1,12 @@
 {
 	"name": "@automattic/vip-design-system",
-	"version": "0.18.3-0",
+	"version": "0.18.4-0",
 	"lockfileVersion": 2,
 	"requires": true,
 	"packages": {
 		"": {
 			"name": "@automattic/vip-design-system",
-			"version": "0.18.3-0",
+			"version": "0.18.4-0",
 			"dependencies": {
 				"@radix-ui/react-checkbox": "^1.0.0",
 				"@radix-ui/react-dialog": "^1.0.0",

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
 	"name": "@automattic/vip-design-system",
-	"version": "0.18.2-0",
+	"version": "0.18.3-0",
 	"main": "build/system/index.js",
 	"scripts": {
 		"build-storybook": "build-storybook",

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
 	"name": "@automattic/vip-design-system",
-	"version": "0.18.3-0",
+	"version": "0.18.4-0",
 	"main": "build/system/index.js",
 	"scripts": {
 		"build-storybook": "build-storybook",

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
 	"name": "@automattic/vip-design-system",
-	"version": "0.18.5-0",
+	"version": "0.19.0",
 	"main": "build/system/index.js",
 	"scripts": {
 		"build-storybook": "build-storybook",

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
 	"name": "@automattic/vip-design-system",
-	"version": "0.18.4-0",
+	"version": "0.18.5-0",
 	"main": "build/system/index.js",
 	"scripts": {
 		"build-storybook": "build-storybook",

--- a/src/system/Dropdown/Dropdown.js
+++ b/src/system/Dropdown/Dropdown.js
@@ -22,7 +22,18 @@ const DropdownSub = DropdownMenuPrimitive.DropdownMenuSub;
 const DropdownSubTrigger = DropdownMenuPrimitive.DropdownMenuSubTrigger;
 const DropdownSubContent = DropdownMenuPrimitive.DropdownMenuSubContent;
 
-export const Dropdown = ( { trigger, children } ) => {
+export const Dropdown = ( {
+	trigger,
+	children,
+	// Radix Specific Properties
+	open = undefined,
+	defaultOpen = false,
+	onOpenChange = undefined,
+	modal = true,
+	dir = 'ltr',
+	contentProps = {},
+	portalProps = {},
+} ) => {
 	const firstChild = React.useMemo(
 		() =>
 			React.isValidElement( children ) ? React.Children.only( children )?.type?.displayName : '',
@@ -30,17 +41,23 @@ export const Dropdown = ( { trigger, children } ) => {
 	);
 
 	return (
-		<DropdownMenu>
+		<DropdownMenu
+			open={ open }
+			defaultOpen={ defaultOpen }
+			onOpenChange={ onOpenChange }
+			modal={ modal }
+			dir={ dir }
+		>
 			<DropdownTrigger asChild>{ trigger }</DropdownTrigger>
 
-			<DropdownMenuPrimitive.Portal>
+			<DropdownMenuPrimitive.Portal { ...portalProps }>
 				{ /* User can customize the content */ }
 				{ firstChild === 'DropdownContent' ? (
 					children
 				) : (
-					<DropdownContent>
+					<DropdownContent { ...contentProps }>
 						{ children }
-						<DropdownMenuPrimitive.Arrow sx={ { fill: 'white' } } />
+						<DropdownMenuPrimitive.Arrow sx={ { fill: 'background', boxShadow: 'high' } } />
 					</DropdownContent>
 				) }
 			</DropdownMenuPrimitive.Portal>
@@ -51,6 +68,13 @@ export const Dropdown = ( { trigger, children } ) => {
 Dropdown.propTypes = {
 	trigger: PropTypes.node.isRequired,
 	children: PropTypes.node.isRequired,
+	open: PropTypes.bool,
+	defaultOpen: PropTypes.bool,
+	onOpenChange: PropTypes.func,
+	modal: PropTypes.bool,
+	dir: PropTypes.string,
+	contentProps: PropTypes.any,
+	portalProps: PropTypes.any,
 };
 
 // Exports

--- a/src/system/Dropdown/Dropdown.js
+++ b/src/system/Dropdown/Dropdown.js
@@ -68,12 +68,17 @@ export const Dropdown = ( {
 Dropdown.propTypes = {
 	trigger: PropTypes.node.isRequired,
 	children: PropTypes.node.isRequired,
+
+	// Props in root: https://www.radix-ui.com/docs/primitives/components/dropdown-menu#root
 	open: PropTypes.bool,
 	defaultOpen: PropTypes.bool,
 	onOpenChange: PropTypes.func,
 	modal: PropTypes.bool,
 	dir: PropTypes.string,
+
+	// Content props in: https://www.radix-ui.com/docs/primitives/components/dropdown-menu#content
 	contentProps: PropTypes.any,
+	// Portal props in: https://www.radix-ui.com/docs/primitives/components/dropdown-menu#portal
 	portalProps: PropTypes.any,
 };
 

--- a/src/system/Dropdown/Dropdown.stories.jsx
+++ b/src/system/Dropdown/Dropdown.stories.jsx
@@ -129,9 +129,9 @@ export const WithDialog = () => {
 			} }
 			content={
 				<>
-					<button type="button" onClick={ () => onConfirm() }>
-						Close
-					</button>
+					<Button variant="secondary" onClick={ () => onConfirm() }>
+						Custom Close.
+					</Button>
 
 					<p>Teste abc.</p>
 				</>
@@ -141,17 +141,23 @@ export const WithDialog = () => {
 
 	return (
 		<div>
+			<p>
+				This is an important example when combining the Dropdown component with the NewDialog
+				component. In order to have the correct accessibility, there are some events you need to
+				use. Use this example if you can to copy and paste the code.
+			</p>
+
 			<Dropdown.Root
 				open={ menuOpen }
 				onOpenChange={ setMenuOpen }
 				contentProps={ { sideOffset: 5 } }
-				trigger={ <button>open</button> }
+				trigger={ <Button>Open</Button> }
 			>
-				<Dropdown.Item>New Window</Dropdown.Item>
+				<Dropdown.Item>I don&apos;t do anything</Dropdown.Item>
 
 				<AreYouSureDialog
-					title="Django"
-					description="Django man"
+					title="Are you in the jungle?"
+					description="sha-n-n-n-n-n-n-n-n knees, knees"
 					open={ alertOpen }
 					onOpenChange={ setAlertOpen }
 					onConfirm={ () => {
@@ -159,7 +165,7 @@ export const WithDialog = () => {
 						setMenuOpen( false );
 					} }
 					trigger={
-						<Dropdown.Item onSelect={ event => event.preventDefault() }>Delete</Dropdown.Item>
+						<Dropdown.Item onSelect={ event => event.preventDefault() }>Open Dialog</Dropdown.Item>
 					}
 				/>
 			</Dropdown.Root>

--- a/src/system/Dropdown/Dropdown.stories.jsx
+++ b/src/system/Dropdown/Dropdown.stories.jsx
@@ -1,10 +1,10 @@
-/** @jsxImportSource theme-ui */
-
 /**
  * External dependencies
  */
+
 import React from 'react';
-import { DotFilledIcon, CheckIcon, ChevronRightIcon } from '@radix-ui/react-icons';
+import * as DropdownMenuPrimitive from '@radix-ui/react-dropdown-menu';
+import * as AlertDialog from '../NewDialog';
 
 /**
  /**
@@ -12,146 +12,71 @@ import { DotFilledIcon, CheckIcon, ChevronRightIcon } from '@radix-ui/react-icon
 */
 
 import * as Dropdown from '.';
-import { Button } from '../Button';
-import { NewConfirmationDialog } from '../NewConfirmationDialog';
 
 export default {
 	title: 'Dropdown',
 	component: Dropdown.Root,
 };
 
-export const Default = () => (
-	<>
-		<Dropdown.Root trigger={ <Button>Open</Button> }>
-			<Dropdown.Item>All</Dropdown.Item>
-			<Dropdown.Item>Completed</Dropdown.Item>
-			<Dropdown.Item>Running</Dropdown.Item>
-			<Dropdown.Item>Cancelled</Dropdown.Item>
-			<Dropdown.Separator />
-			<Dropdown.Item>Errored</Dropdown.Item>
-		</Dropdown.Root>
+// Exportsconst DropdownMenuContent = Content;
+const DropdownMenuItem = DropdownMenuPrimitive.Item;
 
-		<p>
-			This component is based on the Radix Dropdown. You can find all available options, props and
-			features in the{ ' ' }
-			<a
-				href="https://www.radix-ui.com/docs/primitives/components/dropdown-menu"
-				target="_blank"
-				rel="noopener noreferrer"
-			>
-				Dropdown Documentation page.
-			</a>
-		</p>
-	</>
-);
-
-export const ComplexOptions = () => {
-	const [ bookmarksChecked, setBookmarksChecked ] = React.useState( true );
-	const [ urlsChecked, setUrlsChecked ] = React.useState( false );
-	const [ person, setPerson ] = React.useState( 'pedro' );
-
-	return (
-		<>
-			<Dropdown.Root trigger={ <Button>See options</Button> }>
-				<Dropdown.Item>New Tab</Dropdown.Item>
-				<Dropdown.Item>New Window</Dropdown.Item>
-				<Dropdown.Item disabled>New Private Window</Dropdown.Item>
-				<Dropdown.Sub>
-					<Dropdown.SubTrigger>
-						More Tools
-						<ChevronRightIcon />
-					</Dropdown.SubTrigger>
-					<Dropdown.SubContent sideOffset={ 2 } alignOffset={ -5 }>
-						<Dropdown.Item>Save Page As…</Dropdown.Item>
-						<Dropdown.Item>Create Shortcut…</Dropdown.Item>
-						<Dropdown.Item>Name Window…</Dropdown.Item>
-						<Dropdown.Separator />
-						<Dropdown.Item>Developer Tools</Dropdown.Item>
-					</Dropdown.SubContent>
-				</Dropdown.Sub>
-				<Dropdown.Separator />
-				<Dropdown.CheckboxItem checked={ bookmarksChecked } onCheckedChange={ setBookmarksChecked }>
-					<Dropdown.ItemIndicator>
-						<CheckIcon />
-					</Dropdown.ItemIndicator>
-					Show Bookmarks
-				</Dropdown.CheckboxItem>
-				<Dropdown.CheckboxItem checked={ urlsChecked } onCheckedChange={ setUrlsChecked }>
-					<Dropdown.ItemIndicator>
-						<CheckIcon />
-					</Dropdown.ItemIndicator>
-					Show Full URLs
-				</Dropdown.CheckboxItem>
-				<Dropdown.Separator />
-				<Dropdown.Label>People</Dropdown.Label>
-				<Dropdown.RadioGroup value={ person } onValueChange={ setPerson }>
-					<Dropdown.RadioItem value="pedro">
-						<Dropdown.ItemIndicator>
-							<DotFilledIcon />
-						</Dropdown.ItemIndicator>
-						Pedro Duarte
-					</Dropdown.RadioItem>
-					<Dropdown.RadioItem value="colm">
-						<Dropdown.ItemIndicator>
-							<DotFilledIcon />
-						</Dropdown.ItemIndicator>
-						Colm Tuite
-					</Dropdown.RadioItem>
-				</Dropdown.RadioGroup>
-			</Dropdown.Root>
-
-			<p>
-				This component is based on the Radix Dropdown. You can find all available options, props and
-				features in the{ ' ' }
-				<a
-					href="https://www.radix-ui.com/docs/primitives/components/dropdown-menu"
-					target="_blank"
-					rel="noopener noreferrer"
-				>
-					Dropdown Documentation page.
-				</a>
-			</p>
-		</>
-	);
-};
-
-export const WithDialogState = () => {
+// Your app...
+export const Default = () => {
 	const [ alertOpen, setAlertOpen ] = React.useState( false );
 	const [ menuOpen, setMenuOpen ] = React.useState( false );
 	const triggerRef = React.useRef();
-	return (
-		<>
-			<p>
-				In this example, you can see how to trigger a Dialog from the Dropdown and still keep the
-				focus back to the dropdown once the Dialog is closed. This example is important to keep
-				accessibility.
-			</p>
+	const [ container, setContainer ] = React.useState( null );
 
+	const AreYouSureDialog = ( { children, onConfirm, onCancel, trigger, ...props } ) => (
+		<AlertDialog.Root
+			{ ...props }
+			contentProps={ {
+				onCloseAutoFocus: () => {
+					console.log( 'ok' );
+					triggerRef?.current?.setAttribute( 'tabindex', '-1' );
+					triggerRef?.current?.focus();
+					onConfirm();
+				},
+			} }
+			trigger={ trigger }
+			content={
+				<>
+					<button type="button" onClick={ () => onConfirm() }>
+						Close
+					</button>
+
+					<p>Teste abc.</p>
+				</>
+			}
+		/>
+	);
+
+	return (
+		<div>
 			<Dropdown.Root
 				open={ menuOpen }
 				onOpenChange={ setMenuOpen }
-				trigger={ <Button ref={ triggerRef }>Open</Button> }
+				contentProps={ { sideOffset: 5 } }
+				trigger={ <button ref={ triggerRef }>open</button> }
 			>
-				<Dropdown.Content hidden={ alertOpen }>
-					<Dropdown.Item>Copy</Dropdown.Item>
+				<Dropdown.Item>New Window</Dropdown.Item>
 
-					<NewConfirmationDialog
-						title={ 'Are you sure?' }
-						description={ 'Please confirm that' }
-						body="Bla bleh."
-						needsConfirm={ true }
-						open={ alertOpen }
-						onOpenChange={ setAlertOpen }
-						onConfirm={ () => {
-							setMenuOpen( false );
-							triggerRef.current.focus();
-						} }
-						trigger={
-							<Dropdown.Item onSelect={ event => event.preventDefault() }>Click here</Dropdown.Item>
-						}
-					/>
-				</Dropdown.Content>
+				<AreYouSureDialog
+					title="Django"
+					description="Django man"
+					open={ alertOpen }
+					onOpenChange={ setAlertOpen }
+					onConfirm={ () => {
+						setAlertOpen( false );
+						console.log( triggerRef?.current );
+						setMenuOpen( false );
+					} }
+					trigger={
+						<Dropdown.Item onSelect={ event => event.preventDefault() }>Delete</Dropdown.Item>
+					}
+				/>
 			</Dropdown.Root>
-		</>
+		</div>
 	);
 };

--- a/src/system/Dropdown/Dropdown.stories.jsx
+++ b/src/system/Dropdown/Dropdown.stories.jsx
@@ -1,45 +1,132 @@
 /**
  * External dependencies
  */
-
 import React from 'react';
-import * as DropdownMenuPrimitive from '@radix-ui/react-dropdown-menu';
-import * as AlertDialog from '../NewDialog';
+import { DotFilledIcon, CheckIcon, ChevronRightIcon } from '@radix-ui/react-icons';
 
 /**
- /**
+/**
 * Internal dependencies
 */
 
 import * as Dropdown from '.';
+import { Button } from '../Button';
+import * as NewDialog from '../NewDialog';
 
 export default {
 	title: 'Dropdown',
 	component: Dropdown.Root,
 };
 
-// Exportsconst DropdownMenuContent = Content;
-const DropdownMenuItem = DropdownMenuPrimitive.Item;
-
 // Your app...
-export const Default = () => {
+
+export const Default = () => (
+	<>
+		<Dropdown.Root trigger={ <Button>Open</Button> }>
+			<Dropdown.Item>All</Dropdown.Item>
+			<Dropdown.Item>Completed</Dropdown.Item>
+			<Dropdown.Item>Running</Dropdown.Item>
+			<Dropdown.Item>Cancelled</Dropdown.Item>
+			<Dropdown.Separator />
+			<Dropdown.Item>Errored</Dropdown.Item>
+		</Dropdown.Root>
+
+		<p>
+			This component is based on the Radix Dropdown. You can find all available options, props and
+			features in the{ ' ' }
+			<a
+				href="https://www.radix-ui.com/docs/primitives/components/dropdown-menu"
+				target="_blank"
+				rel="noopener noreferrer"
+			>
+				Dropdown Documentation page.
+			</a>
+		</p>
+	</>
+);
+
+export const ComplexOptions = () => {
+	const [ bookmarksChecked, setBookmarksChecked ] = React.useState( true );
+	const [ urlsChecked, setUrlsChecked ] = React.useState( false );
+	const [ person, setPerson ] = React.useState( 'pedro' );
+
+	return (
+		<>
+			<Dropdown.Root trigger={ <Button>See options</Button> }>
+				<Dropdown.Item>New Tab</Dropdown.Item>
+				<Dropdown.Item>New Window</Dropdown.Item>
+				<Dropdown.Item disabled>New Private Window</Dropdown.Item>
+				<Dropdown.Sub>
+					<Dropdown.SubTrigger>
+						More Tools
+						<ChevronRightIcon />
+					</Dropdown.SubTrigger>
+					<Dropdown.SubContent sideOffset={ 2 } alignOffset={ -5 }>
+						<Dropdown.Item>Save Page As…</Dropdown.Item>
+						<Dropdown.Item>Create Shortcut…</Dropdown.Item>
+						<Dropdown.Item>Name Window…</Dropdown.Item>
+						<Dropdown.Separator />
+						<Dropdown.Item>Developer Tools</Dropdown.Item>
+					</Dropdown.SubContent>
+				</Dropdown.Sub>
+				<Dropdown.Separator />
+				<Dropdown.CheckboxItem checked={ bookmarksChecked } onCheckedChange={ setBookmarksChecked }>
+					<Dropdown.ItemIndicator>
+						<CheckIcon />
+					</Dropdown.ItemIndicator>
+					Show Bookmarks
+				</Dropdown.CheckboxItem>
+				<Dropdown.CheckboxItem checked={ urlsChecked } onCheckedChange={ setUrlsChecked }>
+					<Dropdown.ItemIndicator>
+						<CheckIcon />
+					</Dropdown.ItemIndicator>
+					Show Full URLs
+				</Dropdown.CheckboxItem>
+				<Dropdown.Separator />
+				<Dropdown.Label>People</Dropdown.Label>
+				<Dropdown.RadioGroup value={ person } onValueChange={ setPerson }>
+					<Dropdown.RadioItem value="pedro">
+						<Dropdown.ItemIndicator>
+							<DotFilledIcon />
+						</Dropdown.ItemIndicator>
+						Pedro Duarte
+					</Dropdown.RadioItem>
+					<Dropdown.RadioItem value="colm">
+						<Dropdown.ItemIndicator>
+							<DotFilledIcon />
+						</Dropdown.ItemIndicator>
+						Colm Tuite
+					</Dropdown.RadioItem>
+				</Dropdown.RadioGroup>
+			</Dropdown.Root>
+
+			<p>
+				This component is based on the Radix Dropdown. You can find all available options, props and
+				features in the{ ' ' }
+				<a
+					href="https://www.radix-ui.com/docs/primitives/components/dropdown-menu"
+					target="_blank"
+					rel="noopener noreferrer"
+				>
+					Dropdown Documentation page.
+				</a>
+			</p>
+		</>
+	);
+};
+
+export const WithDialog = () => {
 	const [ alertOpen, setAlertOpen ] = React.useState( false );
 	const [ menuOpen, setMenuOpen ] = React.useState( false );
-	const triggerRef = React.useRef();
-	const [ container, setContainer ] = React.useState( null );
 
-	const AreYouSureDialog = ( { children, onConfirm, onCancel, trigger, ...props } ) => (
-		<AlertDialog.Root
+	const AreYouSureDialog = ( { onConfirm, ...props } ) => (
+		<NewDialog.Root
 			{ ...props }
 			contentProps={ {
 				onCloseAutoFocus: () => {
-					console.log( 'ok' );
-					triggerRef?.current?.setAttribute( 'tabindex', '-1' );
-					triggerRef?.current?.focus();
 					onConfirm();
 				},
 			} }
-			trigger={ trigger }
 			content={
 				<>
 					<button type="button" onClick={ () => onConfirm() }>
@@ -58,7 +145,7 @@ export const Default = () => {
 				open={ menuOpen }
 				onOpenChange={ setMenuOpen }
 				contentProps={ { sideOffset: 5 } }
-				trigger={ <button ref={ triggerRef }>open</button> }
+				trigger={ <button>open</button> }
 			>
 				<Dropdown.Item>New Window</Dropdown.Item>
 
@@ -69,7 +156,6 @@ export const Default = () => {
 					onOpenChange={ setAlertOpen }
 					onConfirm={ () => {
 						setAlertOpen( false );
-						console.log( triggerRef?.current );
 						setMenuOpen( false );
 					} }
 					trigger={

--- a/src/system/Dropdown/Dropdown.stories.jsx
+++ b/src/system/Dropdown/Dropdown.stories.jsx
@@ -120,11 +120,6 @@ export const WithDialog = () => {
 	const AreYouSureDialog = ( { onConfirm, ...props } ) => (
 		<NewDialog.Root
 			{ ...props }
-			contentProps={ {
-				onCloseAutoFocus: () => {
-					onConfirm();
-				},
-			} }
 			content={
 				<>
 					<Button variant="secondary" onClick={ () => onConfirm() }>
@@ -146,6 +141,7 @@ export const WithDialog = () => {
 			</p>
 
 			<Dropdown.Root
+				modal={ ! alertOpen }
 				open={ menuOpen }
 				onOpenChange={ setMenuOpen }
 				contentProps={ { sideOffset: 5 } }

--- a/src/system/Dropdown/Dropdown.stories.jsx
+++ b/src/system/Dropdown/Dropdown.stories.jsx
@@ -117,6 +117,7 @@ export const WithDialog = () => {
 	const [ alertOpen, setAlertOpen ] = React.useState( false );
 	const [ menuOpen, setMenuOpen ] = React.useState( false );
 
+	// eslint-disable-next-line react/prop-types
 	const AreYouSureDialog = ( { onConfirm, ...props } ) => (
 		<NewDialog.Root
 			{ ...props }
@@ -125,7 +126,6 @@ export const WithDialog = () => {
 					<Button variant="secondary" onClick={ () => onConfirm() }>
 						Custom Close.
 					</Button>
-
 					<p>Teste abc.</p>
 				</>
 			}

--- a/src/system/Dropdown/Dropdown.stories.jsx
+++ b/src/system/Dropdown/Dropdown.stories.jsx
@@ -18,8 +18,6 @@ export default {
 	component: Dropdown.Root,
 };
 
-// Your app...
-
 export const Default = () => (
 	<>
 		<Dropdown.Root trigger={ <Button>Open</Button> }>
@@ -144,7 +142,7 @@ export const WithDialog = () => {
 			<p>
 				This is an important example when combining the Dropdown component with the NewDialog
 				component. In order to have the correct accessibility, there are some events you need to
-				use. Use this example if you can to copy and paste the code.
+				use. Use this example if you want to copy and paste the code.
 			</p>
 
 			<Dropdown.Root

--- a/src/system/NewConfirmationDialog/NewConfirmationDialog.js
+++ b/src/system/NewConfirmationDialog/NewConfirmationDialog.js
@@ -58,7 +58,6 @@ const NewConfirmationDialog = ( {
 	body = '',
 	...props
 } ) => {
-	const [ open, setOpen ] = React.useState( false );
 	const directTrigger = React.cloneElement( trigger, { onClick: onConfirm } );
 
 	if ( ! needsConfirm ) {
@@ -67,20 +66,18 @@ const NewConfirmationDialog = ( {
 
 	return (
 		<NewDialog.Root
-			open={ open }
-			onOpenChange={ setOpen }
 			sx={ { maxWidth: 680 } }
 			title={ title }
 			description={ body }
-			content={
+			content={ ( { onClose } ) => (
 				<NewConfirmationDialogContent
-					onClose={ () => setOpen( false ) }
+					onClose={ onClose }
 					onConfirm={ onConfirm }
 					body={ body }
 					label={ label }
 					buttonVariant={ buttonVariant }
 				/>
-			}
+			) }
 			trigger={ trigger }
 			{ ...props }
 		/>

--- a/src/system/NewConfirmationDialog/NewConfirmationDialog.js
+++ b/src/system/NewConfirmationDialog/NewConfirmationDialog.js
@@ -56,6 +56,7 @@ const NewConfirmationDialog = ( {
 	buttonVariant,
 	title,
 	body = '',
+	...props
 } ) => {
 	const [ open, setOpen ] = React.useState( false );
 	const directTrigger = React.cloneElement( trigger, { onClick: onConfirm } );
@@ -81,6 +82,7 @@ const NewConfirmationDialog = ( {
 				/>
 			}
 			trigger={ trigger }
+			{ ...props }
 		/>
 	);
 };

--- a/src/system/NewDialog/NewDialog.js
+++ b/src/system/NewDialog/NewDialog.js
@@ -24,6 +24,7 @@ export const NewDialog = ( {
 	disabled = false,
 	style: extraStyles,
 	contentProps = {},
+	portalProps = {},
 
 	// Radix Specific Properties
 	defaultOpen = false,
@@ -63,7 +64,7 @@ export const NewDialog = ( {
 		>
 			{ trigger && <DialogPrimitive.Trigger asChild>{ trigger }</DialogPrimitive.Trigger> }
 
-			<DialogPrimitive.Portal data-test="me">
+			<DialogPrimitive.Portal { ...portalProps }>
 				<DialogOverlay />
 
 				<DialogPrimitive.Content
@@ -92,7 +93,12 @@ NewDialog.propTypes = {
 	showHeading: PropTypes.bool,
 	disabled: PropTypes.bool,
 	style: PropTypes.oneOfType( [ PropTypes.object, PropTypes.func ] ),
+
+	// Content props in: https://www.radix-ui.com/docs/primitives/components/dialog#content
 	contentProps: PropTypes.any,
+
+	// Portal props in: https://www.radix-ui.com/docs/primitives/components/dialog#portal
+	portalProps: PropTypes.any,
 
 	// Radix DialogPrimitive.Root properties
 	// https://www.radix-ui.com/docs/primitives/components/dialog#root

--- a/src/system/NewDialog/NewDialog.js
+++ b/src/system/NewDialog/NewDialog.js
@@ -23,6 +23,7 @@ export const NewDialog = ( {
 	showHeading = true,
 	disabled = false,
 	style: extraStyles,
+	contentProps = {},
 
 	// Radix Specific Properties
 	defaultOpen = false,
@@ -62,12 +63,13 @@ export const NewDialog = ( {
 		>
 			{ trigger && <DialogPrimitive.Trigger asChild>{ trigger }</DialogPrimitive.Trigger> }
 
-			<DialogPrimitive.Portal>
+			<DialogPrimitive.Portal data-test="me">
 				<DialogOverlay />
 
 				<DialogPrimitive.Content
 					className="vip-dialog-component"
 					sx={ { ...contentStyles, ...extraStyles } }
+					{ ...contentProps }
 				>
 					<DialogClose />
 					<DialogTitle title={ title } hidden={ ! showHeading } />
@@ -90,6 +92,7 @@ NewDialog.propTypes = {
 	showHeading: PropTypes.bool,
 	disabled: PropTypes.bool,
 	style: PropTypes.oneOfType( [ PropTypes.object, PropTypes.func ] ),
+	contentProps: PropTypes.any,
 
 	// Radix DialogPrimitive.Root properties
 	// https://www.radix-ui.com/docs/primitives/components/dialog#root

--- a/src/system/NewDialog/NewDialog.js
+++ b/src/system/NewDialog/NewDialog.js
@@ -25,15 +25,9 @@ export const NewDialog = ( {
 	style: extraStyles,
 	contentProps = {},
 	portalProps = {},
-
-	// Radix Specific Properties
-	defaultOpen = false,
-	allowPinchZoom = false,
-	onOpenChange = undefined,
-	open = undefined,
-	id = undefined,
+	...props
 } ) => {
-	const [ isOpen, setIsOpen ] = React.useState( open || defaultOpen );
+	const closeRef = React.useRef( null );
 
 	if ( disabled ) {
 		return;
@@ -42,26 +36,12 @@ export const NewDialog = ( {
 	// if content is a function, pass in onClose
 	const isContentFunction = typeof content === 'function';
 
-	const handleOnOpenChange = status => {
-		setIsOpen( status );
-
-		if ( onOpenChange ) {
-			onOpenChange( status );
-		}
+	const onClose = () => {
+		closeRef?.current?.click();
 	};
 
-	React.useEffect( () => {
-		handleOnOpenChange( open );
-	}, [ open ] );
-
 	return (
-		<DialogPrimitive.Root
-			id={ id }
-			open={ isOpen }
-			onOpenChange={ handleOnOpenChange }
-			defaultOpen={ defaultOpen }
-			allowPinchZoom={ allowPinchZoom }
-		>
+		<DialogPrimitive.Root { ...props }>
 			{ trigger && <DialogPrimitive.Trigger asChild>{ trigger }</DialogPrimitive.Trigger> }
 
 			<DialogPrimitive.Portal { ...portalProps }>
@@ -72,13 +52,11 @@ export const NewDialog = ( {
 					sx={ { ...contentStyles, ...extraStyles } }
 					{ ...contentProps }
 				>
-					<DialogClose />
+					<DialogClose ref={ closeRef } />
 					<DialogTitle title={ title } hidden={ ! showHeading } />
 					<DialogDescription description={ description } hidden={ ! showHeading } />
 
-					<div role="document">
-						{ isContentFunction ? content( { onClose: () => setIsOpen( false ) } ) : content }
-					</div>
+					<div role="document">{ isContentFunction ? content( { onClose } ) : content }</div>
 				</DialogPrimitive.Content>
 			</DialogPrimitive.Portal>
 		</DialogPrimitive.Root>

--- a/src/system/NewDialog/NewDialog.js
+++ b/src/system/NewDialog/NewDialog.js
@@ -77,12 +77,4 @@ NewDialog.propTypes = {
 
 	// Portal props in: https://www.radix-ui.com/docs/primitives/components/dialog#portal
 	portalProps: PropTypes.any,
-
-	// Radix DialogPrimitive.Root properties
-	// https://www.radix-ui.com/docs/primitives/components/dialog#root
-	id: PropTypes.string,
-	open: PropTypes.bool,
-	defaultOpen: PropTypes.bool,
-	allowPinchZoom: PropTypes.bool,
-	onOpenChange: PropTypes.func,
 };

--- a/src/system/NewDialog/NewDialog.stories.jsx
+++ b/src/system/NewDialog/NewDialog.stories.jsx
@@ -155,7 +155,7 @@ export const CustomStateManagement = () => {
 					// eslint-disable-next-line no-console
 					console.log( 'New status changed', status );
 
-					setOpen( !! open );
+					setOpen( ! open );
 				} }
 				trigger={ <Button>Trigger Dialog</Button> }
 				content={

--- a/src/system/Tooltip/Tooltip.js
+++ b/src/system/Tooltip/Tooltip.js
@@ -15,7 +15,7 @@ import { Card, Text } from '..';
 const StyledArrow = props => <TooltipPrimitive.Arrow sx={ { fill: 'white' } } { ...props } />;
 
 const Tooltip = ( {
-	trigger = <MdHelp />,
+	trigger = <MdHelp sx={ { fill: 'text' } } />,
 	text = '',
 	width = 200,
 	children,
@@ -48,7 +48,8 @@ const Tooltip = ( {
 						background: 'transparent',
 						border: 'none',
 						display: 'inline-flex',
-						outline: 'none',
+						'&:focus': theme => theme.outline,
+						'&:focus-visible': theme => theme.outline,
 						p: 0,
 						m: 0,
 					} }
@@ -56,8 +57,8 @@ const Tooltip = ( {
 					{ trigger }
 
 					<TooltipPrimitive.Content>
-						<Card className="tooltip-content" sx={ { width: width } } { ...props }>
-							{ children ? children : <Text sx={ { fontSize: 1 } }>{ text }</Text> }
+						<Card className="tooltip-content" sx={ { width, background: 'dialog' } } { ...props }>
+							{ children ? children : <Text sx={ { fontSize: 2, color: 'text' } }>{ text }</Text> }
 						</Card>
 						<StyledArrow />
 					</TooltipPrimitive.Content>

--- a/src/system/Tooltip/Tooltip.stories.jsx
+++ b/src/system/Tooltip/Tooltip.stories.jsx
@@ -12,7 +12,7 @@ export const Default = () => (
 	<Flex sx={ { alignItems: 'center' } }>
 		<Heading sx={ { mb: 0, mr: 2 } }>My Section Heading</Heading>
 		<Tooltip>
-			<Text sx={ { fontSize: 1 } }>
+			<Text sx={ { fontSize: 1, color: 'text' } }>
 				This is a tooltip that can be used to describe various pieces of functionality.
 				<br />
 				<Link>Find out more &rarr;</Link>


### PR DESCRIPTION
## Description

- NewConfirmationDialog: Now just passes all props to NewDialog to avoid having to control the state internally
- Tooltip: Fix Dark mode for Tooltip. Adds outline to focus state
- NewDialog: Created `portalProps`, `contentProps` to make NewDialog more flexible when using Radix properties
- Dropdown: Updates the examples using a Dropdown triggering a NewDialog 😱
- Bumped version to alpha

## Checklist

- [ ] This PR has good automated test coverage
- [x] The storybook for the component has been updated

## Steps to Test — Tooltip

1. Pull down PR.
2. `npm run dev`.
3. Open http://localhost:6006/?path=/story/tooltip--default
4. Activate Dark Mode. The tooltip should be readable in dark mode.
1. Verify cookies are delicious.

## Steps to Test — Dropdown + Dialog example

1. Pull down PR.
2. `npm run dev`.
3. Open http://localhost:6006/?path=/story/dropdown--with-dialog
4. Navigate using the keyboard. The focus should work back to the trigger if you close the DIALOG with ESC or clicking on the custom close button