### PR TITLE
Fix FormSelect styles for inLine and new Notice examples

### DIFF
--- a/src/system/NewForm/FormSelect.js
+++ b/src/system/NewForm/FormSelect.js
@@ -113,13 +113,11 @@ const FormSelect = React.forwardRef(
 				<FormSelectContent isInline={ inlineLabel } label={ inlineLabel ? <SelectLabel /> : null }>
 					<select onChange={ onValueChange } ref={ forwardRef } sx={ defaultStyles } { ...props }>
 						{ placeholder && <option>{ placeholder }</option> }
-						{ options.map( ( { options: groupOptions, ...option } ) => {
-							const value = optionValue( option );
-
-							return value
-								? renderOption( optionLabel( option ), value )
-								: renderGroup( optionLabel( option ), groupOptions );
-						} ) }
+						{ options.map( ( { options: groupOptions, ...option } ) =>
+							option.options
+								? renderGroup( optionLabel( option ), groupOptions )
+								: renderOption( optionLabel( option ), optionValue( option ) )
+						) }
 					</select>
 
 					<FormSelectArrow />

--- a/src/system/NewForm/FormSelect.js
+++ b/src/system/NewForm/FormSelect.js
@@ -114,7 +114,7 @@ const FormSelect = React.forwardRef(
 					<select onChange={ onValueChange } ref={ forwardRef } sx={ defaultStyles } { ...props }>
 						{ placeholder && <option>{ placeholder }</option> }
 						{ options.map( ( { options: groupOptions, ...option } ) =>
-							option.options
+							groupOptions
 								? renderGroup( optionLabel( option ), groupOptions )
 								: renderOption( optionLabel( option ), optionValue( option ) )
 						) }

--- a/src/system/NewForm/FormSelect.test.js
+++ b/src/system/NewForm/FormSelect.test.js
@@ -71,12 +71,7 @@ describe( '<FormSelect />', () => {
 	} );
 
 	it( 'renders the FormSelect with nullish options', async () => {
-		const nullishOptions = [
-			{ value: 'chocolate', label: 'Chocolate' },
-			{ value: 'strawberry', label: 'Strawberry Chocolate Vanilla Chocolate Vanilla' },
-			{ value: 'vanilla', label: 'Vanilla' },
-			{ value: null, label: 'Empty' },
-		];
+		const nullishOptions = [ ...options, { value: null, label: 'Empty' } ];
 
 		const { container } = render(
 			<FormSelect id="my_desert_list" { ...defaultProps } options={ nullishOptions } />

--- a/src/system/NewForm/FormSelect.test.js
+++ b/src/system/NewForm/FormSelect.test.js
@@ -70,6 +70,25 @@ describe( '<FormSelect />', () => {
 		await expect( await axe( container ) ).toHaveNoViolations();
 	} );
 
+	it( 'renders the FormSelect with nullish options', async () => {
+		const nullishOptions = [
+			{ value: 'chocolate', label: 'Chocolate' },
+			{ value: 'strawberry', label: 'Strawberry Chocolate Vanilla Chocolate Vanilla' },
+			{ value: 'vanilla', label: 'Vanilla' },
+			{ value: null, label: 'Empty' },
+		];
+
+		const { container } = render(
+			<FormSelect id="my_desert_list" { ...defaultProps } options={ nullishOptions } />
+		);
+
+		expect( screen.getByLabelText( defaultProps.label ) ).toBeInTheDocument();
+		expect( screen.getByRole( 'combobox' ) ).toBeInTheDocument();
+
+		// Check for accessibility issues
+		await expect( await axe( container ) ).toHaveNoViolations();
+	} );
+
 	it( 'renders the FormSelect component when getOptionLabel and getOptionValue', async () => {
 		const props = {
 			...defaultProps,

--- a/src/system/NewForm/FormSelectArrow.js
+++ b/src/system/NewForm/FormSelectArrow.js
@@ -12,12 +12,12 @@ export const FormSelectArrow = React.forwardRef( ( props, forwardRef ) => (
 		aria-hidden="true"
 		size={ 24 }
 		sx={ {
+			position: 'absolute',
 			paddingLeft: 2,
 			borderLeftWidth: '1px',
 			borderLeftStyle: 'solid',
 			borderLeftColor: 'border',
-			position: 'relative',
-			right: 34,
+			right: 2,
 			pointerEvents: 'none',
 		} }
 		{ ...props }

--- a/src/system/NewForm/FormSelectContent.js
+++ b/src/system/NewForm/FormSelectContent.js
@@ -12,11 +12,12 @@ import { inlineStyles } from './FormSelectInline';
  */
 
 const defaultStyles = {
+	position: 'relative',
 	width: '100%',
-	'&:hover select': { borderColor: 'border' },
 	display: 'inline-flex',
 	flexDirection: 'row',
 	alignItems: 'center',
+	'&:hover select': { borderColor: 'border' },
 };
 
 const FormSelectContent = React.forwardRef( ( { isInline, label, children }, forwardRef ) => (

--- a/src/system/NewForm/FormSelectContent.js
+++ b/src/system/NewForm/FormSelectContent.js
@@ -12,6 +12,7 @@ import { inlineStyles } from './FormSelectInline';
  */
 
 const defaultStyles = {
+	width: '100%',
 	'&:hover select': { borderColor: 'border' },
 	display: 'inline-flex',
 	flexDirection: 'row',

--- a/src/system/NewForm/FormSelectInline.js
+++ b/src/system/NewForm/FormSelectInline.js
@@ -1,6 +1,7 @@
 export const inlineStyles = {
+	display: 'grid',
+	gridTemplateColumns: 'auto 1fr',
 	position: 'relative',
-	display: 'inline-flex',
 	alignItems: 'center',
 	borderColor: 'border',
 	borderRadius: 1,

--- a/src/system/Notice/Notice.stories.jsx
+++ b/src/system/Notice/Notice.stories.jsx
@@ -31,5 +31,20 @@ export const Default = () => (
 		<Notice variant="success" sx={ { mb: 4 } } title="You made it!">
 			<Text sx={ { mb: 0 } }>This notice has a title and children</Text>
 		</Notice>
+
+		<Notice variant="alert" sx={ { mb: 4 } }>
+			<Heading variant="h4">There are errors in your form</Heading>
+			<ul sx={ { mb: 0 } }>
+				<li>
+					<a href="#name">Please enter your name.</a>
+				</li>
+				<li>
+					<a href="#email">Please enter your email address.</a>
+				</li>
+				<li>
+					<a href="#terms">Please agree to the terms.</a>
+				</li>
+			</ul>
+		</Notice>
 	</React.Fragment>
 );


### PR DESCRIPTION
## Description

- Adjust FormSelect style for Inline
- Add support for options with the value as null
- [Additional] Add Notice examples for errors

## Steps to Test

1. Pull down PR.
2. `npm run dev`.
3. Open https://deploy-preview-121--vip-design-system-components.netlify.app/
4. Styles for the inline work well for 100% width

