### PR TITLE
Fix/dropdown menu expanded

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -10,7 +10,7 @@
 			"dependencies": {
 				"@radix-ui/react-checkbox": "^1.0.0",
 				"@radix-ui/react-dialog": "^1.0.0",
-				"@radix-ui/react-dropdown-menu": "^1.0.0",
+				"@radix-ui/react-dropdown-menu": "^1.0.1-rc.6",
 				"@radix-ui/react-radio-group": "^1.0.0",
 				"@radix-ui/react-switch": "^1.0.0",
 				"@radix-ui/react-tooltip": "^1.0.0",
@@ -4695,16 +4695,16 @@
 			}
 		},
 		"node_modules/@radix-ui/react-dropdown-menu": {
-			"version": "1.0.0",
-			"resolved": "https://registry.npmjs.org/@radix-ui/react-dropdown-menu/-/react-dropdown-menu-1.0.0.tgz",
-			"integrity": "sha512-Ptben3TxPWrZLbInO7zjAK73kmjYuStsxfg6ujgt+EywJyREoibhZYnsSNqC+UiOtl4PdW/MOHhxVDtew5fouQ==",
+			"version": "1.0.1-rc.6",
+			"resolved": "https://registry.npmjs.org/@radix-ui/react-dropdown-menu/-/react-dropdown-menu-1.0.1-rc.6.tgz",
+			"integrity": "sha512-Pbp/n+Vaet0YZO8GpQ7LXcwnZQ8G9W+gR6gGjYEs5ziHI1HgrzT1aIkJqBVNuy/i6NCytt+AuuDC71qCmEsNPw==",
 			"dependencies": {
 				"@babel/runtime": "^7.13.10",
 				"@radix-ui/primitive": "1.0.0",
 				"@radix-ui/react-compose-refs": "1.0.0",
 				"@radix-ui/react-context": "1.0.0",
 				"@radix-ui/react-id": "1.0.0",
-				"@radix-ui/react-menu": "1.0.0",
+				"@radix-ui/react-menu": "1.0.1-rc.6",
 				"@radix-ui/react-primitive": "1.0.0",
 				"@radix-ui/react-use-controllable-state": "1.0.0"
 			},
@@ -4759,9 +4759,9 @@
 			}
 		},
 		"node_modules/@radix-ui/react-dropdown-menu/node_modules/@radix-ui/react-menu": {
-			"version": "1.0.0",
-			"resolved": "https://registry.npmjs.org/@radix-ui/react-menu/-/react-menu-1.0.0.tgz",
-			"integrity": "sha512-icW4C64T6nHh3Z4Q1fxO1RlSShouFF4UpUmPV8FLaJZfphDljannKErDuALDx4ClRLihAPZ9i+PrLNPoWS2DMA==",
+			"version": "1.0.1-rc.6",
+			"resolved": "https://registry.npmjs.org/@radix-ui/react-menu/-/react-menu-1.0.1-rc.6.tgz",
+			"integrity": "sha512-AaC1FSlfidR/uncBbOiwgRKk7hihl2GgQSAl5+p4IVuhhFlnH2fRLXwriRlqvEthxkKDTIkdghB8ZvH3urOPTQ==",
 			"dependencies": {
 				"@babel/runtime": "^7.13.10",
 				"@radix-ui/primitive": "1.0.0",
@@ -4769,7 +4769,7 @@
 				"@radix-ui/react-compose-refs": "1.0.0",
 				"@radix-ui/react-context": "1.0.0",
 				"@radix-ui/react-direction": "1.0.0",
-				"@radix-ui/react-dismissable-layer": "1.0.0",
+				"@radix-ui/react-dismissable-layer": "1.0.1-rc.6",
 				"@radix-ui/react-focus-guards": "1.0.0",
 				"@radix-ui/react-focus-scope": "1.0.0",
 				"@radix-ui/react-id": "1.0.0",
@@ -4781,7 +4781,7 @@
 				"@radix-ui/react-slot": "1.0.0",
 				"@radix-ui/react-use-callback-ref": "1.0.0",
 				"aria-hidden": "^1.1.1",
-				"react-remove-scroll": "2.5.4"
+				"react-remove-scroll": "2.5.5"
 			},
 			"peerDependencies": {
 				"react": "^16.8 || ^17.0 || ^18.0",
@@ -4816,9 +4816,9 @@
 			}
 		},
 		"node_modules/@radix-ui/react-dropdown-menu/node_modules/@radix-ui/react-menu/node_modules/@radix-ui/react-dismissable-layer": {
-			"version": "1.0.0",
-			"resolved": "https://registry.npmjs.org/@radix-ui/react-dismissable-layer/-/react-dismissable-layer-1.0.0.tgz",
-			"integrity": "sha512-n7kDRfx+LB1zLueRDvZ1Pd0bxdJWDUZNQ/GWoxDn2prnuJKRdxsjulejX/ePkOsLi2tTm6P24mDqlMSgQpsT6g==",
+			"version": "1.0.1-rc.6",
+			"resolved": "https://registry.npmjs.org/@radix-ui/react-dismissable-layer/-/react-dismissable-layer-1.0.1-rc.6.tgz",
+			"integrity": "sha512-GH/0+mc1CxDy0veIbFWWB3K5XFegvNnzkha5qWYjzro4LGD+oChZnEtbWvxvAcK6fL4lLMXZ1gaUPQG1ESTVwA==",
 			"dependencies": {
 				"@babel/runtime": "^7.13.10",
 				"@radix-ui/primitive": "1.0.0",
@@ -5048,9 +5048,9 @@
 			}
 		},
 		"node_modules/@radix-ui/react-dropdown-menu/node_modules/@radix-ui/react-menu/node_modules/react-remove-scroll": {
-			"version": "2.5.4",
-			"resolved": "https://registry.npmjs.org/react-remove-scroll/-/react-remove-scroll-2.5.4.tgz",
-			"integrity": "sha512-xGVKJJr0SJGQVirVFAUZ2k1QLyO6m+2fy0l8Qawbp5Jgrv3DeLalrfMNBFSlmz5kriGGzsVBtGVnf4pTKIhhWA==",
+			"version": "2.5.5",
+			"resolved": "https://registry.npmjs.org/react-remove-scroll/-/react-remove-scroll-2.5.5.tgz",
+			"integrity": "sha512-ImKhrzJJsyXJfBZ4bzu8Bwpka14c/fQt0k+cyFp/PBhTfyDnU5hjOtM4AG/0AMyy8oKzOTR0lDgJIM7pYXI0kw==",
 			"dependencies": {
 				"react-remove-scroll-bar": "^2.3.3",
 				"react-style-singleton": "^2.2.1",
@@ -39250,16 +39250,16 @@
 			}
 		},
 		"@radix-ui/react-dropdown-menu": {
-			"version": "1.0.0",
-			"resolved": "https://registry.npmjs.org/@radix-ui/react-dropdown-menu/-/react-dropdown-menu-1.0.0.tgz",
-			"integrity": "sha512-Ptben3TxPWrZLbInO7zjAK73kmjYuStsxfg6ujgt+EywJyREoibhZYnsSNqC+UiOtl4PdW/MOHhxVDtew5fouQ==",
+			"version": "1.0.1-rc.6",
+			"resolved": "https://registry.npmjs.org/@radix-ui/react-dropdown-menu/-/react-dropdown-menu-1.0.1-rc.6.tgz",
+			"integrity": "sha512-Pbp/n+Vaet0YZO8GpQ7LXcwnZQ8G9W+gR6gGjYEs5ziHI1HgrzT1aIkJqBVNuy/i6NCytt+AuuDC71qCmEsNPw==",
 			"requires": {
 				"@babel/runtime": "^7.13.10",
 				"@radix-ui/primitive": "1.0.0",
 				"@radix-ui/react-compose-refs": "1.0.0",
 				"@radix-ui/react-context": "1.0.0",
 				"@radix-ui/react-id": "1.0.0",
-				"@radix-ui/react-menu": "1.0.0",
+				"@radix-ui/react-menu": "1.0.1-rc.6",
 				"@radix-ui/react-primitive": "1.0.0",
 				"@radix-ui/react-use-controllable-state": "1.0.0"
 			},
@@ -39300,9 +39300,9 @@
 					}
 				},
 				"@radix-ui/react-menu": {
-					"version": "1.0.0",
-					"resolved": "https://registry.npmjs.org/@radix-ui/react-menu/-/react-menu-1.0.0.tgz",
-					"integrity": "sha512-icW4C64T6nHh3Z4Q1fxO1RlSShouFF4UpUmPV8FLaJZfphDljannKErDuALDx4ClRLihAPZ9i+PrLNPoWS2DMA==",
+					"version": "1.0.1-rc.6",
+					"resolved": "https://registry.npmjs.org/@radix-ui/react-menu/-/react-menu-1.0.1-rc.6.tgz",
+					"integrity": "sha512-AaC1FSlfidR/uncBbOiwgRKk7hihl2GgQSAl5+p4IVuhhFlnH2fRLXwriRlqvEthxkKDTIkdghB8ZvH3urOPTQ==",
 					"requires": {
 						"@babel/runtime": "^7.13.10",
 						"@radix-ui/primitive": "1.0.0",
@@ -39310,7 +39310,7 @@
 						"@radix-ui/react-compose-refs": "1.0.0",
 						"@radix-ui/react-context": "1.0.0",
 						"@radix-ui/react-direction": "1.0.0",
-						"@radix-ui/react-dismissable-layer": "1.0.0",
+						"@radix-ui/react-dismissable-layer": "1.0.1-rc.6",
 						"@radix-ui/react-focus-guards": "1.0.0",
 						"@radix-ui/react-focus-scope": "1.0.0",
 						"@radix-ui/react-id": "1.0.0",
@@ -39322,7 +39322,7 @@
 						"@radix-ui/react-slot": "1.0.0",
 						"@radix-ui/react-use-callback-ref": "1.0.0",
 						"aria-hidden": "^1.1.1",
-						"react-remove-scroll": "2.5.4"
+						"react-remove-scroll": "2.5.5"
 					},
 					"dependencies": {
 						"@radix-ui/react-collection": {
@@ -39346,9 +39346,9 @@
 							}
 						},
 						"@radix-ui/react-dismissable-layer": {
-							"version": "1.0.0",
-							"resolved": "https://registry.npmjs.org/@radix-ui/react-dismissable-layer/-/react-dismissable-layer-1.0.0.tgz",
-							"integrity": "sha512-n7kDRfx+LB1zLueRDvZ1Pd0bxdJWDUZNQ/GWoxDn2prnuJKRdxsjulejX/ePkOsLi2tTm6P24mDqlMSgQpsT6g==",
+							"version": "1.0.1-rc.6",
+							"resolved": "https://registry.npmjs.org/@radix-ui/react-dismissable-layer/-/react-dismissable-layer-1.0.1-rc.6.tgz",
+							"integrity": "sha512-GH/0+mc1CxDy0veIbFWWB3K5XFegvNnzkha5qWYjzro4LGD+oChZnEtbWvxvAcK6fL4lLMXZ1gaUPQG1ESTVwA==",
 							"requires": {
 								"@babel/runtime": "^7.13.10",
 								"@radix-ui/primitive": "1.0.0",
@@ -39523,9 +39523,9 @@
 							}
 						},
 						"react-remove-scroll": {
-							"version": "2.5.4",
-							"resolved": "https://registry.npmjs.org/react-remove-scroll/-/react-remove-scroll-2.5.4.tgz",
-							"integrity": "sha512-xGVKJJr0SJGQVirVFAUZ2k1QLyO6m+2fy0l8Qawbp5Jgrv3DeLalrfMNBFSlmz5kriGGzsVBtGVnf4pTKIhhWA==",
+							"version": "2.5.5",
+							"resolved": "https://registry.npmjs.org/react-remove-scroll/-/react-remove-scroll-2.5.5.tgz",
+							"integrity": "sha512-ImKhrzJJsyXJfBZ4bzu8Bwpka14c/fQt0k+cyFp/PBhTfyDnU5hjOtM4AG/0AMyy8oKzOTR0lDgJIM7pYXI0kw==",
 							"requires": {
 								"react-remove-scroll-bar": "^2.3.3",
 								"react-style-singleton": "^2.2.1",

--- a/package.json
+++ b/package.json
@@ -22,7 +22,7 @@
 	"dependencies": {
 		"@radix-ui/react-checkbox": "^1.0.0",
 		"@radix-ui/react-dialog": "^1.0.0",
-		"@radix-ui/react-dropdown-menu": "^1.0.0",
+		"@radix-ui/react-dropdown-menu": "^1.0.1-rc.6",
 		"@radix-ui/react-radio-group": "^1.0.0",
 		"@radix-ui/react-switch": "^1.0.0",
 		"@radix-ui/react-tooltip": "^1.0.0",

--- a/src/system/Dropdown/DropdownSeparator.js
+++ b/src/system/Dropdown/DropdownSeparator.js
@@ -8,7 +8,7 @@ import * as DropdownMenuPrimitive from '@radix-ui/react-dropdown-menu';
 
 export const styles = {
 	height: '1px',
-	backgroundColor: 'border',
+	backgroundColor: 'borders.2',
 	my: '5px',
 };
 


### PR DESCRIPTION
## Description

- Updates @radix-ui/dropdown-menu to 1.0.1-rc.6. This update has the fix for the `menu-expandade="false"` we need to have full a11y
- Updates the border color for the dropdown

## Checklist

- [ ] This PR has good automated test coverage
- [ ] The storybook for the component has been updated

## Steps to Test — Border color

1. Pull down PR.
2. `npm run dev`.
3. Open http://localhost:6006/?path=/story/dropdown--default
4. Verify the border color of the separator is lighter than in here: https://vip-design-system-components.netlify.app/?path=/story/dropdown--default

## Steps to Test — Menu aria-expanded

1. Pull down PR.
2. `npm run dev`.
3. Open http://localhost:6006/?path=/story/dropdown--default and Open the menu
4. With the menu closed, you should see the `aria-expanded="false"` in the button HTML, as the screenshot shows below:

<img width="1210" alt="Screen Shot 2022-09-21 at 16 40 01" src="https://user-images.githubusercontent.com/3402/191596130-4e2d8ffa-caf8-4b1a-9e2b-8c45ba515a16.png">

