### PR TITLE
Improve/form components

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -1,12 +1,12 @@
 {
 	"name": "@automattic/vip-design-system",
-	"version": "0.26.4",
+	"version": "0.26.5",
 	"lockfileVersion": 2,
 	"requires": true,
 	"packages": {
 		"": {
 			"name": "@automattic/vip-design-system",
-			"version": "0.26.4",
+			"version": "0.26.5",
 			"dependencies": {
 				"@radix-ui/react-accordion": "^1.0.1",
 				"@radix-ui/react-checkbox": "^1.0.0",

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
 	"name": "@automattic/vip-design-system",
-	"version": "0.26.4",
+	"version": "0.26.5",
 	"main": "build/system/index.js",
 	"scripts": {
 		"build-storybook": "build-storybook",

--- a/src/system/NewForm/Form.js
+++ b/src/system/NewForm/Form.js
@@ -3,15 +3,22 @@
  */
 import React from 'react';
 import PropTypes from 'prop-types';
+import classNames from 'classnames';
 
-const Form = React.forwardRef( ( { children, ...props }, forwardRef ) => (
-	<form ref={ forwardRef } { ...props }>
+const Form = React.forwardRef( ( { children, className, ...props }, forwardRef ) => (
+	<form
+		ref={ forwardRef }
+		className={ classNames( 'vip-form-component', className ) }
+		noValidate
+		{ ...props }
+	>
 		{ children }
 	</form>
 ) );
 
 Form.propTypes = {
 	children: PropTypes.any,
+	className: PropTypes.any,
 };
 
 Form.displayName = 'Form';

--- a/src/system/NewForm/FormAutocomplete.js
+++ b/src/system/NewForm/FormAutocomplete.js
@@ -5,8 +5,8 @@
  */
 import React, { useCallback, useEffect, useMemo, useState } from 'react';
 import PropTypes from 'prop-types';
-import { Label } from '../Form/Label';
 import Autocomplete from 'accessible-autocomplete/react';
+import classNames from 'classnames';
 
 /**
  * Internal dependencies
@@ -14,6 +14,7 @@ import Autocomplete from 'accessible-autocomplete/react';
 import css from './FormAutocomplete.css';
 import { FormSelectContent } from './FormSelectContent';
 import { FormSelectArrow } from './FormSelectArrow';
+import { Label } from '../Form/Label';
 
 const defaultStyles = {
 	width: '100%',
@@ -81,6 +82,7 @@ const FormAutocomplete = React.forwardRef(
 			showAllValues = true,
 			displayMenu = 'overlay',
 			id = 'vip-autocomplete',
+			className,
 			...props
 		},
 		forwardRef
@@ -152,7 +154,7 @@ const FormAutocomplete = React.forwardRef(
 		}, [ setIsDirty ] );
 
 		return (
-			<>
+			<div className={ classNames( 'vip-form-autocomplete-component', className ) }>
 				{ label && ! isInline && <SelectLabel /> }
 
 				<div sx={ { ...defaultStyles, ...( isInline && inlineStyles ) } }>
@@ -173,7 +175,7 @@ const FormAutocomplete = React.forwardRef(
 						<FormSelectArrow />
 					</FormSelectContent>
 				</div>
-			</>
+			</div>
 		);
 	}
 );
@@ -190,6 +192,7 @@ FormAutocomplete.propTypes = {
 	getOptionLabel: PropTypes.func,
 	getOptionValue: PropTypes.func,
 	onChange: PropTypes.func,
+	className: PropTypes.any,
 };
 
 FormAutocomplete.displayName = 'FormAutocomplete';


### PR DESCRIPTION
## Description

- Add `noValidation` by default for `<Form.Root>`. Reason: HTML5 default validations are not accessible;
- Added base `className` to Form.Root and FormAutocomplete 

## Checklist

- [ ] This PR has good automated test coverage
- [ ] The storybook for the component has been updated

## Steps to Test

1. Pull down PR.
2. `npm run dev`.
3. Open Storybook.
4. Verify http://localhost:6006/?path=/story/form-autocomplete--default and http://localhost:6006/?path=/story/form-input--default both have base classes for the tag `<form>` and the autocomplete component
