### PR TITLE
Add dark mode support for <FormSelect>

### DIFF
--- a/src/system/NewForm/FormSelect.js
+++ b/src/system/NewForm/FormSelect.js
@@ -23,6 +23,8 @@ const defaultStyles = {
 	py: 0,
 	borderColor: 'border',
 	borderRadius: 1,
+	backgroundColor: 'background',
+	color: 'text',
 	appearance: 'none',
 	minHeight: '36px',
 	'&:focus': theme => theme.outline,


### PR DESCRIPTION
## Description

### Before
<img width="793" alt="image" src="https://user-images.githubusercontent.com/3402/192282685-2e1fb430-5d4c-46e2-9376-a0f35d9412a3.png">


### After
<img width="636" alt="image" src="https://user-images.githubusercontent.com/3402/192282733-0b59adcb-bcd7-4c32-bc19-a5df7ed8c71c.png">


## Checklist

- [ ] This PR has good automated test coverage
- [ ] The storybook for the component has been updated

## Steps to Test

1. Pull down PR.
2. `npm run dev`.
3. Open http://localhost:6006/?path=/story/form-select--default&globals=backgrounds.value:!hex(1C1C1B)
4. Dark mode support should work as expected
