### PR TITLE
Require users to pass a caption to the table

### DIFF
--- a/src/system/ScreenReaderText/ScreenReaderText.js
+++ b/src/system/ScreenReaderText/ScreenReaderText.js
@@ -10,24 +10,21 @@ import PropTypes from 'prop-types';
  * Internal dependencies
  */
 
+export const screenReaderTextClass = {
+	border: 'none',
+	clip: 'rect(1px, 1px, 1px, 1px)',
+	clipPath: 'inset(50%)',
+	height: '1px',
+	margin: '-1px',
+	overflow: 'hidden',
+	padding: '0',
+	position: 'absolute',
+	width: '1px',
+	wordWrap: 'normal !important',
+};
+
 export const ScreenReaderText = React.forwardRef( ( props, forwardRef ) => (
-	<span
-		className="screen-reader-text"
-		sx={ {
-			border: 'none',
-			clip: 'rect(1px, 1px, 1px, 1px)',
-			clipPath: 'inset(50%)',
-			height: '1px',
-			margin: '-1px',
-			overflow: 'hidden',
-			padding: '0',
-			position: 'absolute',
-			width: '1px',
-			wordWrap: 'normal !important',
-		} }
-		{ ...props }
-		ref={ forwardRef }
-	>
+	<span className="screen-reader-text" sx={ screenReaderTextClass } { ...props } ref={ forwardRef }>
 		{ props.children }
 	</span>
 ) );

--- a/src/system/Table/Table.js
+++ b/src/system/Table/Table.js
@@ -6,23 +6,38 @@
 import React from 'react';
 import PropTypes from 'prop-types';
 import classNames from 'classnames';
+import { screenReaderTextClass } from '../ScreenReaderText/ScreenReaderText';
 
-const Table = React.forwardRef( ( { sx, className, ...props }, forwardRef ) => (
-	<table
-		sx={ { width: '100%', minWidth: 1024, ...sx } }
-		cellPadding={ 0 }
-		cellSpacing={ 0 }
-		className={ classNames( 'vip-table-component', className ) }
-		ref={ forwardRef }
-		{ ...props }
-	/>
-) );
+const Table = React.forwardRef(
+	( { sx, className, children, caption = null, ...props }, forwardRef ) => {
+		if ( ! caption ) {
+			// eslint-disable-next-line no-console
+			console.warn( '[A11Y] Please, add a caption to your table.' );
+		}
+
+		return (
+			<table
+				sx={ { width: '100%', minWidth: 1024, ...sx } }
+				cellPadding={ 0 }
+				cellSpacing={ 0 }
+				className={ classNames( 'vip-table-component', className ) }
+				ref={ forwardRef }
+				{ ...props }
+			>
+				{ caption && <caption sx={ screenReaderTextClass }>{ caption }</caption> }
+				{ children }
+			</table>
+		);
+	}
+);
 
 Table.displayName = 'Table';
 
 Table.propTypes = {
 	sx: PropTypes.object,
 	className: PropTypes.any,
+	children: PropTypes.any,
+	caption: PropTypes.string.isRequired,
 };
 
 export { Table };

--- a/src/system/Table/Table.stories.jsx
+++ b/src/system/Table/Table.stories.jsx
@@ -1,3 +1,5 @@
+/** @jsxImportSource theme-ui */
+
 /**
  * Internal dependencies
  */
@@ -9,7 +11,7 @@ export default {
 };
 
 export const Default = () => (
-	<Table>
+	<Table caption="Storybook Example">
 		<thead>
 			<TableRow head cells={ [ 'User', 'Command', 'Duration', 'Time' ] } />
 		</thead>
@@ -35,6 +37,7 @@ export const Default = () => (
 						11th Mar 2020, 16:49:22
 					</Text>,
 				] }
+				gbc
 			/>
 			<TableRow>
 				<TableCell sx={ { backgroundColor: 'lightgray' } }>


### PR DESCRIPTION
## Description

To keep consistency, we are adding the "caption" prop on the `Table` as required. The component will warn all users if the prop is not passed.

## Checklist

- [ ] This PR has good automated test coverage
- [ ] The storybook for the component has been updated

## Steps to Test

1. Pull down PR.
2. `npm run dev`.
3. Open http://localhost:6006/?path=/story/table--default
4. Table should have a hidden `caption` using the prop passed on the story

