### PR TITLE
Do not assume a header when a custom title node is given

### DIFF
--- a/src/system/Wizard/Wizard.js
+++ b/src/system/Wizard/Wizard.js
@@ -42,7 +42,7 @@ const Wizard = ( { steps, activeStep, variant, completed = [], className = null,
 					{ steps[ activeStep ].children }
 				</Box>
 			) : (
-				steps.map( ( { title, subTitle, children, titleVariant }, index ) => (
+				steps.map( ( { title, subTitle, children }, index ) => (
 					<WizardStep
 						active={ index === activeStep }
 						complete={ completed.includes( index ) }
@@ -50,7 +50,6 @@ const Wizard = ( { steps, activeStep, variant, completed = [], className = null,
 						order={ index + 1 }
 						subTitle={ subTitle }
 						title={ title }
-						titleVariant={ titleVariant }
 					>
 						{ children }
 					</WizardStep>

--- a/src/system/Wizard/Wizard.stories.jsx
+++ b/src/system/Wizard/Wizard.stories.jsx
@@ -1,3 +1,5 @@
+/** @jsxImportSource theme-ui */
+
 /**
  * External dependencies
  */
@@ -55,11 +57,11 @@ export const Default = () => {
 export const CustomTitle = () => {
 	const steps = [
 		{
-			title: <h1 sx={ { m: 0 } }>Choose Domain</h1>,
+			title: <h3 sx={ { m: 0 } }>Choose Domain</h3>,
 			subTitle: <span>You can bring a domain name you already own, or buy a new one.</span>,
 		},
 		{
-			title: <h1 sx={ { m: 0 } }>Configure DNS</h1>,
+			title: <h3 sx={ { m: 0 } }>Configure DNS</h3>,
 		},
 	];
 	return (

--- a/src/system/Wizard/Wizard.stories.jsx
+++ b/src/system/Wizard/Wizard.stories.jsx
@@ -52,16 +52,14 @@ export const Default = () => {
 	);
 };
 
-export const CustomHeadingVariant = () => {
+export const CustomTitle = () => {
 	const steps = [
 		{
-			title: 'Choose Domain',
-			titleVariant: 'h1',
-			subTitle: <h2>You can bring a domain name you already own, or buy a new one.</h2>,
+			title: <h1 sx={ { m: 0 } }>Choose Domain</h1>,
+			subTitle: <span>You can bring a domain name you already own, or buy a new one.</span>,
 		},
 		{
-			title: 'Configure DNS',
-			titleVariant: 'h1',
+			title: <h1 sx={ { m: 0 } }>Configure DNS</h1>,
 		},
 	];
 	return (

--- a/src/system/Wizard/WizardStep.js
+++ b/src/system/Wizard/WizardStep.js
@@ -9,18 +9,10 @@ import PropTypes from 'prop-types';
 /**
  * Internal dependencies
  */
-import { Card, Heading, Text } from '..';
+import { Card, Heading, Text, Flex } from '..';
 
-const WizardStep = ( {
-	title,
-	subTitle,
-	complete = false,
-	children,
-	active,
-	order,
-	titleVariant = 'h4',
-} ) => {
-	let borderLeftColor = 'borders.2';
+const WizardStep = ( { title, subTitle, complete = false, children, active, order } ) => {
+	let borderLeftColor = 'border';
 
 	if ( complete ) {
 		borderLeftColor = 'success';
@@ -56,19 +48,26 @@ const WizardStep = ( {
 			data-step={ order }
 			data-active={ active || undefined }
 		>
-			<Heading
-				variant={ titleVariant }
-				sx={ {
-					mb: 0,
-					display: 'flex',
-					alignItems: 'center',
-					color,
-					fontSize: 2,
-				} }
-			>
-				<MdCheckCircle sx={ { mr: 2 } } size={ 18 } />
-				{ title }
-			</Heading>
+			{ typeof title === 'string' ? (
+				<Heading
+					variant="h4"
+					sx={ {
+						mb: 0,
+						display: 'flex',
+						alignItems: 'center',
+						color: color,
+					} }
+				>
+					<MdCheckCircle sx={ { mr: 2 } } />
+					{ title }
+				</Heading>
+			) : (
+				<Flex sx={ { alignItems: 'center', color } }>
+					<MdCheckCircle sx={ { mr: 2 } } />
+					{ title }
+				</Flex>
+			) }
+
 			{ subTitle && active && <Text sx={ { mb: 3 } }>{ subTitle }</Text> }
 
 			{ active && children }
@@ -83,7 +82,6 @@ WizardStep.propTypes = {
 	order: PropTypes.number.isRequired,
 	subTitle: PropTypes.node,
 	title: PropTypes.node,
-	titleVariant: PropTypes.string,
 };
 
 export { WizardStep };

--- a/src/system/Wizard/WizardStep.js
+++ b/src/system/Wizard/WizardStep.js
@@ -58,12 +58,12 @@ const WizardStep = ( { title, subTitle, complete = false, children, active, orde
 						color: color,
 					} }
 				>
-					<MdCheckCircle sx={ { mr: 2 } } />
+					<MdCheckCircle aria-hidden="true" sx={ { mr: 2 } } />
 					{ title }
 				</Heading>
 			) : (
 				<Flex sx={ { alignItems: 'center', color } }>
-					<MdCheckCircle sx={ { mr: 2 } } />
+					<MdCheckCircle aria-hidden="true" sx={ { mr: 2 } } />
 					{ title }
 				</Flex>
 			) }

--- a/src/system/Wizard/WizardStepHorizontal.js
+++ b/src/system/Wizard/WizardStepHorizontal.js
@@ -9,17 +9,19 @@ import PropTypes from 'prop-types';
 /**
  * Internal dependencies
  */
-import { Heading } from '..';
+import { Heading, Flex } from '..';
 
-const WizardStepHorizontal = ( { title, active, order, titleVariant = 'h4' } ) => {
-	return (
+const WizardStepHorizontal = ( { title, active, order } ) => {
+	const color = active ? 'heading' : 'muted';
+
+	return typeof title === 'string' ? (
 		<Heading
-			variant={ titleVariant }
+			variant="h4"
 			sx={ {
 				mb: 0,
 				display: 'flex',
 				alignItems: 'center',
-				color: active ? 'heading' : 'muted',
+				color,
 			} }
 			data-step={ order }
 			data-active={ active || undefined }
@@ -27,6 +29,11 @@ const WizardStepHorizontal = ( { title, active, order, titleVariant = 'h4' } ) =
 			<MdCheckCircle sx={ { mr: 2 } } />
 			{ title }
 		</Heading>
+	) : (
+		<Flex sx={ { alignItems: 'center', color } }>
+			<MdCheckCircle sx={ { mr: 2 } } />
+			{ title }
+		</Flex>
 	);
 };
 
@@ -35,7 +42,6 @@ WizardStepHorizontal.propTypes = {
 	order: PropTypes.number.isRequired,
 	subTitle: PropTypes.node,
 	title: PropTypes.node,
-	titleVariant: PropTypes.string,
 };
 
 export { WizardStepHorizontal };

--- a/src/system/Wizard/WizardStepHorizontal.js
+++ b/src/system/Wizard/WizardStepHorizontal.js
@@ -26,12 +26,12 @@ const WizardStepHorizontal = ( { title, active, order } ) => {
 			data-step={ order }
 			data-active={ active || undefined }
 		>
-			<MdCheckCircle sx={ { mr: 2 } } />
+			<MdCheckCircle aria-hidden="true" sx={ { mr: 2 } } />
 			{ title }
 		</Heading>
 	) : (
 		<Flex sx={ { alignItems: 'center', color } }>
-			<MdCheckCircle sx={ { mr: 2 } } />
+			<MdCheckCircle aria-hidden="true" sx={ { mr: 2 } } />
 			{ title }
 		</Flex>
 	);


### PR DESCRIPTION
## Description

Uses the provided header node instead of allowing customizing the variant via `titleVariant`.

## Checklist

- [ ] This PR has good automated test coverage
- [ ] The storybook for the component has been updated

## Steps to Test

1. Pull down PR.
1. `npm run dev`.
1. Open http://localhost:6006/?path=/story/wizard--custom-title
1. Verify that the given `title` prop of each step is not wrapped by a `h4`.
