### PR TITLE
Fix/wizard headings and Notice links

### DIFF
--- a/src/system/Link/Link.js
+++ b/src/system/Link/Link.js
@@ -10,9 +10,9 @@ import PropTypes from 'prop-types';
 const Link = React.forwardRef( ( { active = false, sx, ...props }, forwardRef ) => (
 	<ThemeLink
 		sx={ {
-			color: active ? 'links.active' : 'link',
 			textDdecorationThickness: '0.1em',
 			textUnderlineOffset: '0.1em',
+			color: active ? 'links.active' : 'link',
 			'&:visited': {
 				color: 'links.visited',
 			},

--- a/src/system/Notice/Notice.js
+++ b/src/system/Notice/Notice.js
@@ -74,7 +74,16 @@ const Notice = React.forwardRef(
 					color: `${ color }.90`,
 					a: {
 						color: `${ color }.90`,
-						border: 'none',
+						'&:visited': {
+							color: `${ color }.90`,
+						},
+						'&:active': {
+							color: `${ color }.90`,
+						},
+						'&:hover, &:focus': {
+							color: `${ color }.90`,
+							textDecoration: 'none',
+						},
 					},
 					...sx,
 				} }

--- a/src/system/Notice/Notice.stories.jsx
+++ b/src/system/Notice/Notice.stories.jsx
@@ -6,7 +6,7 @@
  * Internal dependencies
  */
 import React from 'react';
-import { Notice, Text } from '..';
+import { Notice, Text, Link } from '..';
 
 export default {
 	title: 'Notice',
@@ -27,7 +27,8 @@ export const Default = () => (
 		</Notice>
 
 		<Notice variant="success" sx={ { mb: 4 } }>
-			It looks like you&lsquo;re ready to share your <a href="#">application with the world.</a>
+			It looks like you&lsquo;re ready to share your{ ' ' }
+			<Link href="https://google.com/">application with the world.</Link>
 		</Notice>
 
 		<Notice sx={ { mb: 4 } } title="This notice has only the title prop passed" />

--- a/src/system/Wizard/Wizard.js
+++ b/src/system/Wizard/Wizard.js
@@ -43,7 +43,7 @@ const Wizard = React.forwardRef(
 						{ steps[ activeStep ].children }
 					</Box>
 				) : (
-					steps.map( ( { title, subTitle, children }, index ) => (
+					steps.map( ( { title, subTitle, children, titleVariant }, index ) => (
 						<WizardStep
 							active={ index === activeStep }
 							complete={ completed.includes( index ) }
@@ -51,6 +51,7 @@ const Wizard = React.forwardRef(
 							order={ index + 1 }
 							subTitle={ subTitle }
 							title={ title }
+							titleVariant={ titleVariant }
 						>
 							{ children }
 						</WizardStep>

--- a/src/system/Wizard/Wizard.stories.jsx
+++ b/src/system/Wizard/Wizard.stories.jsx
@@ -44,13 +44,6 @@ export const Default = () => {
 	];
 	return (
 		<React.Fragment>
-			<Flex sx={ { alignItems: 'center' } }>
-				<Box sx={ { flex: '1 1 auto' } }>
-					<Heading variant="h1" sx={ { display: 'flex', alignItems: 'center', mb: 1 } }>
-						Add Domain: <span sx={ { color: 'muted', ml: 2 } }>Production</span>
-					</Heading>
-				</Box>
-			</Flex>
 			<Box mt={ 4 }>
 				<Wizard activeStep={ 0 } steps={ steps } className="vip-wizard-xyz" />
 			</Box>

--- a/src/system/Wizard/Wizard.stories.jsx
+++ b/src/system/Wizard/Wizard.stories.jsx
@@ -8,7 +8,7 @@ import React from 'react';
 /**
  * Internal dependencies
  */
-import { Wizard, Flex, Box, Heading, Label, Input, Button } from '..';
+import { Wizard, Box, Label, Input, Button } from '..';
 
 export default {
 	title: 'Wizard',

--- a/src/system/Wizard/Wizard.stories.jsx
+++ b/src/system/Wizard/Wizard.stories.jsx
@@ -19,6 +19,7 @@ export const Default = () => {
 	const steps = [
 		{
 			title: 'Choose Domain',
+			titleVariant: 'h2',
 			subTitle: 'You can bring a domain name you already own, or buy a new one.',
 			children: (
 				<Box>
@@ -30,12 +31,15 @@ export const Default = () => {
 		},
 		{
 			title: 'Configure DNS',
+			titleVariant: 'h2',
 		},
 		{
 			title: 'Configure Certificate',
+			titleVariant: 'h2',
 		},
 		{
 			title: 'Verify Domain',
+			titleVariant: 'h2',
 		},
 	];
 	return (

--- a/src/system/Wizard/WizardStep.js
+++ b/src/system/Wizard/WizardStep.js
@@ -13,7 +13,10 @@ import PropTypes from 'prop-types';
 import { Card, Heading, Text, Flex } from '..';
 
 const WizardStep = React.forwardRef(
-	( { title, subTitle, complete = false, children, active, order }, forwardRef ) => {
+	(
+		{ title, subTitle, complete = false, children, active, order, titleVariant = 'h3' },
+		forwardRef
+	) => {
 		let borderLeftColor = 'border';
 
 		if ( complete ) {
@@ -32,6 +35,7 @@ const WizardStep = React.forwardRef(
 
 		return (
 			<Card
+				as="section"
 				sx={ {
 					boxShadow: active ? 'low' : 'none',
 					borderLeft: '2px solid',
@@ -53,12 +57,13 @@ const WizardStep = React.forwardRef(
 			>
 				{ typeof title === 'string' ? (
 					<Heading
-						variant="h4"
+						variant={ titleVariant }
 						sx={ {
 							mb: 0,
 							display: 'flex',
 							alignItems: 'center',
 							color: color,
+							fontSize: 2,
 						} }
 					>
 						<MdCheckCircle aria-hidden="true" sx={ { mr: 2 } } />
@@ -88,6 +93,7 @@ WizardStep.propTypes = {
 	order: PropTypes.number.isRequired,
 	subTitle: PropTypes.node,
 	title: PropTypes.node,
+	titleVariant: PropTypes.string,
 };
 
 export { WizardStep };

--- a/src/system/Wizard/WizardStep.js
+++ b/src/system/Wizard/WizardStep.js
@@ -62,8 +62,9 @@ const WizardStep = React.forwardRef(
 							mb: 0,
 							display: 'flex',
 							alignItems: 'center',
-							color: color,
+							color,
 							fontSize: 2,
+							fontWeight: active ? 'bold' : 'normal',
 						} }
 					>
 						<MdCheckCircle aria-hidden="true" sx={ { mr: 2 } } />

--- a/src/system/Wizard/WizardStepHorizontal.js
+++ b/src/system/Wizard/WizardStepHorizontal.js
@@ -12,32 +12,35 @@ import PropTypes from 'prop-types';
  */
 import { Heading, Flex } from '..';
 
-const WizardStepHorizontal = React.forwardRef( ( { title, active, order }, forwardRef ) => {
-	const color = active ? 'heading' : 'muted';
+const WizardStepHorizontal = React.forwardRef(
+	( { title, active, order, titleVariant = 'h3' }, forwardRef ) => {
+		const color = active ? 'heading' : 'muted';
 
-	return typeof title === 'string' ? (
-		<Heading
-			variant="h4"
-			sx={ {
-				mb: 0,
-				display: 'flex',
-				alignItems: 'center',
-				color,
-			} }
-			data-step={ order }
-			data-active={ active || undefined }
-			ref={ forwardRef }
-		>
-			<MdCheckCircle aria-hidden="true" sx={ { mr: 2 } } />
-			{ title }
-		</Heading>
-	) : (
-		<Flex sx={ { alignItems: 'center', color } }>
-			<MdCheckCircle aria-hidden="true" sx={ { mr: 2 } } />
-			{ title }
-		</Flex>
-	);
-} );
+		return typeof title === 'string' ? (
+			<Heading
+				variant={ titleVariant }
+				sx={ {
+					mb: 0,
+					display: 'flex',
+					alignItems: 'center',
+					fontSize: 2,
+					color,
+				} }
+				data-step={ order }
+				data-active={ active || undefined }
+				ref={ forwardRef }
+			>
+				<MdCheckCircle aria-hidden="true" sx={ { mr: 2 } } />
+				{ title }
+			</Heading>
+		) : (
+			<Flex sx={ { alignItems: 'center', color } }>
+				<MdCheckCircle aria-hidden="true" sx={ { mr: 2 } } />
+				{ title }
+			</Flex>
+		);
+	}
+);
 
 WizardStepHorizontal.displayName = 'WizardStepHorizontal';
 
@@ -46,6 +49,7 @@ WizardStepHorizontal.propTypes = {
 	order: PropTypes.number.isRequired,
 	subTitle: PropTypes.node,
 	title: PropTypes.node,
+	titleVariant: PropTypes.string,
 };
 
 export { WizardStepHorizontal };


### PR DESCRIPTION
## Description

- Add the `titleVariant` attribute to `WizardStep`
- Adjust color links for `Notice` internal links

## Checklist

- [ ] This PR has good automated test coverage
- [x] The storybook for the component has been updated

## Steps to Test — Notice

1. Pull down PR.
2. `npm run dev`.
3. Open http://localhost:6006/?path=/story/notice--default
4. Internal links should match the variant color (green links on a success notice)

## Steps to Test — Wizard

1. Pull down PR.
2. `npm run dev`.
3. Open http://localhost:6006/?path=/story/wizard--default
4. Check that heading levels are customized (h2) for wizard steps
