### PR TITLE
Adds new specs to FormSelect

### DIFF
--- a/src/system/NewForm/FormSelect.test.js
+++ b/src/system/NewForm/FormSelect.test.js
@@ -21,9 +21,47 @@ const defaultProps = {
 	options,
 };
 
+const groupedProps = {
+	...defaultProps,
+	options: [
+		{
+			label: 'Group name',
+			options: [ options[ 0 ] ],
+		},
+		{
+			label: 'Another Group name',
+			options: [ options[ 1 ], options[ 2 ] ],
+		},
+	],
+};
+
 describe( '<FormSelect />', () => {
 	it( 'renders the FormSelect component', async () => {
 		const { container } = render( <FormSelect id="my_desert_list" { ...defaultProps } /> );
+
+		expect( screen.getByLabelText( defaultProps.label ) ).toBeInTheDocument();
+		expect( screen.getByRole( 'combobox' ) ).toBeInTheDocument();
+		expect( screen.getAllByRole( 'option' ) ).toHaveLength( 3 );
+		expect( screen.queryByRole( 'group' ) ).not.toBeInTheDocument();
+
+		// Check for accessibility issues
+		await expect( await axe( container ) ).toHaveNoViolations();
+	} );
+
+	it( 'renders the FormSelect component with optgroup when options are grouped', async () => {
+		const { container } = render( <FormSelect id="my_desert_list" { ...groupedProps } /> );
+
+		expect( screen.getByLabelText( defaultProps.label ) ).toBeInTheDocument();
+		expect( screen.getByRole( 'combobox' ) ).toBeInTheDocument();
+		expect( screen.getAllByRole( 'option' ) ).toHaveLength( 3 );
+		expect( screen.getAllByRole( 'group' ) ).toHaveLength( 2 );
+
+		// Check for accessibility issues
+		await expect( await axe( container ) ).toHaveNoViolations();
+	} );
+
+	it( 'renders the FormSelect component when isInline is true', async () => {
+		const { container } = render( <FormSelect id="my_desert_list" isInline { ...defaultProps } /> );
 
 		expect( screen.getByLabelText( defaultProps.label ) ).toBeInTheDocument();
 		expect( screen.getByRole( 'combobox' ) ).toBeInTheDocument();


### PR DESCRIPTION
## Description

Adding more specs to the already merged `NewForm/Select`.

```
 PASS  src/system/NewForm/FormSelect.test.js
  <FormSelect />
    ✓ renders the FormSelect component (711 ms)
    ✓ renders the FormSelect component with optgroup when options are grouped (108 ms)
    ✓ renders the FormSelect component when isInline is true (72 ms)
```

https://github.com/Automattic/vip-design-system/pull/103

## Checklist

- [x] This PR has good automated test coverage
- [x] The storybook for the component has been updated

## Steps to Test

1. Pull down PR.
1. `npm run test src/system/NewForm/FormSelect.test.js`.
1. Verify the passed tests.
