### PR TITLE
Allow developers to use custom heading variants that suit their use case

### DIFF
--- a/src/system/Wizard/Wizard.js
+++ b/src/system/Wizard/Wizard.js
@@ -24,13 +24,14 @@ const Wizard = ( { steps, activeStep, variant, completed = [], className = null,
 						} }
 						{ ...props }
 					>
-						{ steps.map( ( { title, subTitle }, index ) => (
+						{ steps.map( ( { title, subTitle, titleVariant }, index ) => (
 							<React.Fragment key={ index }>
 								<WizardStepHorizontal
-									order={ index + 1 }
 									active={ index === activeStep }
-									title={ title }
+									order={ index + 1 }
 									subTitle={ subTitle }
+									title={ title }
+									titleVariant={ titleVariant }
 								/>
 								{ index < steps.length - 1 && (
 									<MdArrowForward sx={ { mx: 2, color: 'grey.80' } } />
@@ -41,14 +42,15 @@ const Wizard = ( { steps, activeStep, variant, completed = [], className = null,
 					{ steps[ activeStep ].children }
 				</Box>
 			) : (
-				steps.map( ( { title, subTitle, children }, index ) => (
+				steps.map( ( { title, subTitle, children, titleVariant }, index ) => (
 					<WizardStep
 						active={ index === activeStep }
-						title={ title }
-						subTitle={ subTitle }
 						complete={ completed.includes( index ) }
 						key={ index }
 						order={ index + 1 }
+						subTitle={ subTitle }
+						title={ title }
+						titleVariant={ titleVariant }
 					>
 						{ children }
 					</WizardStep>

--- a/src/system/Wizard/Wizard.stories.jsx
+++ b/src/system/Wizard/Wizard.stories.jsx
@@ -52,7 +52,7 @@ export const Default = () => {
 	);
 };
 
-export const CustomLabel = () => {
+export const CustomHeadingVariant = () => {
 	const steps = [
 		{
 			title: 'Choose Domain',

--- a/src/system/Wizard/Wizard.stories.jsx
+++ b/src/system/Wizard/Wizard.stories.jsx
@@ -51,3 +51,22 @@ export const Default = () => {
 		</React.Fragment>
 	);
 };
+
+export const CustomLabel = () => {
+	const steps = [
+		{
+			title: 'Choose Domain',
+			titleVariant: 'h1',
+			subTitle: <h2>You can bring a domain name you already own, or buy a new one.</h2>,
+		},
+		{
+			title: 'Configure DNS',
+			titleVariant: 'h1',
+		},
+	];
+	return (
+		<React.Fragment>
+			<Wizard activeStep={ 0 } steps={ steps } className="vip-wizard-xyz" />
+		</React.Fragment>
+	);
+};

--- a/src/system/Wizard/WizardStep.js
+++ b/src/system/Wizard/WizardStep.js
@@ -11,7 +11,15 @@ import PropTypes from 'prop-types';
  */
 import { Card, Heading, Text } from '..';
 
-const WizardStep = ( { title, subTitle, complete = false, children, active, order } ) => {
+const WizardStep = ( {
+	title,
+	subTitle,
+	complete = false,
+	children,
+	active,
+	order,
+	titleVariant = 'h4',
+} ) => {
 	let borderLeftColor = 'border';
 
 	if ( complete ) {
@@ -48,7 +56,7 @@ const WizardStep = ( { title, subTitle, complete = false, children, active, orde
 			data-active={ active || undefined }
 		>
 			<Heading
-				variant="h4"
+				variant={ titleVariant }
 				sx={ {
 					mb: 0,
 					display: 'flex',
@@ -67,12 +75,13 @@ const WizardStep = ( { title, subTitle, complete = false, children, active, orde
 };
 
 WizardStep.propTypes = {
-	title: PropTypes.node,
-	subTitle: PropTypes.node,
-	complete: PropTypes.bool,
 	active: PropTypes.bool,
 	children: PropTypes.node,
+	complete: PropTypes.bool,
 	order: PropTypes.number.isRequired,
+	subTitle: PropTypes.node,
+	title: PropTypes.node,
+	titleVariant: PropTypes.string,
 };
 
 export { WizardStep };

--- a/src/system/Wizard/WizardStepHorizontal.js
+++ b/src/system/Wizard/WizardStepHorizontal.js
@@ -31,10 +31,11 @@ const WizardStepHorizontal = ( { title, active, order, titleVariant = 'h4' } ) =
 };
 
 WizardStepHorizontal.propTypes = {
-	title: PropTypes.node,
-	subTitle: PropTypes.node,
 	active: PropTypes.bool,
 	order: PropTypes.number.isRequired,
+	subTitle: PropTypes.node,
+	title: PropTypes.node,
+	titleVariant: PropTypes.string,
 };
 
 export { WizardStepHorizontal };

--- a/src/system/Wizard/WizardStepHorizontal.js
+++ b/src/system/Wizard/WizardStepHorizontal.js
@@ -11,10 +11,10 @@ import PropTypes from 'prop-types';
  */
 import { Heading } from '..';
 
-const WizardStepHorizontal = ( { title, active, order } ) => {
+const WizardStepHorizontal = ( { title, active, order, titleVariant = 'h4' } ) => {
 	return (
 		<Heading
-			variant="h4"
+			variant={ titleVariant }
 			sx={ {
 				mb: 0,
 				display: 'flex',


### PR DESCRIPTION
## Description

Reference: https://wp.me/p6jPRI-5L3#comment-28220

We need a way to define the heading level of the wizard steps. This PR adds `titleVariant` to the wizard step configuration:

```jsx
const CustomHeadingVariant = () => {
	const steps = [
		{
			title: 'Choose Domain',
			titleVariant: 'h1',
			subTitle: <h2>You can bring a domain name you already own, or buy a new one.</h2>,
		},
		{
			title: 'Configure DNS',
			titleVariant: 'h1',
		},
	];
	return (
		<React.Fragment>
			<Wizard activeStep={ 0 } steps={ steps } className="vip-wizard-xyz" />
		</React.Fragment>
	);
};
```

## Checklist

- [ ] This PR has good automated test coverage
- [ ] The storybook for the component has been updated

## Steps to Test

1. Pull down PR.
1. `npm run dev`.
1. Open Storybook.
1. Check out custom heading variants example: http://localhost:6006/?path=/story/wizard--custom-heading-variant
