### PR TITLE
Improve Progress, Heading and table components

### DIFF
--- a/src/system/Heading/Heading.js
+++ b/src/system/Heading/Heading.js
@@ -3,23 +3,29 @@
 /**
  * External dependencies
  */
+import React from 'react';
 import { Heading as ThemeHeading } from 'theme-ui';
 import PropTypes from 'prop-types';
 import classNames from 'classnames';
 
-const Heading = ( { variant = 'h3', sx, className = null, ...props } ) => (
-	<ThemeHeading
-		as={ variant }
-		sx={ {
-			color: 'heading',
-			// pass variant prop to sx
-			variant: `text.${ variant }`,
-			...sx,
-		} }
-		className={ classNames( 'vip-heading-component', className ) }
-		{ ...props }
-	/>
+const Heading = React.forwardRef(
+	( { variant = 'h3', sx, className = null, ...props }, forwardRef ) => (
+		<ThemeHeading
+			as={ variant }
+			sx={ {
+				color: 'heading',
+				// pass variant prop to sx
+				variant: `text.${ variant }`,
+				...sx,
+			} }
+			className={ classNames( 'vip-heading-component', className ) }
+			ref={ forwardRef }
+			{ ...props }
+		/>
+	)
 );
+
+Heading.displayName = 'Heading';
 
 Heading.propTypes = {
 	variant: PropTypes.string,

--- a/src/system/Heading/Heading.stories.jsx
+++ b/src/system/Heading/Heading.stories.jsx
@@ -15,6 +15,5 @@ export const Default = () => (
 		<Heading variant="h3">Heading Three</Heading>
 		<Heading variant="h4">Heading Four</Heading>
 		<Heading variant="h5">Heading Five</Heading>
-		<Heading variant="caps">Heading Caps</Heading>
 	</Box>
 );

--- a/src/system/Progress/Progress.js
+++ b/src/system/Progress/Progress.js
@@ -13,8 +13,7 @@ import classNames from 'classnames';
  */
 import { Spinner } from '../Spinner';
 import { MdCheck } from 'react-icons/md';
-import { Box, Text, Flex, Label } from '../';
-import ScreenReaderText from '../ScreenReaderText';
+import { Box, Text, Flex } from '../';
 
 const prefix = 'vip-progress-component';
 const uniqueID = () => Math.random().toString( 36 ).substring( 7 );
@@ -28,7 +27,7 @@ const Progress = React.forwardRef(
 		const currentValue = activeStep + 1;
 
 		return (
-			<Box className={ classNames( prefix, className ) } ref={ forwardRef }>
+			<Box className={ classNames( prefix, className ) }>
 				<ThemeProgress
 					sx={ {
 						color: 'primary',
@@ -39,6 +38,7 @@ const Progress = React.forwardRef(
 					value={ currentValue }
 					id={ htmlFor }
 					aria-label={ forLabel }
+					ref={ forwardRef }
 					{ ...props }
 				/>
 

--- a/src/system/Progress/Progress.js
+++ b/src/system/Progress/Progress.js
@@ -13,47 +13,47 @@ import classNames from 'classnames';
  */
 import { Spinner } from '../Spinner';
 import { MdCheck } from 'react-icons/md';
-import { Box, Text, Flex } from '../';
+import { Box, Text, Flex, Label } from '../';
+import ScreenReaderText from '../ScreenReaderText';
 
 const prefix = 'vip-progress-component';
 const uniqueID = () => Math.random().toString( 36 ).substring( 7 );
 
 const Progress = React.forwardRef(
-	( { steps, activeStep, sx, className, ...props }, forwardRef ) => {
+	( { steps, activeStep, sx, forLabel = '', className, ...props }, forwardRef ) => {
 		const stepsTotal = steps.length;
 		const isDone = activeStep === stepsTotal - 1;
 		const instance = uniqueID();
 		const htmlFor = `${ prefix }-${ instance }`;
+		const currentValue = activeStep + 1;
 
 		return (
-			<Box
-				className={ classNames( prefix, className ) }
-				ref={ forwardRef }
-				aria-live="polite"
-				aria-atomic="true"
-			>
+			<Box className={ classNames( prefix, className ) } ref={ forwardRef }>
 				<ThemeProgress
 					sx={ {
 						color: 'primary',
+						backgroundColor: 'background',
 						...sx,
 					} }
 					max={ stepsTotal }
-					value={ activeStep + 1 }
+					value={ currentValue }
 					id={ htmlFor }
+					aria-label={ forLabel }
 					{ ...props }
 				/>
 
 				{ steps && (
 					<Flex
 						sx={ { alignItems: 'center', mt: 2 } }
-						aria-busy={ ! isDone }
+						aria-live="polite"
+						aria-atomic="true"
 						aria-describedby={ htmlFor }
 					>
 						{ ! isDone && <Spinner size={ 24 } aria-hidden="true" /> }
 						{ isDone && <MdCheck size={ 24 } aria-hidden="true" /> }
 
 						<Text sx={ { ml: 2, mb: 0 } }>
-							<strong>{ `${ activeStep + 1 } of ${ stepsTotal }` }: </strong>
+							<strong>{ `${ currentValue } of ${ stepsTotal }` }: </strong>
 							<Text as="span" sx={ { color: 'muted' } }>
 								{ steps[ activeStep ] }
 							</Text>
@@ -70,6 +70,7 @@ Progress.displayName = 'Progress';
 Progress.propTypes = {
 	steps: PropTypes.array,
 	activeStep: PropTypes.number,
+	forLabel: PropTypes.node,
 	sx: PropTypes.object,
 	className: PropTypes.any,
 };

--- a/src/system/Progress/Progress.js
+++ b/src/system/Progress/Progress.js
@@ -13,47 +13,53 @@ import classNames from 'classnames';
  */
 import { Spinner } from '../Spinner';
 import { MdCheck } from 'react-icons/md';
-import { Box, Text, Flex, Label } from '../';
+import { Box, Text, Flex } from '../';
 
 const prefix = 'vip-progress-component';
-const uniqueID = Math.random().toString( 36 ).substring( 7 );
+const uniqueID = () => Math.random().toString( 36 ).substring( 7 );
 
 const Progress = React.forwardRef(
-	( { steps, activeStep, sx, className, forLabel = '', ...props }, forwardRef ) => {
-		const isDone = activeStep === steps.length - 1;
+	( { steps, activeStep, sx, className, ...props }, forwardRef ) => {
+		const stepsTotal = steps.length;
+		const isDone = activeStep === stepsTotal - 1;
 		const instance = uniqueID();
 		const htmlFor = `${ prefix }-${ instance }`;
 
 		return (
-			<Box className={ classNames( prefix, className ) } ref={ forwardRef }>
-				<Label htmlFor={ htmlFor }>{ forLabel }</Label>
+			<Box
+				className={ classNames( prefix, className ) }
+				ref={ forwardRef }
+				aria-live="polite"
+				aria-atomic="true"
+			>
+				<ThemeProgress
+					sx={ {
+						color: 'primary',
+						...sx,
+					} }
+					max={ stepsTotal }
+					value={ activeStep + 1 }
+					id={ htmlFor }
+					{ ...props }
+				/>
 
-				<div aria-live="polite" aria-atomic="true" aria-busy={ ! isDone }>
-					<ThemeProgress
-						{ ...props }
-						sx={ {
-							color: 'primary',
-							...sx,
-						} }
-						max={ steps.length }
-						value={ activeStep + 1 }
-						id={ htmlFor }
-					/>
+				{ steps && (
+					<Flex
+						sx={ { alignItems: 'center', mt: 2 } }
+						aria-busy={ ! isDone }
+						aria-describedby={ htmlFor }
+					>
+						{ ! isDone && <Spinner size={ 24 } aria-hidden="true" /> }
+						{ isDone && <MdCheck size={ 24 } aria-hidden="true" /> }
 
-					{ steps && (
-						<Flex sx={ { alignItems: 'center', mt: 2 } }>
-							{ ! isDone && <Spinner size={ 24 } aria-hidden="true" /> }
-							{ isDone && <MdCheck size={ 24 } aria-hidden="true" /> }
-
-							<Text variant="h4" sx={ { ml: 2, mb: 0 } }>
-								<strong>{ `${ activeStep + 1 } of ${ steps.length }` }: </strong>
-								<Text as="span" sx={ { color: 'muted' } }>
-									{ steps[ activeStep ] }
-								</Text>
+						<Text sx={ { ml: 2, mb: 0 } }>
+							<strong>{ `${ activeStep + 1 } of ${ stepsTotal }` }: </strong>
+							<Text as="span" sx={ { color: 'muted' } }>
+								{ steps[ activeStep ] }
 							</Text>
-						</Flex>
-					) }
-				</div>
+						</Text>
+					</Flex>
+				) }
 			</Box>
 		);
 	}
@@ -63,7 +69,6 @@ Progress.displayName = 'Progress';
 
 Progress.propTypes = {
 	steps: PropTypes.array,
-	forLabel: PropTypes.node,
 	activeStep: PropTypes.number,
 	sx: PropTypes.object,
 	className: PropTypes.any,

--- a/src/system/Progress/Progress.js
+++ b/src/system/Progress/Progress.js
@@ -3,41 +3,59 @@
 /**
  * External dependencies
  */
+import React from 'react';
 import { Progress as ThemeProgress } from 'theme-ui';
 import PropTypes from 'prop-types';
+import classNames from 'classnames';
 
 /**
  * Internal dependencies
  */
 import { Spinner } from '../Spinner';
-import { Box, Heading, Text, Flex } from '../';
-import classNames from 'classnames';
+import { MdCheck } from 'react-icons/md';
+import { Box, Text, Flex } from '../';
 
-const Progress = ( { steps, activeStep, sx, className, ...props } ) => (
-	<Box>
-		<ThemeProgress
-			className={ classNames( 'vip-progress-component', className ) }
-			{ ...props }
-			sx={ {
-				color: 'primary',
-				...sx,
-			} }
-			max={ steps.length }
-			value={ activeStep + 1 }
-		/>
-		{ steps && (
-			<Flex sx={ { alignItems: 'center', mt: 2 } }>
-				<Spinner size={ 24 } />
-				<Heading variant="h4" sx={ { ml: 2, mb: 0 } }>
-					{ `${ activeStep + 1 } of ${ steps.length }` }:{ ' ' }
-					<Text as="span" sx={ { color: 'muted' } }>
-						{ steps[ activeStep ] }
-					</Text>
-				</Heading>
-			</Flex>
-		) }
-	</Box>
+const Progress = React.forwardRef(
+	( { steps, activeStep, sx, className, ...props }, forwardRef ) => {
+		const isDone = activeStep === steps.length - 1;
+
+		return (
+			<Box
+				className={ classNames( 'vip-progress-component', className ) }
+				aria-live="polite"
+				aria-atomic="true"
+				aria-busy={ ! isDone }
+				ref={ forwardRef }
+			>
+				<ThemeProgress
+					{ ...props }
+					sx={ {
+						color: 'primary',
+						...sx,
+					} }
+					max={ steps.length }
+					value={ activeStep + 1 }
+				/>
+
+				{ steps && (
+					<Flex sx={ { alignItems: 'center', mt: 2 } }>
+						{ ! isDone && <Spinner size={ 24 } aria-hidden="true" /> }
+						{ isDone && <MdCheck size={ 24 } aria-hidden="true" /> }
+
+						<Text variant="h4" sx={ { ml: 2, mb: 0 } }>
+							<strong>{ `${ activeStep + 1 } of ${ steps.length }` }: </strong>
+							<Text as="span" sx={ { color: 'muted' } }>
+								{ steps[ activeStep ] }
+							</Text>
+						</Text>
+					</Flex>
+				) }
+			</Box>
+		);
+	}
 );
+
+Progress.displayName = 'Progress';
 
 Progress.propTypes = {
 	steps: PropTypes.array,

--- a/src/system/Progress/Progress.js
+++ b/src/system/Progress/Progress.js
@@ -13,43 +13,47 @@ import classNames from 'classnames';
  */
 import { Spinner } from '../Spinner';
 import { MdCheck } from 'react-icons/md';
-import { Box, Text, Flex } from '../';
+import { Box, Text, Flex, Label } from '../';
+
+const prefix = 'vip-progress-component';
+const uniqueID = Math.random().toString( 36 ).substring( 7 );
 
 const Progress = React.forwardRef(
-	( { steps, activeStep, sx, className, ...props }, forwardRef ) => {
+	( { steps, activeStep, sx, className, forLabel = '', ...props }, forwardRef ) => {
 		const isDone = activeStep === steps.length - 1;
+		const instance = uniqueID();
+		const htmlFor = `${ prefix }-${ instance }`;
 
 		return (
-			<Box
-				className={ classNames( 'vip-progress-component', className ) }
-				aria-live="polite"
-				aria-atomic="true"
-				aria-busy={ ! isDone }
-				ref={ forwardRef }
-			>
-				<ThemeProgress
-					{ ...props }
-					sx={ {
-						color: 'primary',
-						...sx,
-					} }
-					max={ steps.length }
-					value={ activeStep + 1 }
-				/>
+			<Box className={ classNames( prefix, className ) } ref={ forwardRef }>
+				<Label htmlFor={ htmlFor }>{ forLabel }</Label>
 
-				{ steps && (
-					<Flex sx={ { alignItems: 'center', mt: 2 } }>
-						{ ! isDone && <Spinner size={ 24 } aria-hidden="true" /> }
-						{ isDone && <MdCheck size={ 24 } aria-hidden="true" /> }
+				<div aria-live="polite" aria-atomic="true" aria-busy={ ! isDone }>
+					<ThemeProgress
+						{ ...props }
+						sx={ {
+							color: 'primary',
+							...sx,
+						} }
+						max={ steps.length }
+						value={ activeStep + 1 }
+						id={ htmlFor }
+					/>
 
-						<Text variant="h4" sx={ { ml: 2, mb: 0 } }>
-							<strong>{ `${ activeStep + 1 } of ${ steps.length }` }: </strong>
-							<Text as="span" sx={ { color: 'muted' } }>
-								{ steps[ activeStep ] }
+					{ steps && (
+						<Flex sx={ { alignItems: 'center', mt: 2 } }>
+							{ ! isDone && <Spinner size={ 24 } aria-hidden="true" /> }
+							{ isDone && <MdCheck size={ 24 } aria-hidden="true" /> }
+
+							<Text variant="h4" sx={ { ml: 2, mb: 0 } }>
+								<strong>{ `${ activeStep + 1 } of ${ steps.length }` }: </strong>
+								<Text as="span" sx={ { color: 'muted' } }>
+									{ steps[ activeStep ] }
+								</Text>
 							</Text>
-						</Text>
-					</Flex>
-				) }
+						</Flex>
+					) }
+				</div>
 			</Box>
 		);
 	}
@@ -59,6 +63,7 @@ Progress.displayName = 'Progress';
 
 Progress.propTypes = {
 	steps: PropTypes.array,
+	forLabel: PropTypes.node,
 	activeStep: PropTypes.number,
 	sx: PropTypes.object,
 	className: PropTypes.any,

--- a/src/system/Progress/Progress.stories.jsx
+++ b/src/system/Progress/Progress.stories.jsx
@@ -22,14 +22,11 @@ export const Default = () => {
 	}, [ counter, setCounter ] );
 
 	return (
-		<>
-			<p>Progress goes until the end.</p>
-
-			<Progress
-				value={ counter }
-				steps={ [ 'Downloading Data', 'Importing Data...', 'Finalizing', 'Done' ] }
-				activeStep={ counter }
-			/>
-		</>
+		<Progress
+			forLabel="Update site progress"
+			value={ counter }
+			steps={ [ 'Downloading Data', 'Importing Data...', 'Finalizing', 'Done' ] }
+			activeStep={ counter }
+		/>
 	);
 };

--- a/src/system/Progress/Progress.stories.jsx
+++ b/src/system/Progress/Progress.stories.jsx
@@ -1,6 +1,7 @@
 /**
  * Internal dependencies
  */
+import React, { useEffect } from 'react';
 import { Progress } from '..';
 
 export default {
@@ -8,11 +9,27 @@ export default {
 	component: Progress,
 };
 
-export const Default = () => (
-	<Progress
-		max={ 1 }
-		value={ 1 / 2 }
-		steps={ [ 'Downloading Data', 'Importing Data...', 'Finalizing' ] }
-		activeStep={ 1 }
-	/>
-);
+const max = 3;
+export const Default = () => {
+	const [ counter, setCounter ] = React.useState( 0 );
+
+	useEffect( () => {
+		setTimeout( () => {
+			if ( counter < max ) {
+				setCounter( counter + 1 );
+			}
+		}, 1000 );
+	}, [ counter, setCounter ] );
+
+	return (
+		<>
+			<p>Progress goes until the end.</p>
+
+			<Progress
+				value={ counter }
+				steps={ [ 'Downloading Data', 'Importing Data...', 'Finalizing', 'Done' ] }
+				activeStep={ counter }
+			/>
+		</>
+	);
+};

--- a/src/system/Progress/Progress.stories.jsx
+++ b/src/system/Progress/Progress.stories.jsx
@@ -18,7 +18,7 @@ export const Default = () => {
 			if ( counter < steps.length - 1 ) {
 				setCounter( counter + 1 );
 			}
-		}, 1000 );
+		}, 2000 );
 	}, [ counter, setCounter ] );
 
 	return <Progress forLabel="Update site progress" steps={ steps } activeStep={ counter } />;

--- a/src/system/Progress/Progress.stories.jsx
+++ b/src/system/Progress/Progress.stories.jsx
@@ -9,24 +9,17 @@ export default {
 	component: Progress,
 };
 
-const max = 3;
 export const Default = () => {
 	const [ counter, setCounter ] = React.useState( 0 );
+	const steps = [ 'Downloading Data', 'Importing Data...', 'Finalizing', 'Done' ];
 
 	useEffect( () => {
 		setTimeout( () => {
-			if ( counter < max ) {
+			if ( counter < steps.length - 1 ) {
 				setCounter( counter + 1 );
 			}
 		}, 1000 );
 	}, [ counter, setCounter ] );
 
-	return (
-		<Progress
-			forLabel="Update site progress"
-			value={ counter }
-			steps={ [ 'Downloading Data', 'Importing Data...', 'Finalizing', 'Done' ] }
-			activeStep={ counter }
-		/>
-	);
+	return <Progress forLabel="Update site progress" steps={ steps } activeStep={ counter } />;
 };

--- a/src/system/Table/Table.js
+++ b/src/system/Table/Table.js
@@ -3,18 +3,22 @@
 /**
  * External dependencies
  */
+import React from 'react';
 import PropTypes from 'prop-types';
 import classNames from 'classnames';
 
-const Table = ( { sx, className, ...props } ) => (
+const Table = React.forwardRef( ( { sx, className, ...props }, forwardRef ) => (
 	<table
 		sx={ { width: '100%', minWidth: 1024, ...sx } }
 		cellPadding={ 0 }
 		cellSpacing={ 0 }
 		className={ classNames( 'vip-table-component', className ) }
+		ref={ forwardRef }
 		{ ...props }
 	/>
-);
+) );
+
+Table.displayName = 'Table';
 
 Table.propTypes = {
 	sx: PropTypes.object,


### PR DESCRIPTION
## Description

- Improved the `Progress` component to support `aria-live` and `aria-atomic`;
- Added the a ✅  for the last step.
- Added a `aria-busy` on the text and a `aria-describedby` pointing to the progress bar
- Removed the heading inside, made a <p>

![dhhCtOIS6E](https://user-images.githubusercontent.com/3402/190005345-c494b153-92f0-44b2-b090-339497e7eb31.gif)

- Added `forwardRef` to the Heading component
- Added `forwardRef` to the Table component

## Checklist

- [ ] This PR has good automated test coverage
- [x] The storybook for the component has been updated

## Steps to Test

1. Pull down PR.
2. `npm run dev`.
3. Open http://localhost:6006/?path=/story/progress--default
4. Open Voice Over, should announce the progress if nothing else is disturbing the reader
