### PR TITLE
Fixes accordion trigger indicator animation

### DIFF
--- a/src/system/Accordion/Accordion.js
+++ b/src/system/Accordion/Accordion.js
@@ -85,6 +85,7 @@ export const Trigger = React.forwardRef(
 					'&[data-state="open"]': {
 						backgroundColor: 'backgroundSecondary',
 						borderBottom: theme => `1px solid ${ theme.colors.border }`,
+						'.vip-accordion-trigger-indicator': { transform: 'rotate(270deg)' },
 					},
 					'&:hover': { backgroundColor: 'backgroundSecondary' },
 				} }
@@ -93,12 +94,12 @@ export const Trigger = React.forwardRef(
 			>
 				{ children }
 				<MdChevronRight
+					className="vip-accordion-trigger-indicator"
 					sx={ {
 						fontSize: 3,
 						color: 'text',
 						transform: 'rotate(90deg)',
 						transition: 'transform 300ms cubic-bezier(0.87, 0, 0.13, 1)',
-						'[data-state=open] &': { transform: 'rotate(270deg)' },
 					} }
 					aria-hidden
 				/>


### PR DESCRIPTION
## Description

On the Dashboard, the CSS transform doesn't apply well resulting in the arrow not turning around. I've changed it so that it uses stronger selector specificity to avoid problems.

## Checklist

- [ ] This PR has good automated test coverage
- [ ] The storybook for the component has been updated

## Steps to Test

I could only reproduce this on the Dashboard. Here, you can verify that the animation still works.

1. Pull down PR.
1. `npm run dev`.
1. Open Storybook.
1. Open the Accordion component
1. Verify that the chevron arrow rotates when opening and closing items.
