### PR TITLE
Adjust <Link/> colors and move deprecated components to a proper section

### DIFF
--- a/src/system/BlankState/BlankState.stories.jsx
+++ b/src/system/BlankState/BlankState.stories.jsx
@@ -4,7 +4,7 @@
 import { Link, BlankState } from '..';
 
 export default {
-	title: 'BlankState',
+	title: 'Deprecated/BlankState',
 	component: BlankState,
 };
 

--- a/src/system/ConfirmationDialog/ConfirmationDialog.stories.jsx
+++ b/src/system/ConfirmationDialog/ConfirmationDialog.stories.jsx
@@ -4,7 +4,7 @@
 import { Box, ConfirmationDialog, Button, Heading, Text, Flex } from '..';
 
 export default {
-	title: 'ConfirmationDialog',
+	title: 'Deprecated/ConfirmationDialog',
 	component: ConfirmationDialog,
 };
 

--- a/src/system/Dialog/Dialog.stories.jsx
+++ b/src/system/Dialog/Dialog.stories.jsx
@@ -14,7 +14,7 @@ import {
 } from '..';
 
 export default {
-	title: 'Dialog (Deprecated)',
+	title: 'Deprecated/Dialog',
 	component: Dialog,
 };
 

--- a/src/system/Link/Link.js
+++ b/src/system/Link/Link.js
@@ -11,9 +11,6 @@ const Link = ( { active = false, sx, ...props } ) => (
 		{ ...props }
 		sx={ {
 			color: active ? 'heading' : 'link',
-			textDecoration: 'none',
-			borderBottom: '1px solid',
-			borderBottomColor: 'border',
 			'&:visited': {
 				color: 'link',
 			},

--- a/src/system/theme/index.js
+++ b/src/system/theme/index.js
@@ -94,7 +94,7 @@ export default {
 		primary: light.brand[ '70' ],
 		secondary: '#30c',
 		muted: light.grey[ '90' ],
-		link: light.brand[ '90' ],
+		link: getColor( 'text', 'interactive' ),
 		card: '#fff',
 		border: light.grey[ '20' ],
 		hover: 'rgba(0,0,0,.02)',


### PR DESCRIPTION
## Description

### Adjusted the `<Link />` color and the style. We are now moving to a regular `text-decoration: underline` link approach to improve accessibility

<img width="218" alt="image" src="https://user-images.githubusercontent.com/3402/188945821-28044ec6-9055-4590-b1d2-ea279510e302.png">


### Moved `Dialog`, `ConfirmationDialog`, and `BlankState` to the Deprecated section in storybook

<img width="288" alt="image" src="https://user-images.githubusercontent.com/3402/188945857-cf4ba27f-fb1d-4718-a377-0d35be5d044e.png">


## Checklist

- [ ] This PR has good automated test coverage
- [x] The storybook for the component has been updated

## Steps to Test - Link

1. Pull down PR.
2. `npm run dev`.
3. Open http://localhost:6006/?path=/story/link--default
4. Links should have an underline style by default with the color #9a6014
