### PR TITLE
Add getOptionLabel / getOptionValue and onChange on new Select component

### DIFF
--- a/src/system/NewForm/FormSelect.js
+++ b/src/system/NewForm/FormSelect.js
@@ -68,22 +68,27 @@ const FormSelect = React.forwardRef(
 			);
 		}
 
-		const optionLabel = useCallback( option =>
-			getOptionLabel ? getOptionLabel( option ) : option.label
+		const optionLabel = useCallback(
+			option => ( getOptionLabel ? getOptionLabel( option ) : option.label ),
+			[ getOptionLabel ]
 		);
 
-		const optionValue = useCallback( option =>
-			getOptionValue ? getOptionValue( option ) : option.value
+		const optionValue = useCallback(
+			option => ( getOptionValue ? getOptionValue( option ) : option.value ),
+			[ getOptionValue ]
 		);
 
-		const getOptionByValue = useCallback( value =>
-			options.find( option => option.value === value )
+		const getOptionByValue = useCallback(
+			value => options.find( option => optionValue( option ) === value ),
+			[ options, optionValue ]
 		);
 
-		const onValueChange = useCallback( event =>
-			onChange
-				? onChange( getOptionByValue( event.target.value ) )
-				: getOptionByValue( event.target.value )
+		const onValueChange = useCallback(
+			event =>
+				onChange
+					? onChange( getOptionByValue( event.target.value ) )
+					: getOptionByValue( event.target.value ),
+			[ onChange, getOptionByValue ]
 		);
 
 		const SelectLabel = () => <Label htmlFor={ forLabel || props.id }>{ label }</Label>;

--- a/src/system/NewForm/FormSelect.js
+++ b/src/system/NewForm/FormSelect.js
@@ -86,7 +86,7 @@ const FormSelect = React.forwardRef(
 		const onValueChange = useCallback(
 			event =>
 				onChange
-					? onChange( getOptionByValue( event.target.value ) )
+					? onChange( getOptionByValue( event.target.value ), event )
 					: getOptionByValue( event.target.value ),
 			[ onChange, getOptionByValue ]
 		);

--- a/src/system/NewForm/FormSelect.stories.jsx
+++ b/src/system/NewForm/FormSelect.stories.jsx
@@ -110,13 +110,11 @@ WithOptionLabelAndValue.args = {
 };
 
 export const WithOnChange = () => {
-	const [ option, setOption ] = useState();
-	const [ event, setEvent ] = useState();
+	const [ option, setOption ] = useState( null );
 
-	const onChange = useCallback( ( val, originalEvent ) => {
-		setOption( val );
-		setEvent( originalEvent );
-	} );
+	const onChange = useCallback( ( val, event ) =>
+		setOption( { obj: val, eventValue: event.target.value } )
+	);
 
 	const args = {
 		label: 'Select with onChange',
@@ -129,8 +127,8 @@ export const WithOnChange = () => {
 	return (
 		<>
 			<DefaultComponent onChange={ onChange } { ...args } />
-			{ option && <p>Object to JSON: { JSON.stringify( option ) }</p> }
-			{ event && <p>Original Event Value: { event.target }</p> }
+			{ option && <p>Object to JSON: { JSON.stringify( option.obj ) }</p> }
+			{ option && <p>Original Event Value: { option.eventValue }</p> }
 		</>
 	);
 };

--- a/src/system/NewForm/FormSelect.stories.jsx
+++ b/src/system/NewForm/FormSelect.stories.jsx
@@ -3,6 +3,7 @@
 /**
  * Internal dependencies
  */
+import { useCallback, useState } from 'react';
 import * as Form from '.';
 
 export default {
@@ -26,7 +27,7 @@ const options = [
 ];
 
 // eslint-disable-next-line react/prop-types
-const DefaultComponent = ( { label = 'Label', width = 250, ...rest } ) => (
+const DefaultComponent = ( { label = 'Label', width = 250, onChange, ...rest } ) => (
 	<>
 		<p>
 			This is a simple wrapper at the top of a browser default select component. This component
@@ -49,7 +50,7 @@ const DefaultComponent = ( { label = 'Label', width = 250, ...rest } ) => (
 		</p>
 		<Form.Root>
 			<div sx={ { width } }>
-				<Form.Select id="form-select" label={ label } { ...rest } />
+				<Form.Select id="form-select" label={ label } onChange={ onChange } { ...rest } />
 			</div>
 		</Form.Root>
 	</>
@@ -93,4 +94,38 @@ IsInline.args = {
 			options: options,
 		},
 	],
+};
+
+export const WithOptionLabelAndValue = DefaultComponent.bind( {} );
+
+WithOptionLabelAndValue.args = {
+	label: 'Select with getOptionLabel / getOptionValue',
+	width: '100%',
+	options: options.map( ( { label, value } ) => ( {
+		name: label,
+		id: value,
+	} ) ),
+	getOptionLabel: option => option.name,
+	getOptionValue: option => option.id,
+};
+
+export const WithOnChange = () => {
+	const [ option, setOption ] = useState();
+
+	const onChange = useCallback( val => setOption( val ) );
+
+	const args = {
+		label: 'Select with onChange',
+		placeholder: '- Select -',
+		width: '100%',
+		onChange,
+		options,
+	};
+
+	return (
+		<>
+			<DefaultComponent onChange={ onChange } { ...args } />
+			{ option && <p>Object to JSON: { JSON.stringify( option ) }</p> }
+		</>
+	);
 };

--- a/src/system/NewForm/FormSelect.stories.jsx
+++ b/src/system/NewForm/FormSelect.stories.jsx
@@ -111,8 +111,12 @@ WithOptionLabelAndValue.args = {
 
 export const WithOnChange = () => {
 	const [ option, setOption ] = useState();
+	const [ event, setEvent ] = useState();
 
-	const onChange = useCallback( val => setOption( val ) );
+	const onChange = useCallback( ( val, originalEvent ) => {
+		setOption( val );
+		setEvent( originalEvent );
+	} );
 
 	const args = {
 		label: 'Select with onChange',
@@ -126,6 +130,7 @@ export const WithOnChange = () => {
 		<>
 			<DefaultComponent onChange={ onChange } { ...args } />
 			{ option && <p>Object to JSON: { JSON.stringify( option ) }</p> }
+			{ event && <p>Original Event Value: { event.target }</p> }
 		</>
 	);
 };

--- a/src/system/NewForm/FormSelect.test.js
+++ b/src/system/NewForm/FormSelect.test.js
@@ -69,4 +69,29 @@ describe( '<FormSelect />', () => {
 		// Check for accessibility issues
 		await expect( await axe( container ) ).toHaveNoViolations();
 	} );
+
+	it( 'renders the FormSelect component when getOptionLabel and getOptionValue', async () => {
+		const props = {
+			...defaultProps,
+			options: options.map( ( { label, value } ) => ( {
+				name: label,
+				id: value,
+			} ) ),
+			getOptionLabel: option => option.name,
+			getOptionValue: option => option.id,
+		};
+
+		const { container } = render( <FormSelect id="my_desert_list" { ...props } /> );
+
+		expect( screen.getByLabelText( defaultProps.label ) ).toBeInTheDocument();
+		expect( screen.getByRole( 'combobox' ) ).toBeInTheDocument();
+		expect( screen.getAllByRole( 'option' ) ).toHaveLength( 3 );
+		expect( screen.getByText( options[ 0 ].label ) ).toBeInTheDocument();
+		expect( screen.getByText( options[ 1 ].label ) ).toBeInTheDocument();
+		expect( screen.getByText( options[ 2 ].label ) ).toBeInTheDocument();
+		expect( screen.queryByRole( 'group' ) ).not.toBeInTheDocument();
+
+		// Check for accessibility issues
+		await expect( await axe( container ) ).toHaveNoViolations();
+	} );
 } );


### PR DESCRIPTION
## Description

Adding `getOptionLabel`, `getOptionValue` and `onChange` on new Select component 🥳 . 

<img width="1165" alt="image" src="https://user-images.githubusercontent.com/199867/191787841-9081bc5d-ca59-4eff-bc96-7c30bfc9e4f4.png">

```
Select.args = {
	options: options.map( ( { label, value } ) => ( {
		name: label,
		id: value,
	} ) ),
	getOptionLabel: option => option.name,
	getOptionValue: option => option.id,
};
```

## Checklist

- [x] This PR has good automated test coverage
- [x] The storybook for the component has been updated

## Steps to Test

1. Pull down PR.
1. `npm run dev`.
1. Open Storybook - https://deploy-preview-118--vip-design-system-components.netlify.app/?path=/story/form-select--with-on-change
1. Check the entire object returned on changing a different option in select.