### PR TITLE
PIE-3411 Adds Accordion component

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -8,6 +8,7 @@
 			"name": "@automattic/vip-design-system",
 			"version": "0.23.6",
 			"dependencies": {
+				"@radix-ui/react-accordion": "^1.0.1",
 				"@radix-ui/react-checkbox": "^1.0.0",
 				"@radix-ui/react-dialog": "^1.0.0",
 				"@radix-ui/react-dropdown-menu": "^1.0.1-rc.6",
@@ -4161,6 +4162,192 @@
 			"integrity": "sha512-3e7rn8FDMin4CgeL7Z/49smCA3rFYY3Ha2rUQ7HRWFadS5iCRw08ZgVT1LaNTCNqgvrUiyczLflrVrF0SRQtNA==",
 			"dependencies": {
 				"@babel/runtime": "^7.13.10"
+			}
+		},
+		"node_modules/@radix-ui/react-accordion": {
+			"version": "1.0.1",
+			"resolved": "https://registry.npmjs.org/@radix-ui/react-accordion/-/react-accordion-1.0.1.tgz",
+			"integrity": "sha512-Ka7BQoyRRPwsOb0YEv0fQU8V8aCXCxAzNVI5BRN7WmPG2E1zQKKxmb86NVDqIj6uSnaahJ1E5S6bX5Lk9hTK+g==",
+			"dependencies": {
+				"@babel/runtime": "^7.13.10",
+				"@radix-ui/primitive": "1.0.0",
+				"@radix-ui/react-collapsible": "1.0.1",
+				"@radix-ui/react-collection": "1.0.1",
+				"@radix-ui/react-compose-refs": "1.0.0",
+				"@radix-ui/react-context": "1.0.0",
+				"@radix-ui/react-id": "1.0.0",
+				"@radix-ui/react-primitive": "1.0.1",
+				"@radix-ui/react-use-controllable-state": "1.0.0"
+			},
+			"peerDependencies": {
+				"react": "^16.8 || ^17.0 || ^18.0",
+				"react-dom": "^16.8 || ^17.0 || ^18.0"
+			}
+		},
+		"node_modules/@radix-ui/react-accordion/node_modules/@radix-ui/react-collapsible": {
+			"version": "1.0.1",
+			"resolved": "https://registry.npmjs.org/@radix-ui/react-collapsible/-/react-collapsible-1.0.1.tgz",
+			"integrity": "sha512-0maX4q91iYa4gjt3PsNf7dq/yqSR+HGAE8I5p54dQ6gnveS+ETWlMoijxrhmgV1k8svxpm34mQAtqIrJt4XZmA==",
+			"dependencies": {
+				"@babel/runtime": "^7.13.10",
+				"@radix-ui/primitive": "1.0.0",
+				"@radix-ui/react-compose-refs": "1.0.0",
+				"@radix-ui/react-context": "1.0.0",
+				"@radix-ui/react-id": "1.0.0",
+				"@radix-ui/react-presence": "1.0.0",
+				"@radix-ui/react-primitive": "1.0.1",
+				"@radix-ui/react-use-controllable-state": "1.0.0",
+				"@radix-ui/react-use-layout-effect": "1.0.0"
+			},
+			"peerDependencies": {
+				"react": "^16.8 || ^17.0 || ^18.0",
+				"react-dom": "^16.8 || ^17.0 || ^18.0"
+			}
+		},
+		"node_modules/@radix-ui/react-accordion/node_modules/@radix-ui/react-collapsible/node_modules/@radix-ui/react-presence": {
+			"version": "1.0.0",
+			"resolved": "https://registry.npmjs.org/@radix-ui/react-presence/-/react-presence-1.0.0.tgz",
+			"integrity": "sha512-A+6XEvN01NfVWiKu38ybawfHsBjWum42MRPnEuqPsBZ4eV7e/7K321B5VgYMPv3Xx5An6o1/l9ZuDBgmcmWK3w==",
+			"dependencies": {
+				"@babel/runtime": "^7.13.10",
+				"@radix-ui/react-compose-refs": "1.0.0",
+				"@radix-ui/react-use-layout-effect": "1.0.0"
+			},
+			"peerDependencies": {
+				"react": "^16.8 || ^17.0 || ^18.0",
+				"react-dom": "^16.8 || ^17.0 || ^18.0"
+			}
+		},
+		"node_modules/@radix-ui/react-accordion/node_modules/@radix-ui/react-collapsible/node_modules/@radix-ui/react-use-layout-effect": {
+			"version": "1.0.0",
+			"resolved": "https://registry.npmjs.org/@radix-ui/react-use-layout-effect/-/react-use-layout-effect-1.0.0.tgz",
+			"integrity": "sha512-6Tpkq+R6LOlmQb1R5NNETLG0B4YP0wc+klfXafpUCj6JGyaUc8il7/kUZ7m59rGbXGczE9Bs+iz2qloqsZBduQ==",
+			"dependencies": {
+				"@babel/runtime": "^7.13.10"
+			},
+			"peerDependencies": {
+				"react": "^16.8 || ^17.0 || ^18.0"
+			}
+		},
+		"node_modules/@radix-ui/react-accordion/node_modules/@radix-ui/react-collection": {
+			"version": "1.0.1",
+			"resolved": "https://registry.npmjs.org/@radix-ui/react-collection/-/react-collection-1.0.1.tgz",
+			"integrity": "sha512-uuiFbs+YCKjn3X1DTSx9G7BHApu4GHbi3kgiwsnFUbOKCrwejAJv4eE4Vc8C0Oaxt9T0aV4ox0WCOdx+39Xo+g==",
+			"dependencies": {
+				"@babel/runtime": "^7.13.10",
+				"@radix-ui/react-compose-refs": "1.0.0",
+				"@radix-ui/react-context": "1.0.0",
+				"@radix-ui/react-primitive": "1.0.1",
+				"@radix-ui/react-slot": "1.0.1"
+			},
+			"peerDependencies": {
+				"react": "^16.8 || ^17.0 || ^18.0",
+				"react-dom": "^16.8 || ^17.0 || ^18.0"
+			}
+		},
+		"node_modules/@radix-ui/react-accordion/node_modules/@radix-ui/react-collection/node_modules/@radix-ui/react-slot": {
+			"version": "1.0.1",
+			"resolved": "https://registry.npmjs.org/@radix-ui/react-slot/-/react-slot-1.0.1.tgz",
+			"integrity": "sha512-avutXAFL1ehGvAXtPquu0YK5oz6ctS474iM3vNGQIkswrVhdrS52e3uoMQBzZhNRAIE0jBnUyXWNmSjGHhCFcw==",
+			"dependencies": {
+				"@babel/runtime": "^7.13.10",
+				"@radix-ui/react-compose-refs": "1.0.0"
+			},
+			"peerDependencies": {
+				"react": "^16.8 || ^17.0 || ^18.0"
+			}
+		},
+		"node_modules/@radix-ui/react-accordion/node_modules/@radix-ui/react-compose-refs": {
+			"version": "1.0.0",
+			"resolved": "https://registry.npmjs.org/@radix-ui/react-compose-refs/-/react-compose-refs-1.0.0.tgz",
+			"integrity": "sha512-0KaSv6sx787/hK3eF53iOkiSLwAGlFMx5lotrqD2pTjB18KbybKoEIgkNZTKC60YECDQTKGTRcDBILwZVqVKvA==",
+			"dependencies": {
+				"@babel/runtime": "^7.13.10"
+			},
+			"peerDependencies": {
+				"react": "^16.8 || ^17.0 || ^18.0"
+			}
+		},
+		"node_modules/@radix-ui/react-accordion/node_modules/@radix-ui/react-context": {
+			"version": "1.0.0",
+			"resolved": "https://registry.npmjs.org/@radix-ui/react-context/-/react-context-1.0.0.tgz",
+			"integrity": "sha512-1pVM9RfOQ+n/N5PJK33kRSKsr1glNxomxONs5c49MliinBY6Yw2Q995qfBUUo0/Mbg05B/sGA0gkgPI7kmSHBg==",
+			"dependencies": {
+				"@babel/runtime": "^7.13.10"
+			},
+			"peerDependencies": {
+				"react": "^16.8 || ^17.0 || ^18.0"
+			}
+		},
+		"node_modules/@radix-ui/react-accordion/node_modules/@radix-ui/react-id": {
+			"version": "1.0.0",
+			"resolved": "https://registry.npmjs.org/@radix-ui/react-id/-/react-id-1.0.0.tgz",
+			"integrity": "sha512-Q6iAB/U7Tq3NTolBBQbHTgclPmGWE3OlktGGqrClPozSw4vkQ1DfQAOtzgRPecKsMdJINE05iaoDUG8tRzCBjw==",
+			"dependencies": {
+				"@babel/runtime": "^7.13.10",
+				"@radix-ui/react-use-layout-effect": "1.0.0"
+			},
+			"peerDependencies": {
+				"react": "^16.8 || ^17.0 || ^18.0"
+			}
+		},
+		"node_modules/@radix-ui/react-accordion/node_modules/@radix-ui/react-id/node_modules/@radix-ui/react-use-layout-effect": {
+			"version": "1.0.0",
+			"resolved": "https://registry.npmjs.org/@radix-ui/react-use-layout-effect/-/react-use-layout-effect-1.0.0.tgz",
+			"integrity": "sha512-6Tpkq+R6LOlmQb1R5NNETLG0B4YP0wc+klfXafpUCj6JGyaUc8il7/kUZ7m59rGbXGczE9Bs+iz2qloqsZBduQ==",
+			"dependencies": {
+				"@babel/runtime": "^7.13.10"
+			},
+			"peerDependencies": {
+				"react": "^16.8 || ^17.0 || ^18.0"
+			}
+		},
+		"node_modules/@radix-ui/react-accordion/node_modules/@radix-ui/react-primitive": {
+			"version": "1.0.1",
+			"resolved": "https://registry.npmjs.org/@radix-ui/react-primitive/-/react-primitive-1.0.1.tgz",
+			"integrity": "sha512-fHbmislWVkZaIdeF6GZxF0A/NH/3BjrGIYj+Ae6eTmTCr7EB0RQAAVEiqsXK6p3/JcRqVSBQoceZroj30Jj3XA==",
+			"dependencies": {
+				"@babel/runtime": "^7.13.10",
+				"@radix-ui/react-slot": "1.0.1"
+			},
+			"peerDependencies": {
+				"react": "^16.8 || ^17.0 || ^18.0",
+				"react-dom": "^16.8 || ^17.0 || ^18.0"
+			}
+		},
+		"node_modules/@radix-ui/react-accordion/node_modules/@radix-ui/react-primitive/node_modules/@radix-ui/react-slot": {
+			"version": "1.0.1",
+			"resolved": "https://registry.npmjs.org/@radix-ui/react-slot/-/react-slot-1.0.1.tgz",
+			"integrity": "sha512-avutXAFL1ehGvAXtPquu0YK5oz6ctS474iM3vNGQIkswrVhdrS52e3uoMQBzZhNRAIE0jBnUyXWNmSjGHhCFcw==",
+			"dependencies": {
+				"@babel/runtime": "^7.13.10",
+				"@radix-ui/react-compose-refs": "1.0.0"
+			},
+			"peerDependencies": {
+				"react": "^16.8 || ^17.0 || ^18.0"
+			}
+		},
+		"node_modules/@radix-ui/react-accordion/node_modules/@radix-ui/react-use-controllable-state": {
+			"version": "1.0.0",
+			"resolved": "https://registry.npmjs.org/@radix-ui/react-use-controllable-state/-/react-use-controllable-state-1.0.0.tgz",
+			"integrity": "sha512-FohDoZvk3mEXh9AWAVyRTYR4Sq7/gavuofglmiXB2g1aKyboUD4YtgWxKj8O5n+Uak52gXQ4wKz5IFST4vtJHg==",
+			"dependencies": {
+				"@babel/runtime": "^7.13.10",
+				"@radix-ui/react-use-callback-ref": "1.0.0"
+			},
+			"peerDependencies": {
+				"react": "^16.8 || ^17.0 || ^18.0"
+			}
+		},
+		"node_modules/@radix-ui/react-accordion/node_modules/@radix-ui/react-use-controllable-state/node_modules/@radix-ui/react-use-callback-ref": {
+			"version": "1.0.0",
+			"resolved": "https://registry.npmjs.org/@radix-ui/react-use-callback-ref/-/react-use-callback-ref-1.0.0.tgz",
+			"integrity": "sha512-GZtyzoHz95Rhs6S63D2t/eqvdFCm7I+yHMLVQheKM7nBD8mbZIt+ct1jz4536MDnaOGKIxynJ8eHTkVGVVkoTg==",
+			"dependencies": {
+				"@babel/runtime": "^7.13.10"
+			},
+			"peerDependencies": {
+				"react": "^16.8 || ^17.0 || ^18.0"
 			}
 		},
 		"node_modules/@radix-ui/react-checkbox": {
@@ -38857,6 +39044,157 @@
 			"integrity": "sha512-3e7rn8FDMin4CgeL7Z/49smCA3rFYY3Ha2rUQ7HRWFadS5iCRw08ZgVT1LaNTCNqgvrUiyczLflrVrF0SRQtNA==",
 			"requires": {
 				"@babel/runtime": "^7.13.10"
+			}
+		},
+		"@radix-ui/react-accordion": {
+			"version": "1.0.1",
+			"resolved": "https://registry.npmjs.org/@radix-ui/react-accordion/-/react-accordion-1.0.1.tgz",
+			"integrity": "sha512-Ka7BQoyRRPwsOb0YEv0fQU8V8aCXCxAzNVI5BRN7WmPG2E1zQKKxmb86NVDqIj6uSnaahJ1E5S6bX5Lk9hTK+g==",
+			"requires": {
+				"@babel/runtime": "^7.13.10",
+				"@radix-ui/primitive": "1.0.0",
+				"@radix-ui/react-collapsible": "1.0.1",
+				"@radix-ui/react-collection": "1.0.1",
+				"@radix-ui/react-compose-refs": "1.0.0",
+				"@radix-ui/react-context": "1.0.0",
+				"@radix-ui/react-id": "1.0.0",
+				"@radix-ui/react-primitive": "1.0.1",
+				"@radix-ui/react-use-controllable-state": "1.0.0"
+			},
+			"dependencies": {
+				"@radix-ui/react-collapsible": {
+					"version": "1.0.1",
+					"resolved": "https://registry.npmjs.org/@radix-ui/react-collapsible/-/react-collapsible-1.0.1.tgz",
+					"integrity": "sha512-0maX4q91iYa4gjt3PsNf7dq/yqSR+HGAE8I5p54dQ6gnveS+ETWlMoijxrhmgV1k8svxpm34mQAtqIrJt4XZmA==",
+					"requires": {
+						"@babel/runtime": "^7.13.10",
+						"@radix-ui/primitive": "1.0.0",
+						"@radix-ui/react-compose-refs": "1.0.0",
+						"@radix-ui/react-context": "1.0.0",
+						"@radix-ui/react-id": "1.0.0",
+						"@radix-ui/react-presence": "1.0.0",
+						"@radix-ui/react-primitive": "1.0.1",
+						"@radix-ui/react-use-controllable-state": "1.0.0",
+						"@radix-ui/react-use-layout-effect": "1.0.0"
+					},
+					"dependencies": {
+						"@radix-ui/react-presence": {
+							"version": "1.0.0",
+							"resolved": "https://registry.npmjs.org/@radix-ui/react-presence/-/react-presence-1.0.0.tgz",
+							"integrity": "sha512-A+6XEvN01NfVWiKu38ybawfHsBjWum42MRPnEuqPsBZ4eV7e/7K321B5VgYMPv3Xx5An6o1/l9ZuDBgmcmWK3w==",
+							"requires": {
+								"@babel/runtime": "^7.13.10",
+								"@radix-ui/react-compose-refs": "1.0.0",
+								"@radix-ui/react-use-layout-effect": "1.0.0"
+							}
+						},
+						"@radix-ui/react-use-layout-effect": {
+							"version": "1.0.0",
+							"resolved": "https://registry.npmjs.org/@radix-ui/react-use-layout-effect/-/react-use-layout-effect-1.0.0.tgz",
+							"integrity": "sha512-6Tpkq+R6LOlmQb1R5NNETLG0B4YP0wc+klfXafpUCj6JGyaUc8il7/kUZ7m59rGbXGczE9Bs+iz2qloqsZBduQ==",
+							"requires": {
+								"@babel/runtime": "^7.13.10"
+							}
+						}
+					}
+				},
+				"@radix-ui/react-collection": {
+					"version": "1.0.1",
+					"resolved": "https://registry.npmjs.org/@radix-ui/react-collection/-/react-collection-1.0.1.tgz",
+					"integrity": "sha512-uuiFbs+YCKjn3X1DTSx9G7BHApu4GHbi3kgiwsnFUbOKCrwejAJv4eE4Vc8C0Oaxt9T0aV4ox0WCOdx+39Xo+g==",
+					"requires": {
+						"@babel/runtime": "^7.13.10",
+						"@radix-ui/react-compose-refs": "1.0.0",
+						"@radix-ui/react-context": "1.0.0",
+						"@radix-ui/react-primitive": "1.0.1",
+						"@radix-ui/react-slot": "1.0.1"
+					},
+					"dependencies": {
+						"@radix-ui/react-slot": {
+							"version": "1.0.1",
+							"resolved": "https://registry.npmjs.org/@radix-ui/react-slot/-/react-slot-1.0.1.tgz",
+							"integrity": "sha512-avutXAFL1ehGvAXtPquu0YK5oz6ctS474iM3vNGQIkswrVhdrS52e3uoMQBzZhNRAIE0jBnUyXWNmSjGHhCFcw==",
+							"requires": {
+								"@babel/runtime": "^7.13.10",
+								"@radix-ui/react-compose-refs": "1.0.0"
+							}
+						}
+					}
+				},
+				"@radix-ui/react-compose-refs": {
+					"version": "1.0.0",
+					"resolved": "https://registry.npmjs.org/@radix-ui/react-compose-refs/-/react-compose-refs-1.0.0.tgz",
+					"integrity": "sha512-0KaSv6sx787/hK3eF53iOkiSLwAGlFMx5lotrqD2pTjB18KbybKoEIgkNZTKC60YECDQTKGTRcDBILwZVqVKvA==",
+					"requires": {
+						"@babel/runtime": "^7.13.10"
+					}
+				},
+				"@radix-ui/react-context": {
+					"version": "1.0.0",
+					"resolved": "https://registry.npmjs.org/@radix-ui/react-context/-/react-context-1.0.0.tgz",
+					"integrity": "sha512-1pVM9RfOQ+n/N5PJK33kRSKsr1glNxomxONs5c49MliinBY6Yw2Q995qfBUUo0/Mbg05B/sGA0gkgPI7kmSHBg==",
+					"requires": {
+						"@babel/runtime": "^7.13.10"
+					}
+				},
+				"@radix-ui/react-id": {
+					"version": "1.0.0",
+					"resolved": "https://registry.npmjs.org/@radix-ui/react-id/-/react-id-1.0.0.tgz",
+					"integrity": "sha512-Q6iAB/U7Tq3NTolBBQbHTgclPmGWE3OlktGGqrClPozSw4vkQ1DfQAOtzgRPecKsMdJINE05iaoDUG8tRzCBjw==",
+					"requires": {
+						"@babel/runtime": "^7.13.10",
+						"@radix-ui/react-use-layout-effect": "1.0.0"
+					},
+					"dependencies": {
+						"@radix-ui/react-use-layout-effect": {
+							"version": "1.0.0",
+							"resolved": "https://registry.npmjs.org/@radix-ui/react-use-layout-effect/-/react-use-layout-effect-1.0.0.tgz",
+							"integrity": "sha512-6Tpkq+R6LOlmQb1R5NNETLG0B4YP0wc+klfXafpUCj6JGyaUc8il7/kUZ7m59rGbXGczE9Bs+iz2qloqsZBduQ==",
+							"requires": {
+								"@babel/runtime": "^7.13.10"
+							}
+						}
+					}
+				},
+				"@radix-ui/react-primitive": {
+					"version": "1.0.1",
+					"resolved": "https://registry.npmjs.org/@radix-ui/react-primitive/-/react-primitive-1.0.1.tgz",
+					"integrity": "sha512-fHbmislWVkZaIdeF6GZxF0A/NH/3BjrGIYj+Ae6eTmTCr7EB0RQAAVEiqsXK6p3/JcRqVSBQoceZroj30Jj3XA==",
+					"requires": {
+						"@babel/runtime": "^7.13.10",
+						"@radix-ui/react-slot": "1.0.1"
+					},
+					"dependencies": {
+						"@radix-ui/react-slot": {
+							"version": "1.0.1",
+							"resolved": "https://registry.npmjs.org/@radix-ui/react-slot/-/react-slot-1.0.1.tgz",
+							"integrity": "sha512-avutXAFL1ehGvAXtPquu0YK5oz6ctS474iM3vNGQIkswrVhdrS52e3uoMQBzZhNRAIE0jBnUyXWNmSjGHhCFcw==",
+							"requires": {
+								"@babel/runtime": "^7.13.10",
+								"@radix-ui/react-compose-refs": "1.0.0"
+							}
+						}
+					}
+				},
+				"@radix-ui/react-use-controllable-state": {
+					"version": "1.0.0",
+					"resolved": "https://registry.npmjs.org/@radix-ui/react-use-controllable-state/-/react-use-controllable-state-1.0.0.tgz",
+					"integrity": "sha512-FohDoZvk3mEXh9AWAVyRTYR4Sq7/gavuofglmiXB2g1aKyboUD4YtgWxKj8O5n+Uak52gXQ4wKz5IFST4vtJHg==",
+					"requires": {
+						"@babel/runtime": "^7.13.10",
+						"@radix-ui/react-use-callback-ref": "1.0.0"
+					},
+					"dependencies": {
+						"@radix-ui/react-use-callback-ref": {
+							"version": "1.0.0",
+							"resolved": "https://registry.npmjs.org/@radix-ui/react-use-callback-ref/-/react-use-callback-ref-1.0.0.tgz",
+							"integrity": "sha512-GZtyzoHz95Rhs6S63D2t/eqvdFCm7I+yHMLVQheKM7nBD8mbZIt+ct1jz4536MDnaOGKIxynJ8eHTkVGVVkoTg==",
+							"requires": {
+								"@babel/runtime": "^7.13.10"
+							}
+						}
+					}
+				}
 			}
 		},
 		"@radix-ui/react-checkbox": {

--- a/package.json
+++ b/package.json
@@ -20,6 +20,7 @@
 		"watch": "npm run build -- --watch"
 	},
 	"dependencies": {
+		"@radix-ui/react-accordion": "^1.0.1",
 		"@radix-ui/react-checkbox": "^1.0.0",
 		"@radix-ui/react-dialog": "^1.0.0",
 		"@radix-ui/react-dropdown-menu": "^1.0.1-rc.6",

--- a/src/system/Accordion/Accordion.js
+++ b/src/system/Accordion/Accordion.js
@@ -72,7 +72,7 @@ export const Trigger = React.forwardRef(
 					cursor: 'pointer',
 					all: 'unset',
 					fontFamily: 'inherit',
-					padding: '0 20px',
+					px: 3,
 					height: 45,
 					flex: 1,
 					display: 'flex',
@@ -117,6 +117,20 @@ Trigger.propTypes = {
 	headingVariant: PropTypes.string,
 };
 
+export const TriggerWithIcon = React.forwardRef( ( { children, icon, ...props }, forwardedRef ) => (
+	<Trigger { ...props } ref={ forwardedRef }>
+		<span sx={ { color: theme => theme.colors.grey[ '70' ], fontSize: 20 } }>{ icon }</span>
+		<div sx={ { flexGrow: 1, textAlign: 'left', ml: 3 } }>{ children }</div>
+	</Trigger>
+) );
+
+TriggerWithIcon.displayName = 'Accordion.TriggerWithIcon';
+
+TriggerWithIcon.propTypes = {
+	children: PropTypes.node.isRequired,
+	icon: PropTypes.node.isRequired,
+};
+
 export const Content = React.forwardRef( ( { children, ...props }, forwardedRef ) => {
 	return (
 		<AccordionPrimitive.Content
@@ -138,7 +152,8 @@ export const Content = React.forwardRef( ( { children, ...props }, forwardedRef 
 		>
 			<div
 				sx={ {
-					padding: '15px 20px',
+					px: 3,
+					py: 2,
 				} }
 			>
 				{ children }

--- a/src/system/Accordion/Accordion.js
+++ b/src/system/Accordion/Accordion.js
@@ -1,0 +1,184 @@
+/** @jsxImportSource theme-ui */
+
+/**
+ * External dependencies
+ */
+import React from 'react';
+import PropTypes from 'prop-types';
+import { MdChevronRight } from 'react-icons/md';
+import * as AccordionPrimitive from '@radix-ui/react-accordion';
+import { keyframes } from '@emotion/react';
+
+/**
+ * Internal dependencies
+ */
+import { Heading } from '../Heading';
+
+const slideDown = keyframes( {
+	from: { height: 0 },
+	to: { height: 'var(--radix-accordion-content-height)' },
+} );
+
+const slideUp = keyframes( {
+	from: { height: 'var(--radix-accordion-content-height)' },
+	to: { height: 0 },
+} );
+
+export const Item = ( { children, ...props } ) => (
+	<AccordionPrimitive.Item
+		{ ...props }
+		sx={ {
+			overflow: 'hidden',
+			borderWidth: '0 1px 1px 1px',
+			borderStyle: 'solid',
+			borderColor: theme => theme.colors.gray[ '7' ],
+
+			'&:first-of-type': {
+				borderTopWidth: '1px',
+				borderTopLeftRadius: 4,
+				borderTopRightRadius: 4,
+			},
+			'&:last-child': {
+				borderBottomLeftRadius: 4,
+				borderBottomRightRadius: 4,
+			},
+			'&:focus-within': {
+				zIndex: 1,
+				outline: 'auto',
+			},
+		} }
+	>
+		{ children }
+	</AccordionPrimitive.Item>
+);
+
+Item.displayName = 'Accordion.Item';
+
+Item.propTypes = {
+	children: PropTypes.node.isRequired,
+};
+
+export const Trigger = React.forwardRef(
+	( { children, headingVariant = 'h3', ...props }, forwardedRef ) => (
+		<Heading
+			sx={ {
+				all: 'unset',
+				display: 'flex',
+			} }
+			variant={ headingVariant }
+		>
+			<AccordionPrimitive.Trigger
+				sx={ {
+					cursor: 'pointer',
+					all: 'unset',
+					fontFamily: 'inherit',
+					padding: '0 20px',
+					height: 45,
+					flex: 1,
+					display: 'flex',
+					alignItems: 'center',
+					justifyContent: 'space-between',
+					fontSize: 12,
+					fontWeight: 600,
+					lineHeight: '14px',
+					textTransform: 'uppercase',
+					color: theme => theme.colors.black,
+
+					'&[data-state="closed"]': { backgroundColor: 'transparent' },
+					'&[data-state="open"]': {
+						backgroundColor: theme => theme.colors.gold[ '7' ],
+						borderBottom: theme => `1px solid ${ theme.colors.gray[ '7' ] }`,
+					},
+					'&:hover': { backgroundColor: theme => theme.colors?.gold[ '7' ] },
+				} }
+				{ ...props }
+				ref={ forwardedRef }
+			>
+				{ children }
+				<MdChevronRight
+					sx={ {
+						fontSize: 22,
+						color: theme => theme.colors.grey[ '70' ],
+						transform: 'rotate(90deg)',
+						transition: 'transform 300ms cubic-bezier(0.87, 0, 0.13, 1)',
+						'[data-state=open] &': { transform: 'rotate(270deg)' },
+					} }
+					aria-hidden
+				/>
+			</AccordionPrimitive.Trigger>
+		</Heading>
+	)
+);
+
+Trigger.displayName = 'Accordion.Trigger';
+
+Trigger.propTypes = {
+	children: PropTypes.node.isRequired,
+	headingVariant: PropTypes.string,
+};
+
+export const Content = React.forwardRef( ( { children, ...props }, forwardedRef ) => {
+	return (
+		<AccordionPrimitive.Content
+			sx={ {
+				backgroundColor: 'white',
+				color: theme => theme.colors.text,
+				fontSize: 15,
+				overflow: 'hidden',
+
+				'&[data-state="open"]': {
+					animation: `${ slideDown } 300ms cubic-bezier(0.87, 0, 0.13, 1)`,
+				},
+				'&[data-state="closed"]': {
+					animation: `${ slideUp } 300ms cubic-bezier(0.87, 0, 0.13, 1)`,
+				},
+			} }
+			{ ...props }
+			ref={ forwardedRef }
+		>
+			<div
+				sx={ {
+					padding: '15px 20px',
+				} }
+			>
+				{ children }
+			</div>
+		</AccordionPrimitive.Content>
+	);
+} );
+
+Content.displayName = 'Accordion.Content';
+
+Content.propTypes = {
+	children: PropTypes.node.isRequired,
+};
+
+const Root = React.forwardRef(
+	( { sx = {}, defaultValue, type, children, className }, forwardRef ) => (
+		<AccordionPrimitive.Root
+			className={ className }
+			collapsible
+			defaultValue={ defaultValue }
+			ref={ forwardRef }
+			sx={ {
+				borderRadius: 6,
+				...sx,
+			} }
+			type={ type }
+		>
+			{ children }
+		</AccordionPrimitive.Root>
+	)
+);
+
+Root.displayName = 'Accordion';
+
+Root.propTypes = {
+	children: PropTypes.node,
+	className: PropTypes.any,
+	defaultValue: PropTypes.any,
+	sx: PropTypes.object,
+	type: PropTypes.oneOf( [ 'single', 'multiple' ] ),
+};
+
+export { Root };

--- a/src/system/Accordion/Accordion.js
+++ b/src/system/Accordion/Accordion.js
@@ -8,6 +8,7 @@ import PropTypes from 'prop-types';
 import { MdChevronRight } from 'react-icons/md';
 import * as AccordionPrimitive from '@radix-ui/react-accordion';
 import { keyframes } from '@emotion/react';
+import classNames from 'classnames';
 
 /**
  * Internal dependencies
@@ -167,7 +168,7 @@ Content.propTypes = {
 const Root = React.forwardRef(
 	( { sx = {}, defaultValue, type, children, className }, forwardRef ) => (
 		<AccordionPrimitive.Root
-			className={ className }
+			className={ classNames( 'vip-accordion-component', className ) }
 			collapsible
 			defaultValue={ defaultValue }
 			ref={ forwardRef }

--- a/src/system/Accordion/Accordion.js
+++ b/src/system/Accordion/Accordion.js
@@ -128,7 +128,7 @@ TriggerWithIcon.propTypes = {
 	icon: PropTypes.node.isRequired,
 };
 
-export const Content = React.forwardRef( ( { children, ...props }, forwardedRef ) => {
+export const Content = React.forwardRef( ( { children, sx = {}, ...props }, forwardedRef ) => {
 	return (
 		<AccordionPrimitive.Content
 			sx={ {
@@ -143,6 +143,7 @@ export const Content = React.forwardRef( ( { children, ...props }, forwardedRef 
 				'&[data-state="closed"]': {
 					animation: `${ slideUp } 300ms cubic-bezier(0.87, 0, 0.13, 1)`,
 				},
+				...sx,
 			} }
 			{ ...props }
 			ref={ forwardedRef }
@@ -163,6 +164,7 @@ Content.displayName = 'Accordion.Content';
 
 Content.propTypes = {
 	children: PropTypes.node.isRequired,
+	sx: PropTypes.object,
 };
 
 const Root = React.forwardRef(

--- a/src/system/Accordion/Accordion.js
+++ b/src/system/Accordion/Accordion.js
@@ -31,7 +31,7 @@ export const Item = ( { children, ...props } ) => (
 			overflow: 'hidden',
 			borderWidth: '0 1px 1px 1px',
 			borderStyle: 'solid',
-			borderColor: theme => theme.colors.border,
+			borderColor: 'border',
 
 			'&:first-of-type': {
 				borderTopWidth: '1px',
@@ -75,10 +75,10 @@ export const Trigger = React.forwardRef(
 					display: 'flex',
 					alignItems: 'center',
 					justifyContent: 'space-between',
-					fontSize: 12,
+					fontSize: 1,
 					fontWeight: 600,
 					textTransform: 'uppercase',
-					color: theme => theme.colors.text,
+					color: 'heading',
 
 					'&[data-state="closed"]': { backgroundColor: 'transparent' },
 					'&[data-state="open"]': {
@@ -93,8 +93,8 @@ export const Trigger = React.forwardRef(
 				{ children }
 				<MdChevronRight
 					sx={ {
-						fontSize: 22,
-						color: theme => theme.colors.text,
+						fontSize: 3,
+						color: 'text',
 						transform: 'rotate(90deg)',
 						transition: 'transform 300ms cubic-bezier(0.87, 0, 0.13, 1)',
 						'[data-state=open] &': { transform: 'rotate(270deg)' },
@@ -115,7 +115,7 @@ Trigger.propTypes = {
 
 export const TriggerWithIcon = React.forwardRef( ( { children, icon, ...props }, forwardedRef ) => (
 	<Trigger { ...props } ref={ forwardedRef }>
-		<span sx={ { color: theme => theme.colors.text, fontSize: 20 } }>{ icon }</span>
+		<span sx={ { color: 'text', fontSize: 3 } }>{ icon }</span>
 		<div sx={ { flexGrow: 1, textAlign: 'left', ml: 3 } }>{ children }</div>
 	</Trigger>
 ) );
@@ -132,8 +132,8 @@ export const Content = React.forwardRef( ( { children, ...props }, forwardedRef 
 		<AccordionPrimitive.Content
 			sx={ {
 				backgroundColor: 'white',
-				color: theme => theme.colors.text,
-				fontSize: 15,
+				color: 'text',
+				fontSize: 2,
 				overflow: 'hidden',
 
 				'&[data-state="open"]': {

--- a/src/system/Accordion/Accordion.js
+++ b/src/system/Accordion/Accordion.js
@@ -67,6 +67,7 @@ export const Trigger = React.forwardRef(
 		>
 			<AccordionPrimitive.Trigger
 				sx={ {
+					color: 'heading',
 					cursor: 'pointer',
 					all: 'unset',
 					fontFamily: 'inherit',
@@ -79,14 +80,13 @@ export const Trigger = React.forwardRef(
 					fontSize: 1,
 					fontWeight: 600,
 					textTransform: 'uppercase',
-					color: 'heading',
 
 					'&[data-state="closed"]': { backgroundColor: 'transparent' },
 					'&[data-state="open"]': {
-						backgroundColor: theme => theme.tag.gold.background,
+						backgroundColor: 'backgroundSecondary',
 						borderBottom: theme => `1px solid ${ theme.colors.border }`,
 					},
-					'&:hover': { backgroundColor: theme => theme.tag.gold.background },
+					'&:hover': { backgroundColor: 'backgroundSecondary' },
 				} }
 				{ ...props }
 				ref={ forwardedRef }
@@ -117,7 +117,7 @@ Trigger.propTypes = {
 export const TriggerWithIcon = React.forwardRef( ( { children, icon, ...props }, forwardedRef ) => (
 	<Trigger { ...props } ref={ forwardedRef }>
 		<span sx={ { color: 'text', fontSize: 3 } }>{ icon }</span>
-		<div sx={ { flexGrow: 1, textAlign: 'left', ml: 3 } }>{ children }</div>
+		<div sx={ { color: 'heading', flexGrow: 1, textAlign: 'left', ml: 3 } }>{ children }</div>
 	</Trigger>
 ) );
 
@@ -132,7 +132,7 @@ export const Content = React.forwardRef( ( { children, ...props }, forwardedRef 
 	return (
 		<AccordionPrimitive.Content
 			sx={ {
-				backgroundColor: 'white',
+				backgroundColor: 'transparent',
 				color: 'text',
 				fontSize: 2,
 				overflow: 'hidden',

--- a/src/system/Accordion/Accordion.js
+++ b/src/system/Accordion/Accordion.js
@@ -31,7 +31,7 @@ export const Item = ( { children, ...props } ) => (
 			overflow: 'hidden',
 			borderWidth: '0 1px 1px 1px',
 			borderStyle: 'solid',
-			borderColor: theme => theme.colors.gray[ '7' ],
+			borderColor: theme => theme.colors.border,
 
 			'&:first-of-type': {
 				borderTopWidth: '1px',
@@ -42,10 +42,7 @@ export const Item = ( { children, ...props } ) => (
 				borderBottomLeftRadius: 4,
 				borderBottomRightRadius: 4,
 			},
-			'&:focus-within': {
-				zIndex: 1,
-				outline: 'auto',
-			},
+			'&:focus-within': theme => theme.outline,
 		} }
 	>
 		{ children }
@@ -80,16 +77,15 @@ export const Trigger = React.forwardRef(
 					justifyContent: 'space-between',
 					fontSize: 12,
 					fontWeight: 600,
-					lineHeight: '14px',
 					textTransform: 'uppercase',
-					color: theme => theme.colors.black,
+					color: theme => theme.colors.text,
 
 					'&[data-state="closed"]': { backgroundColor: 'transparent' },
 					'&[data-state="open"]': {
-						backgroundColor: theme => theme.colors.gold[ '7' ],
-						borderBottom: theme => `1px solid ${ theme.colors.gray[ '7' ] }`,
+						backgroundColor: theme => theme.tag.gold.background,
+						borderBottom: theme => `1px solid ${ theme.colors.border }`,
 					},
-					'&:hover': { backgroundColor: theme => theme.colors?.gold[ '7' ] },
+					'&:hover': { backgroundColor: theme => theme.tag.gold.background },
 				} }
 				{ ...props }
 				ref={ forwardedRef }
@@ -98,7 +94,7 @@ export const Trigger = React.forwardRef(
 				<MdChevronRight
 					sx={ {
 						fontSize: 22,
-						color: theme => theme.colors.grey[ '70' ],
+						color: theme => theme.colors.text,
 						transform: 'rotate(90deg)',
 						transition: 'transform 300ms cubic-bezier(0.87, 0, 0.13, 1)',
 						'[data-state=open] &': { transform: 'rotate(270deg)' },
@@ -119,7 +115,7 @@ Trigger.propTypes = {
 
 export const TriggerWithIcon = React.forwardRef( ( { children, icon, ...props }, forwardedRef ) => (
 	<Trigger { ...props } ref={ forwardedRef }>
-		<span sx={ { color: theme => theme.colors.grey[ '70' ], fontSize: 20 } }>{ icon }</span>
+		<span sx={ { color: theme => theme.colors.text, fontSize: 20 } }>{ icon }</span>
 		<div sx={ { flexGrow: 1, textAlign: 'left', ml: 3 } }>{ children }</div>
 	</Trigger>
 ) );

--- a/src/system/Accordion/Accordion.stories.jsx
+++ b/src/system/Accordion/Accordion.stories.jsx
@@ -15,18 +15,24 @@ export default {
 	component: Accordion,
 };
 
+const ExampleContent = () => (
+	<Box sx={ { p: 3 } }>
+		<p sx={ { mt: 0 } }>Add your key team members to the VIP Dashboard.</p>
+		<p>Add developers to GitHub.</p>
+		<p sx={ { mb: 0 } }>Add content editors and developers to WordPress admin.</p>
+	</Box>
+);
+
 export const Default = () => (
 	<Box>
-		<Accordion.Root defaultValue="teamPermissions" sx={ { width: '400px' } }>
+		<Accordion.Root defaultValue="teamPermissions" sx={ { width: '450px' } }>
 			<Accordion.Item value="teamPermissions">
 				<Accordion.Trigger>
 					<RiUserAddLine sx={ { color: theme => theme.colors.grey[ '70' ], fontSize: 20 } } />
 					Team & Permissions
 				</Accordion.Trigger>
 				<Accordion.Content>
-					<p>Add your key team members to the VIP Dashboard.</p>
-					<p>Add developers to GitHub.</p>
-					<p>Add content editors and developers to WordPress admin.</p>
+					<ExampleContent />
 				</Accordion.Content>
 			</Accordion.Item>
 			<Accordion.Item value="addContentMedia">
@@ -35,9 +41,7 @@ export const Default = () => (
 					Add Content & Media
 				</Accordion.Trigger>
 				<Accordion.Content>
-					<p>Add your key team members to the VIP Dashboard.</p>
-					<p>Add developers to GitHub.</p>
-					<p>Add content editors and developers to WordPress admin.</p>
+					<ExampleContent />
 				</Accordion.Content>
 			</Accordion.Item>
 			<Accordion.Item value="addCode">
@@ -46,9 +50,7 @@ export const Default = () => (
 					Add Code
 				</Accordion.Trigger>
 				<Accordion.Content>
-					<p>Add your key team members to the VIP Dashboard.</p>
-					<p>Add developers to GitHub.</p>
-					<p>Add content editors and developers to WordPress admin.</p>
+					<ExampleContent />
 				</Accordion.Content>
 			</Accordion.Item>
 		</Accordion.Root>

--- a/src/system/Accordion/Accordion.stories.jsx
+++ b/src/system/Accordion/Accordion.stories.jsx
@@ -1,0 +1,56 @@
+/** @jsxImportSource theme-ui */
+
+/**
+ * External dependencies
+ */
+import { RiUserAddLine, RiCodeSSlashFill } from 'react-icons/ri';
+import { BiBookContent } from 'react-icons/bi';
+/**
+ * Internal dependencies
+ */
+import { Box, Accordion } from '..';
+
+export default {
+	title: 'Accordion',
+	component: Accordion,
+};
+
+export const Default = () => (
+	<Box>
+		<Accordion.Root defaultValue="teamPermissions" sx={ { width: '400px' } }>
+			<Accordion.Item value="teamPermissions">
+				<Accordion.Trigger>
+					<RiUserAddLine sx={ { color: theme => theme.colors.grey[ '70' ], fontSize: 20 } } />
+					Team & Permissions
+				</Accordion.Trigger>
+				<Accordion.Content>
+					<p>Add your key team members to the VIP Dashboard.</p>
+					<p>Add developers to GitHub.</p>
+					<p>Add content editors and developers to WordPress admin.</p>
+				</Accordion.Content>
+			</Accordion.Item>
+			<Accordion.Item value="addContentMedia">
+				<Accordion.Trigger>
+					<BiBookContent sx={ { color: theme => theme.colors.grey[ '70' ], fontSize: 20 } } />
+					Add Content & Media
+				</Accordion.Trigger>
+				<Accordion.Content>
+					<p>Add your key team members to the VIP Dashboard.</p>
+					<p>Add developers to GitHub.</p>
+					<p>Add content editors and developers to WordPress admin.</p>
+				</Accordion.Content>
+			</Accordion.Item>
+			<Accordion.Item value="addCode">
+				<Accordion.Trigger>
+					<RiCodeSSlashFill sx={ { color: theme => theme.colors.grey[ '70' ], fontSize: 20 } } />
+					Add Code
+				</Accordion.Trigger>
+				<Accordion.Content>
+					<p>Add your key team members to the VIP Dashboard.</p>
+					<p>Add developers to GitHub.</p>
+					<p>Add content editors and developers to WordPress admin.</p>
+				</Accordion.Content>
+			</Accordion.Item>
+		</Accordion.Root>
+	</Box>
+);

--- a/src/system/Accordion/Accordion.stories.jsx
+++ b/src/system/Accordion/Accordion.stories.jsx
@@ -16,7 +16,7 @@ export default {
 };
 
 const ExampleContent = () => (
-	<Box sx={ { p: 3 } }>
+	<Box>
 		<p sx={ { mt: 0 } }>Add your key team members to the VIP Dashboard.</p>
 		<p>Add developers to GitHub.</p>
 		<p sx={ { mb: 0 } }>Add content editors and developers to WordPress admin.</p>
@@ -27,28 +27,25 @@ export const Default = () => (
 	<Box>
 		<Accordion.Root defaultValue="teamPermissions" sx={ { width: '450px' } }>
 			<Accordion.Item value="teamPermissions">
-				<Accordion.Trigger>
-					<RiUserAddLine sx={ { color: theme => theme.colors.grey[ '70' ], fontSize: 20 } } />
+				<Accordion.TriggerWithIcon icon={ <RiUserAddLine /> }>
 					Team & Permissions
-				</Accordion.Trigger>
+				</Accordion.TriggerWithIcon>
 				<Accordion.Content>
 					<ExampleContent />
 				</Accordion.Content>
 			</Accordion.Item>
 			<Accordion.Item value="addContentMedia">
-				<Accordion.Trigger>
-					<BiBookContent sx={ { color: theme => theme.colors.grey[ '70' ], fontSize: 20 } } />
+				<Accordion.TriggerWithIcon icon={ <BiBookContent /> }>
 					Add Content & Media
-				</Accordion.Trigger>
+				</Accordion.TriggerWithIcon>
 				<Accordion.Content>
 					<ExampleContent />
 				</Accordion.Content>
 			</Accordion.Item>
 			<Accordion.Item value="addCode">
-				<Accordion.Trigger>
-					<RiCodeSSlashFill sx={ { color: theme => theme.colors.grey[ '70' ], fontSize: 20 } } />
+				<Accordion.TriggerWithIcon icon={ <RiCodeSSlashFill /> }>
 					Add Code
-				</Accordion.Trigger>
+				</Accordion.TriggerWithIcon>
 				<Accordion.Content>
 					<ExampleContent />
 				</Accordion.Content>

--- a/src/system/Accordion/Accordion.test.js
+++ b/src/system/Accordion/Accordion.test.js
@@ -1,0 +1,61 @@
+/** @jsxImportSource theme-ui */
+
+/**
+ * External dependencies
+ */
+import { fireEvent, render, screen } from '@testing-library/react';
+import { axe } from 'jest-axe';
+import { ThemeProvider } from 'theme-ui';
+
+/**
+ * Internal dependencies
+ */
+import * as Accordion from './Accordion';
+import { theme } from '../';
+
+const renderWithTheme = children =>
+	render( <ThemeProvider theme={ theme }>{ children }</ThemeProvider> );
+
+const renderComponent = () =>
+	renderWithTheme(
+		<Accordion.Root defaultValue="one" sx={ { width: '400px' } }>
+			<Accordion.Item value="one">
+				<Accordion.Trigger>trigger one</Accordion.Trigger>
+				<Accordion.Content>content one</Accordion.Content>
+			</Accordion.Item>
+			<Accordion.Item value="two">
+				<Accordion.Trigger>trigger two</Accordion.Trigger>
+				<Accordion.Content>content two</Accordion.Content>
+			</Accordion.Item>
+		</Accordion.Root>
+	);
+
+describe( '<Accordion />', () => {
+	it( 'renders the Accordion component with default value visible', async () => {
+		const { container } = renderComponent();
+
+		// Should find the open content
+		expect( screen.getByText( 'content one' ) ).toBeInTheDocument();
+
+		// Should not find the closed content
+		expect( screen.queryByText( 'content two' ) ).toBeNull();
+
+		// Check for accessibility issues
+		await expect( await axe( container ) ).toHaveNoViolations();
+	} );
+
+	it( 'should open the content when clicking on its trigger', async () => {
+		const { container } = renderComponent();
+
+		fireEvent.click( screen.getByRole( 'button', { name: 'trigger two' } ) );
+
+		// Should find the open content
+		expect( screen.queryByText( 'content one' ) ).toBeNull();
+
+		// Should not find the closed content
+		expect( screen.queryByText( 'content two' ) ).toBeInTheDocument();
+
+		// Check for accessibility issues
+		await expect( await axe( container ) ).toHaveNoViolations();
+	} );
+} );

--- a/src/system/Accordion/index.js
+++ b/src/system/Accordion/index.js
@@ -1,0 +1,6 @@
+/**
+ * Internal dependencies
+ */
+import * as Accordion from './Accordion';
+
+export { Accordion };

--- a/src/system/index.js
+++ b/src/system/index.js
@@ -38,6 +38,7 @@ import {
 	Textarea,
 	Checkbox,
 } from './Form';
+import { Accordion } from './Accordion';
 import { Grid } from './Grid';
 import { Heading } from './Heading';
 import { Link } from './Link';
@@ -56,6 +57,7 @@ import theme from './theme';
 import { Wizard, WizardStep, WizardStepHorizontal } from './Wizard';
 
 export {
+	Accordion,
 	Avatar,
 	Badge,
 	Box,

--- a/src/system/theme/getColor.js
+++ b/src/system/theme/getColor.js
@@ -11,3 +11,17 @@ export const getColor = ( color, variant = 'default' ) => {
 
 	return Valet[ color ][ variant ].value;
 };
+
+const resolvePath = ( object, path, defaultValue ) => {
+	return path.split( '.' ).reduce( ( acc, property ) => {
+		return acc ? acc[ property ] : defaultValue;
+	}, object );
+};
+
+export const getVariants = color => {
+	const property = resolvePath( Valet, color, {} );
+
+	return Object.keys( property ).reduce( ( variants, variant ) => {
+		return { ...variants, [ variant ]: property[ variant ].value };
+	}, {} );
+};

--- a/src/system/theme/index.js
+++ b/src/system/theme/index.js
@@ -162,6 +162,10 @@ export default {
 			'0px 2.76726px 2.21381px rgba(0, 0, 0, 0.0196802), 0px 6.6501px 5.32008px rgba(0, 0, 0, 0.0282725), 0px 12.5216px 10.0172px rgba(0, 0, 0, 0.035), 0px 22.3363px 17.869px rgba(0, 0, 0, 0.0417275), 0px 41.7776px 33.4221px rgba(0, 0, 0, 0.0503198), 0px 100px 80px rgba(0, 0, 0, 0.07)',
 	},
 
+	tag: {
+		gold: getVariants( 'tag.gold' ),
+	},
+
 	cards: {
 		primary: {
 			padding: 3,

--- a/src/system/theme/index.js
+++ b/src/system/theme/index.js
@@ -2,7 +2,7 @@
  * Internal dependencies
  */
 import { light, dark } from './colors';
-import { getColor } from './getColor';
+import { getColor, getVariants } from './getColor';
 
 const textStyles = {
 	h1: {
@@ -90,6 +90,8 @@ export default {
 		text: getColor( 'text', 'secondary' ),
 		heading: getColor( 'text', 'primary' ),
 		background: getColor( 'background', 'primary' ),
+		gold: getVariants( 'color.gold' ),
+		gray: getVariants( 'color.gray' ),
 		backgroundSecondary: light.grey[ '10' ],
 		primary: light.brand[ '70' ],
 		secondary: '#30c',


### PR DESCRIPTION
## Description

Adds the accordion component to be used on the Prep Panel side bar.

![4IeiWfhVi3](https://user-images.githubusercontent.com/156388/198141733-95c3a996-4c5b-4ee7-845d-e672e3130ab1.gif)

## Checklist

- [x] This PR has good automated test coverage
- [x] The storybook for the component has been updated

## Steps to Test

1. Pull down PR.
1. `npm run dev`.
1. Open Storybook.
1. Go to the Accordion component
