### PR TITLE
Adjust the table row/td padding

### DIFF
--- a/src/system/Table/TableCell.js
+++ b/src/system/Table/TableCell.js
@@ -21,9 +21,6 @@ const TableCell = ( { head, children, ...rest } ) => {
 		px: 3,
 		py: 2,
 		textAlign: 'left',
-		'&:first-of-type': {
-			pl: 5,
-		},
 		...rest.sx,
 	};
 


### PR DESCRIPTION
## Description

We are updating the TableRow styles to remove the padding-left of 64px.

## Before
![image](https://user-images.githubusercontent.com/3402/194369306-b1dce3ef-8ec0-4f14-8a27-27d0abafd82d.png)

## After
![Screen Shot 2022-10-06 at 13 35 39](https://user-images.githubusercontent.com/3402/194369433-fe7bad50-bc44-4787-8767-db6427abad5a.png)

## Steps to Test

1. Pull down PR.
2. `npm run dev`.
3. Open http://localhost:6006/?path=/story/table--default
4. Table td's should not have a padding-left of 64px
1. Verify cookies are delicious.
