### PR TITLE
Adds new component: Form.Autocomplete

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -1,12 +1,12 @@
 {
 	"name": "@automattic/vip-design-system",
-	"version": "0.23.6",
+	"version": "0.23.3",
 	"lockfileVersion": 2,
 	"requires": true,
 	"packages": {
 		"": {
 			"name": "@automattic/vip-design-system",
-			"version": "0.23.6",
+			"version": "0.23.3",
 			"dependencies": {
 				"@radix-ui/react-checkbox": "^1.0.0",
 				"@radix-ui/react-dialog": "^1.0.0",
@@ -16,6 +16,7 @@
 				"@radix-ui/react-tooltip": "^1.0.0",
 				"@radix-ui/react-visually-hidden": "^1.0.0",
 				"@storybook/addon-storysource": "^6.5.10",
+				"accessible-autocomplete": "^2.0.4",
 				"babel-loader": "^8.2.2",
 				"classnames": "^2.3.1",
 				"framer-motion": "^3.9.1",
@@ -14088,6 +14089,14 @@
 			},
 			"engines": {
 				"node": ">= 0.6"
+			}
+		},
+		"node_modules/accessible-autocomplete": {
+			"version": "2.0.4",
+			"resolved": "https://registry.npmjs.org/accessible-autocomplete/-/accessible-autocomplete-2.0.4.tgz",
+			"integrity": "sha512-2p0txrSpvs5wXFUeQJHMheDPTZVSEmiUHWlEPb7vJnv2Dd1xPfoLnBQQMfNbTSit2pL/9sSQYESuD2Yyohd4Yw==",
+			"dependencies": {
+				"preact": "^8.3.1"
 			}
 		},
 		"node_modules/acorn": {
@@ -29904,6 +29913,12 @@
 			"engines": {
 				"node": ">=6"
 			}
+		},
+		"node_modules/preact": {
+			"version": "8.5.3",
+			"resolved": "https://registry.npmjs.org/preact/-/preact-8.5.3.tgz",
+			"integrity": "sha512-O3kKP+1YdgqHOFsZF2a9JVdtqD+RPzCQc3rP+Ualf7V6rmRDchZ9MJbiGTT7LuyqFKZqlHSOyO/oMFmI2lVTsw==",
+			"hasInstallScript": true
 		},
 		"node_modules/prelude-ls": {
 			"version": "1.2.1",
@@ -46161,6 +46176,14 @@
 				"negotiator": "0.6.2"
 			}
 		},
+		"accessible-autocomplete": {
+			"version": "2.0.4",
+			"resolved": "https://registry.npmjs.org/accessible-autocomplete/-/accessible-autocomplete-2.0.4.tgz",
+			"integrity": "sha512-2p0txrSpvs5wXFUeQJHMheDPTZVSEmiUHWlEPb7vJnv2Dd1xPfoLnBQQMfNbTSit2pL/9sSQYESuD2Yyohd4Yw==",
+			"requires": {
+				"preact": "^8.3.1"
+			}
+		},
 		"acorn": {
 			"version": "7.4.1",
 			"resolved": "https://registry.npmjs.org/acorn/-/acorn-7.4.1.tgz",
@@ -58270,6 +58293,11 @@
 			"resolved": "https://registry.npmjs.org/postcss-value-parser/-/postcss-value-parser-4.1.0.tgz",
 			"integrity": "sha512-97DXOFbQJhk71ne5/Mt6cOu6yxsSfM0QGQyl0L25Gca4yGWEGJaig7l7gbCX623VqTBNGLRLaVUCnNkcedlRSQ==",
 			"dev": true
+		},
+		"preact": {
+			"version": "8.5.3",
+			"resolved": "https://registry.npmjs.org/preact/-/preact-8.5.3.tgz",
+			"integrity": "sha512-O3kKP+1YdgqHOFsZF2a9JVdtqD+RPzCQc3rP+Ualf7V6rmRDchZ9MJbiGTT7LuyqFKZqlHSOyO/oMFmI2lVTsw=="
 		},
 		"prelude-ls": {
 			"version": "1.2.1",

--- a/package.json
+++ b/package.json
@@ -28,6 +28,7 @@
 		"@radix-ui/react-tooltip": "^1.0.0",
 		"@radix-ui/react-visually-hidden": "^1.0.0",
 		"@storybook/addon-storysource": "^6.5.10",
+		"accessible-autocomplete": "^2.0.4",
 		"babel-loader": "^8.2.2",
 		"classnames": "^2.3.1",
 		"framer-motion": "^3.9.1",
@@ -70,6 +71,9 @@
 		],
 		"transform": {
 			"\\.[jt]sx?$": "babel-jest"
+		},
+		"moduleNameMapper": {
+			"\\.(css|less)$": "<rootDir>/test/fileMock.js"
 		}
 	},
 	"devDependencies": {

--- a/src/system/NewForm/FormAutocomplete.css
+++ b/src/system/NewForm/FormAutocomplete.css
@@ -1,0 +1,166 @@
+.autocomplete__wrapper {
+  position: relative;
+}
+
+.autocomplete__hint,
+.autocomplete__input {
+  -webkit-appearance: none;
+  border: 2px solid #0b0c0c;
+  border-radius: 0; /* Safari 10 on iOS adds implicit border rounding. */
+  box-sizing: border-box;
+  -moz-box-sizing: border-box;
+  -webkit-box-sizing: border-box;
+  margin-bottom: 0; /* BUG: Safari 10 on macOS seems to add an implicit margin. */
+  width: 100%;
+}
+
+.autocomplete__input {
+  background-color: transparent;
+  position: relative;
+}
+
+.autocomplete__hint {
+  color: #b1b4b6;
+  position: absolute;
+}
+
+.autocomplete__input--default {
+  padding: 5px;
+}
+.autocomplete__input--focused {
+  outline: 3px solid #fd0;
+  outline-offset: 0;
+  box-shadow: inset 0 0 0 2px;
+}
+
+.autocomplete__input--show-all-values {
+  padding: 5px 34px 5px 5px; /* Space for arrow. Other padding should match .autocomplete__input--default. */
+  cursor: pointer;
+}
+
+.autocomplete__dropdown-arrow-down {
+  z-index: -1;
+  display: inline-block;
+  position: absolute;
+  right: 8px;
+  width: 24px;
+  height: 24px;
+  top: 10px;
+}
+
+.autocomplete__menu {
+  background-color: #fff;
+  border: 2px solid #0B0C0C;
+  border-top: 0;
+  color: #0B0C0C;
+  margin: 0;
+  max-height: 342px;
+  overflow-x: hidden;
+  padding: 0;
+  width: 100%;
+  width: calc(100% - 4px);
+}
+
+.autocomplete__menu--visible {
+  display: block;
+}
+
+.autocomplete__menu--hidden {
+  display: none;
+}
+
+.autocomplete__menu--overlay {
+  box-shadow: rgba(0, 0, 0, 0.256863) 0px 2px 6px;
+  left: 0;
+  position: absolute;
+  top: 100%;
+  z-index: 100;
+}
+
+.autocomplete__menu--inline {
+  position: relative;
+}
+
+.autocomplete__option {
+  border-bottom: solid #b1b4b6;
+  border-width: 1px 0;
+  cursor: pointer;
+  display: block;
+  position: relative;
+}
+
+.autocomplete__option > * {
+  pointer-events: none;
+}
+
+.autocomplete__option:first-of-type {
+  border-top-width: 0;
+}
+
+.autocomplete__option:last-of-type {
+  border-bottom-width: 0;
+}
+
+.autocomplete__option--odd {
+  background-color: #FAFAFA;
+}
+
+.autocomplete__option--focused,
+.autocomplete__option:hover {
+  background-color: #1d70b8;
+  border-color: #1d70b8;
+  color: white;
+  outline: none;
+}
+
+@media (-ms-high-contrast: active), (forced-colors: active) {
+  .autocomplete__menu {
+    border-color: FieldText;
+  }
+
+  .autocomplete__option {
+    background-color: Field;
+    color: FieldText;
+  }
+
+  .autocomplete__option--focused,
+  .autocomplete__option:hover {
+    forced-color-adjust: none; /* prevent backplate from obscuring text */
+    background-color: Highlight;
+    border-color: Highlight;
+    color: HighlightText;
+
+    /* Prefer SelectedItem / SelectedItemText in browsers that support it */
+    background-color: SelectedItem;
+    border-color: SelectedItem;
+    color: SelectedItemText;
+    outline-color: SelectedItemText;
+  }
+}
+
+.autocomplete__option--no-results {
+  background-color: #FAFAFA;
+  color: #646b6f;
+  cursor: not-allowed;
+}
+
+.autocomplete__hint,
+.autocomplete__input,
+.autocomplete__option {
+  font-size: 16px;
+  line-height: 1.25;
+}
+
+.autocomplete__hint,
+.autocomplete__option {
+  padding: 5px;
+}
+
+@media (min-width: 641px) {
+  .autocomplete__hint,
+  .autocomplete__input,
+  .autocomplete__option {
+    font-size: 19px;
+    line-height: 1.31579;
+  }
+}

--- a/src/system/NewForm/FormAutocomplete.js
+++ b/src/system/NewForm/FormAutocomplete.js
@@ -34,14 +34,14 @@ const defaultStyles = {
 		width: '100%',
 		paddingLeft: 3,
 		py: 0,
-		borderWidth: '0px',
+		borderWidth: 0,
 		color: 'text',
 		minHeight: '36px',
 		lineHeight: '36px',
-		'&:focus': { outlineWidth: '0px', boxShadow: 'none' },
-		'&:focus-visible': { outlineWidth: '0px', boxShadow: 'none' },
-		'&:focus-within': { outlineWidth: '0px', boxShadow: 'none' },
-		'&.autocomplete__input--focused': { outlineWidth: '0px', boxShadow: 'none' },
+		'&:focus': { outlineWidth: 0, boxShadow: 'none' },
+		'&:focus-visible': { outlineWidth: 0, boxShadow: 'none' },
+		'&:focus-within': { outlineWidth: 0, boxShadow: 'none' },
+		'&.autocomplete__input--focused': { outlineWidth: 0, boxShadow: 'none' },
 	},
 	'& .autocomplete__menu': {
 		borderWidth: '1px',
@@ -79,7 +79,7 @@ const FormAutocomplete = React.forwardRef(
 			value,
 			showAllValues = true,
 			displayMenu = 'overlay',
-			id = 'autocomplete',
+			id = 'vip-autocomplete',
 		},
 		forwardRef
 	) => {
@@ -127,7 +127,9 @@ const FormAutocomplete = React.forwardRef(
 		);
 
 		useEffect( () => {
-			document.querySelector( '.autocomplete__input' ).setAttribute( 'aria-activedescendant', '' );
+			global.document
+				.querySelector( '.autocomplete__input' )
+				.setAttribute( 'aria-activedescendant', '' );
 		}, [] );
 
 		return (

--- a/src/system/NewForm/FormAutocomplete.js
+++ b/src/system/NewForm/FormAutocomplete.js
@@ -132,6 +132,12 @@ const FormAutocomplete = React.forwardRef(
 				.setAttribute( 'aria-activedescendant', '' );
 		}, [] );
 
+		useEffect( () => {
+			global.document
+				.querySelector( '.autocomplete__menu' )
+				.setAttribute( 'aria-label', `${ label } list` );
+		}, [ label ] );
+
 		return (
 			<>
 				{ label && ! isInline && <SelectLabel /> }

--- a/src/system/NewForm/FormAutocomplete.js
+++ b/src/system/NewForm/FormAutocomplete.js
@@ -3,7 +3,7 @@
 /**
  * External dependencies
  */
-import React, { useCallback, useMemo } from 'react';
+import React, { useCallback, useEffect, useMemo } from 'react';
 import PropTypes from 'prop-types';
 import { Label } from '../Form/Label';
 import Autocomplete from 'accessible-autocomplete/react';
@@ -125,6 +125,10 @@ const FormAutocomplete = React.forwardRef(
 			},
 			[ options ]
 		);
+
+		useEffect( () => {
+			document.querySelector( '.autocomplete__input' ).setAttribute( 'aria-activedescendant', '' );
+		}, [] );
 
 		return (
 			<>

--- a/src/system/NewForm/FormAutocomplete.js
+++ b/src/system/NewForm/FormAutocomplete.js
@@ -1,0 +1,174 @@
+/** @jsxImportSource theme-ui */
+
+/**
+ * External dependencies
+ */
+import React, { useCallback, useMemo } from 'react';
+import PropTypes from 'prop-types';
+import { Label } from '../Form/Label';
+import Autocomplete from 'accessible-autocomplete/react';
+
+/**
+ * Internal dependencies
+ */
+import './FormAutocomplete.css';
+import { FormSelectContent } from './FormSelectContent';
+import { FormSelectArrow } from './FormSelectArrow';
+
+const defaultStyles = {
+	width: '100%',
+	py: 0,
+	borderWidth: '1px',
+	borderStyle: 'solid',
+	borderColor: 'border',
+	borderRadius: 1,
+	backgroundColor: 'background',
+	color: 'text',
+	minHeight: '36px',
+	lineHeight: '36px',
+	'&:focus': theme => theme.outline,
+	'&:focus-visible': theme => theme.outline,
+	'&:focus-within': theme => theme.outline,
+	'&.autocomplete__input--focused': theme => theme.outline,
+	'& .autocomplete__input': {
+		width: '100%',
+		paddingLeft: 3,
+		py: 0,
+		borderWidth: '0px',
+		color: 'text',
+		minHeight: '36px',
+		lineHeight: '36px',
+		'&:focus': { outlineWidth: '0px', boxShadow: 'none' },
+		'&:focus-visible': { outlineWidth: '0px', boxShadow: 'none' },
+		'&:focus-within': { outlineWidth: '0px', boxShadow: 'none' },
+		'&.autocomplete__input--focused': { outlineWidth: '0px', boxShadow: 'none' },
+	},
+	'& .autocomplete__menu': {
+		borderWidth: '1px',
+		borderStyle: 'solid',
+		borderColor: 'border',
+		borderRadius: 1,
+		backgroundColor: 'background',
+		color: 'text',
+	},
+	'& .autocomplete__hint, & .autocomplete__input, & .autocomplete__option': {
+		fontSize: 'inherit',
+	},
+	'& .autocomplete__wrapper': {
+		width: '100%',
+		paddingRight: '40px',
+	},
+	'& .autocomplete__input--show-all-values': {
+		paddingRight: 0,
+	},
+};
+
+const inlineStyles = {
+	borderWidth: '0px',
+};
+
+const FormAutocomplete = React.forwardRef(
+	(
+		{
+			isInline,
+			placeholder,
+			forLabel,
+			options,
+			label,
+			getOptionLabel,
+			getOptionValue,
+			onChange,
+			value,
+			showAllValues = true,
+			displayMenu = 'overlay',
+			...props
+		},
+		forwardRef
+	) => {
+		const SelectLabel = () => <Label htmlFor={ forLabel || props.id }>{ label }</Label>;
+
+		const inlineLabel = !! ( isInline && label );
+
+		const optionValue = useCallback(
+			option => ( getOptionValue ? getOptionValue( option ) : option.value ),
+			[ getOptionValue ]
+		);
+
+		const getAllOptions = useMemo(
+			() =>
+				[
+					...options.filter( option => ! option.options ),
+					...options.filter( option => option.options ).map( option => option.options ),
+				].reduce( ( a, b ) => a.concat( b ), [] ),
+			[ options ]
+		);
+
+		const getOptionByValue = useCallback(
+			inputValue =>
+				getAllOptions.find( option => `${ optionValue( option ) }` === `${ inputValue }` ),
+			[ getAllOptions, optionValue ]
+		);
+
+		const onValueChange = useCallback(
+			inputValue => {
+				if ( onChange ) {
+					onChange( getOptionByValue( inputValue ) );
+				}
+			},
+			[ onChange, getOptionByValue ]
+		);
+
+		const suggest = useCallback(
+			( query, populateResults ) => {
+				const data = options.filter(
+					option => option.label.toLowerCase().indexOf( query.toLowerCase() ) >= 0
+				);
+				populateResults( data.map( option => option.label ) );
+			},
+			[ options ]
+		);
+
+		return (
+			<>
+				{ label && ! isInline && <SelectLabel /> }
+
+				<div sx={ { ...defaultStyles, ...( isInline && inlineStyles ) } }>
+					<FormSelectContent
+						isInline={ inlineLabel }
+						label={ inlineLabel ? <SelectLabel /> : null }
+					>
+						<Autocomplete
+							showAllValues={ showAllValues }
+							ref={ forwardRef }
+							id="autocomplete"
+							source={ suggest }
+							defaultValue={ value }
+							displayMenu={ displayMenu }
+							onConfirm={ onValueChange }
+						/>
+						<FormSelectArrow />
+					</FormSelectContent>
+				</div>
+			</>
+		);
+	}
+);
+
+FormAutocomplete.propTypes = {
+	id: PropTypes.string,
+	showAllValues: PropTypes.bool,
+	isInline: PropTypes.bool,
+	forLabel: PropTypes.string,
+	placeholder: PropTypes.string,
+	value: PropTypes.string,
+	displayMenu: PropTypes.string,
+	label: PropTypes.string,
+	options: PropTypes.array,
+	getOptionLabel: PropTypes.func,
+	getOptionValue: PropTypes.func,
+	onChange: PropTypes.func,
+};
+
+FormAutocomplete.displayName = 'FormAutocomplete';
+
+export { FormAutocomplete };

--- a/src/system/NewForm/FormAutocomplete.js
+++ b/src/system/NewForm/FormAutocomplete.js
@@ -11,7 +11,7 @@ import Autocomplete from 'accessible-autocomplete/react';
 /**
  * Internal dependencies
  */
-import './FormAutocomplete.css';
+import css from './FormAutocomplete.css';
 import { FormSelectContent } from './FormSelectContent';
 import { FormSelectArrow } from './FormSelectArrow';
 
@@ -64,7 +64,7 @@ const defaultStyles = {
 };
 
 const inlineStyles = {
-	borderWidth: '0px',
+	borderWidth: 0,
 };
 
 const FormAutocomplete = React.forwardRef(
@@ -179,4 +179,4 @@ FormAutocomplete.propTypes = {
 
 FormAutocomplete.displayName = 'FormAutocomplete';
 
-export { FormAutocomplete };
+export { FormAutocomplete, css };

--- a/src/system/NewForm/FormAutocomplete.js
+++ b/src/system/NewForm/FormAutocomplete.js
@@ -71,21 +71,19 @@ const FormAutocomplete = React.forwardRef(
 	(
 		{
 			isInline,
-			placeholder,
 			forLabel,
 			options,
 			label,
-			getOptionLabel,
 			getOptionValue,
 			onChange,
 			value,
 			showAllValues = true,
 			displayMenu = 'overlay',
-			...props
+			id = 'autocomplete',
 		},
 		forwardRef
 	) => {
-		const SelectLabel = () => <Label htmlFor={ forLabel || props.id }>{ label }</Label>;
+		const SelectLabel = () => <Label htmlFor={ forLabel || id }>{ label }</Label>;
 
 		const inlineLabel = !! ( isInline && label );
 
@@ -138,9 +136,9 @@ const FormAutocomplete = React.forwardRef(
 						label={ inlineLabel ? <SelectLabel /> : null }
 					>
 						<Autocomplete
+							id={ id }
 							showAllValues={ showAllValues }
 							ref={ forwardRef }
-							id="autocomplete"
 							source={ suggest }
 							defaultValue={ value }
 							displayMenu={ displayMenu }
@@ -159,12 +157,10 @@ FormAutocomplete.propTypes = {
 	showAllValues: PropTypes.bool,
 	isInline: PropTypes.bool,
 	forLabel: PropTypes.string,
-	placeholder: PropTypes.string,
 	value: PropTypes.string,
 	displayMenu: PropTypes.string,
 	label: PropTypes.string,
 	options: PropTypes.array,
-	getOptionLabel: PropTypes.func,
 	getOptionValue: PropTypes.func,
 	onChange: PropTypes.func,
 };

--- a/src/system/NewForm/FormAutocomplete.stories.jsx
+++ b/src/system/NewForm/FormAutocomplete.stories.jsx
@@ -31,7 +31,12 @@ const DefaultComponent = ( { label = 'Label', width = 250, onChange, ...rest } )
 	<>
 		<Form.Root>
 			<div sx={ { width } }>
-				<Form.Autocomplete id="form-select" label={ label } onChange={ onChange } { ...rest } />
+				<Form.Autocomplete
+					id="form-autocomplete"
+					label={ label }
+					onChange={ onChange }
+					{ ...rest }
+				/>
 			</div>
 		</Form.Root>
 	</>

--- a/src/system/NewForm/FormAutocomplete.stories.jsx
+++ b/src/system/NewForm/FormAutocomplete.stories.jsx
@@ -1,0 +1,84 @@
+/** @jsxImportSource theme-ui */
+
+/**
+ * Internal dependencies
+ */
+import { useCallback, useState } from 'react';
+import * as Form from '.';
+
+export default {
+	title: 'Form/Autocomplete',
+	argTypes: {
+		placeholder: {
+			type: { name: 'string', required: false },
+			control: { type: 'text' },
+		},
+		label: {
+			type: { name: 'string', required: false },
+			control: { type: 'text' },
+		},
+	},
+};
+
+const defaultOptions = [
+	{ value: 'chocolate', label: 'Chocolate' },
+	{ value: 'strawberry', label: 'Strawberry Chocolate Vanilla Chocolate Vanilla' },
+	{ value: 'vanilla', label: 'Vanilla' },
+];
+
+// eslint-disable-next-line react/prop-types
+const DefaultComponent = ( { label = 'Label', width = 250, onChange, ...rest } ) => (
+	<>
+		<Form.Root>
+			<div sx={ { width } }>
+				<Form.Autocomplete id="form-select" label={ label } onChange={ onChange } { ...rest } />
+			</div>
+		</Form.Root>
+	</>
+);
+
+export const Default = () => {
+	const [ options, setOptions ] = useState( defaultOptions );
+
+	const onChange = useCallback( value => {
+		setOptions(
+			defaultOptions.filter(
+				option => ! value || option.label.toLowerCase().indexOf( value.toLowerCase() ) >= 0
+			)
+		);
+	} );
+
+	const args = {
+		label: 'Label',
+		options,
+	};
+
+	return (
+		<>
+			<DefaultComponent onChange={ onChange } { ...args } />
+		</>
+	);
+};
+
+export const Inline = () => {
+	const [ options, setOptions ] = useState( defaultOptions );
+
+	const onChange = useCallback( value => {
+		setOptions(
+			defaultOptions.filter(
+				option => ! value || option.label.toLowerCase().indexOf( value.toLowerCase() ) >= 0
+			)
+		);
+	} );
+
+	const args = {
+		label: 'Label',
+		options,
+	};
+
+	return (
+		<>
+			<DefaultComponent isInline={ true } onChange={ onChange } { ...args } />
+		</>
+	);
+};

--- a/src/system/NewForm/FormAutocomplete.test.js
+++ b/src/system/NewForm/FormAutocomplete.test.js
@@ -1,0 +1,32 @@
+/**
+ * External dependencies
+ */
+import { render, screen } from '@testing-library/react';
+import { axe } from 'jest-axe';
+
+/**
+ * Internal dependencies
+ */
+import { FormAutocomplete } from './FormAutocomplete';
+
+const options = [
+	{ value: 'chocolate', label: 'Chocolate' },
+	{ value: 'strawberry', label: 'Strawberry Chocolate Vanilla Chocolate Vanilla' },
+	{ value: 'vanilla', label: 'Vanilla' },
+];
+
+const defaultProps = {
+	label: 'This is a label',
+	options,
+};
+
+describe( '<FormAutocomplete />', () => {
+	it( 'renders the FormAutocomplete component', async () => {
+		const { container } = render( <FormAutocomplete id="my_desert_list" { ...defaultProps } /> );
+
+		expect( screen.getByLabelText( defaultProps.label ) ).toBeInTheDocument();
+
+		// Check for accessibility issues
+		await expect( await axe( container ) ).toHaveNoViolations();
+	} );
+} );

--- a/src/system/NewForm/FormSelect.stories.jsx
+++ b/src/system/NewForm/FormSelect.stories.jsx
@@ -70,7 +70,7 @@ const DefaultComponent = ( { label = 'Label', width = 250, onChange, ...rest } )
 export const Default = DefaultComponent.bind( {} );
 Default.args = {
 	placeholder: '- Select -',
-	options: options,
+	options,
 };
 
 export const WithGroup = DefaultComponent.bind( {} );

--- a/src/system/NewForm/index.js
+++ b/src/system/NewForm/index.js
@@ -3,11 +3,13 @@
  */
 
 import { FormSelect } from './FormSelect';
+import { FormAutocomplete } from './FormAutocomplete';
 import { Form } from './Form';
 
 const Select = FormSelect;
+const Autocomplete = FormAutocomplete;
 const Root = Form;
 
-export { Root, Select };
+export { Root, Select, Autocomplete };
 
 export default Root;

--- a/test/fileMock.js
+++ b/test/fileMock.js
@@ -1,0 +1,1 @@
+module.exports = {};


### PR DESCRIPTION
## Description

Adding the `Form/Autocomplete` new component 🥳 . 

We're using the accessible autocomplete from alphagov as a base, and doing the styling update to have it similar to the VIP design system. A few usage examples are available on [component website](https://alphagov.github.io/accessible-autocomplete/examples/)

### VIP Form/Autocomplete component

<img width="453" alt="image" src="https://user-images.githubusercontent.com/199867/198309289-3ce7e19a-2b28-4b16-99fd-08990db8bb6c.png">

<img width="445" alt="image" src="https://user-images.githubusercontent.com/199867/198309523-6b902502-05a9-4532-a1e1-05e88eaf1d4b.png">

## Checklist

- [ ] This PR has good automated test coverage
- [x] The storybook for the component has been updated

## Steps to Test

Outline the steps to test and verify the PR here.

Example:

1. Pull down PR.
1. `npm run dev`.
1. Open Storybook - https://deploy-preview-127--vip-design-system-components.netlify.app/?path=/story/form-autocomplete--default
1. Check how the Autocomplete behaves similarly to the component, but with accessibility. You can use a keyboard, and navigate between options, etc.
