### PR TITLE
Revamp Radio Component with A11Y

### DIFF
--- a/src/system/Form/Label.js
+++ b/src/system/Form/Label.js
@@ -8,15 +8,20 @@ import React from 'react';
 /**
  * Internal dependencies
  */
-import { Heading } from '..';
 
-const Label = React.forwardRef( ( props, forwardRef ) => (
-	<Heading
-		variant="h4"
-		as="label"
-		sx={ { display: 'block', mb: 2, color: 'muted' } }
+const Label = React.forwardRef( ( { sx, ...rest }, forwardRef ) => (
+	<label
+		sx={ {
+			fontWeight: 500,
+			fontSize: 2,
+			lineHeight: 1.5,
+			display: 'block',
+			mb: 2,
+			color: 'muted',
+			...sx,
+		} }
 		ref={ forwardRef }
-		{ ...props }
+		{ ...rest }
 	/>
 ) );
 

--- a/src/system/Form/Label.js
+++ b/src/system/Form/Label.js
@@ -4,6 +4,7 @@
  * External dependencies
  */
 import React from 'react';
+import PropTypes from 'prop-types';
 
 /**
  * Internal dependencies
@@ -24,6 +25,10 @@ const Label = React.forwardRef( ( { sx, ...rest }, forwardRef ) => (
 		{ ...rest }
 	/>
 ) );
+
+Label.propTypes = {
+	sx: PropTypes.object,
+};
 
 Label.displayName = 'Label';
 

--- a/src/system/Form/Radio.js
+++ b/src/system/Form/Radio.js
@@ -3,18 +3,113 @@
 /**
  * External dependencies
  */
-import React from 'react';
-import { Radio as ThemeRadio } from 'theme-ui';
+import React, { useMemo } from 'react';
 import PropTypes from 'prop-types';
+import { Label } from './Label';
+import { screenReaderTextClass } from '../ScreenReaderText/ScreenReaderText';
 
-const Radio = React.forwardRef( ( { disabled, ...props }, forwardRef ) => (
-	<ThemeRadio
-		sx={ { opacity: disabled ? 0.4 : 1 } }
-		disabled={ disabled }
-		ref={ forwardRef }
-		{ ...props }
-	/>
-) );
+const inputStyle = {
+	...screenReaderTextClass,
+	width: '16px',
+	height: '16px',
+	'&:focus ~ label:before': theme => theme.outline,
+	'&:focus-visible ~ label:before': theme => theme.outline,
+	'&:focus ~ label:before': {
+		content: '""',
+		border: '2px solid',
+		borderColor: 'border',
+		zIndex: 3,
+		left: theme => `${ -1 * ( theme.space[ 4 ] - theme.space[ 2 ] ) }px`,
+	},
+	'&:checked ~ label::after': {
+		opacity: 1,
+		transform: 'scale(1)',
+	},
+};
+
+const labelStyle = {
+	cursor: 'pointer',
+	position: 'relative',
+	marginLeft: theme => `${ theme.space[ 4 ] - theme.space[ 2 ] }px`,
+	marginBottom: 0,
+	userSelect: 'none',
+	color: 'heading',
+	lineHeight: 1.5,
+	'&:before, &:after': {
+		borderRadius: '50%',
+		position: 'absolute',
+		top: 0,
+		left: theme => `${ -1 * ( theme.space[ 4 ] - theme.space[ 2 ] ) }px`,
+		transition: 'all .3s ease-out',
+		zIndex: 2,
+		width: '16px',
+		height: '16px',
+	},
+	'&::before': {
+		content: '""',
+		border: '2px solid',
+		borderColor: 'border',
+	},
+	'&::after': {
+		content: '""',
+		backgroundColor: 'primary',
+		backgroundPosition: 'left 2px top 2px',
+		backgroundSize: '70%',
+		backgroundRepeat: 'no-repeat',
+		backgroundImage: `url(
+					'data:image/svg+xml;utf8,<svg width="14" height="14" viewBox="0 0 14 14" fill="none" xmlns="http://www.w3.org/2000/svg"><path fill-rule="evenodd" clip-rule="evenodd" d="M13.4999 4.9995L5.7254 12.4008L2.5 9.33023L3.83307 7.92994L5.7254 9.73144L12.1668 3.59921L13.4999 4.9995Z" fill="white"/></svg>')`,
+		border: '2px solid',
+		borderColor: 'border',
+		color: 'white',
+		transform: 'scale(0)',
+		opacity: 0,
+	},
+};
+
+const Radio = React.forwardRef(
+	( { disabled, defaultValue, onChange, name = '', options = [], ...props }, forwardRef ) => {
+		const renderedOptions = useMemo(
+			() =>
+				options.map( option => (
+					<div
+						sx={ {
+							display: 'flex',
+							alignItems: 'center',
+							minHeight: theme => `${ theme.space[ 4 ] - theme.space[ 2 ] }px`,
+						} }
+						key={ option.id }
+						className="vip-radio-group-item"
+					>
+						<input
+							type="radio"
+							id={ option.id }
+							name={ name }
+							value={ `${ option.value }` }
+							sx={ inputStyle }
+							onChange={ onChange }
+							className="vip-radio-group-item-input"
+							checked={ `${ option.value }` === `${ defaultValue }` }
+						/>
+
+						{ typeof option.label === 'string' ? (
+							<Label className="vip-radio-group-item-label" htmlFor={ option.id } sx={ labelStyle }>
+								{ option.label }
+							</Label>
+						) : (
+							label
+						) }
+					</div>
+				) ),
+			[ options ]
+		);
+
+		return (
+			<div className="vip-radio-button-group" ref={ forwardRef } { ...props }>
+				{ renderedOptions }
+			</div>
+		);
+	}
+);
 
 Radio.displayName = 'Radio';
 

--- a/src/system/Form/Radio.js
+++ b/src/system/Form/Radio.js
@@ -1,3 +1,4 @@
+/* eslint-disable max-len */
 /** @jsxImportSource theme-ui */
 
 /**
@@ -12,15 +13,14 @@ const inputStyle = {
 	...screenReaderTextClass,
 	width: '16px',
 	height: '16px',
-	'&:focus ~ label:before': theme => theme.outline,
-	'&:focus-visible ~ label:before': theme => theme.outline,
-	'&:focus ~ label:before': {
+	'&:focus ~ label:before': theme => ( {
+		...theme.outline,
 		content: '""',
 		border: '2px solid',
 		borderColor: 'border',
 		zIndex: 3,
-		left: theme => `${ -1 * ( theme.space[ 4 ] - theme.space[ 2 ] ) }px`,
-	},
+		left: `${ -1 * ( theme.space[ 4 ] - theme.space[ 2 ] ) }px`,
+	} ),
 	'&:checked ~ label::after': {
 		opacity: 1,
 		transform: 'scale(1)',
@@ -56,6 +56,7 @@ const labelStyle = {
 		backgroundPosition: 'left 2px top 2px',
 		backgroundSize: '70%',
 		backgroundRepeat: 'no-repeat',
+
 		backgroundImage: `url(
 					'data:image/svg+xml;utf8,<svg width="14" height="14" viewBox="0 0 14 14" fill="none" xmlns="http://www.w3.org/2000/svg"><path fill-rule="evenodd" clip-rule="evenodd" d="M13.4999 4.9995L5.7254 12.4008L2.5 9.33023L3.83307 7.92994L5.7254 9.73144L12.1668 3.59921L13.4999 4.9995Z" fill="white"/></svg>')`,
 		border: '2px solid',
@@ -96,7 +97,7 @@ const Radio = React.forwardRef(
 								{ option.label }
 							</Label>
 						) : (
-							label
+							option.label
 						) }
 					</div>
 				) ),
@@ -118,6 +119,7 @@ Radio.propTypes = {
 	defaultValue: PropTypes.any,
 	onChange: PropTypes.func,
 	options: PropTypes.array,
+	name: PropTypes.string,
 };
 
 export { Radio };

--- a/src/system/Form/Radio.js
+++ b/src/system/Form/Radio.js
@@ -78,6 +78,11 @@ const CustomLabel = ( { children } ) => (
 	</>
 );
 
+CustomLabel.propTypes = {
+	children: PropTypes.shape( { props: { className: PropTypes.any, sx: PropTypes.object } } )
+		.isRequired,
+};
+
 const Radio = React.forwardRef(
 	(
 		{ disabled, defaultValue, onChange, name = '', options = [], className, ...props },
@@ -149,6 +154,7 @@ Radio.propTypes = {
 	onChange: PropTypes.func,
 	options: PropTypes.array,
 	name: PropTypes.string,
+	className: PropTypes.any,
 };
 
 export { Radio };

--- a/src/system/Form/Radio.js
+++ b/src/system/Form/Radio.js
@@ -6,6 +6,7 @@
  */
 import React, { useMemo } from 'react';
 import PropTypes from 'prop-types';
+import classNames from 'classnames';
 import { Label } from './Label';
 import { screenReaderTextClass } from '../ScreenReaderText/ScreenReaderText';
 
@@ -72,13 +73,16 @@ const CustomLabel = ( { children } ) => (
 		{ React.cloneElement( React.Children.only( children ), {
 			...children.props,
 			sx: { ...labelStyle, ...children.props.sx },
-			className: `${ children.props.className } vip-radio-group-item-label`,
+			className: `${ children.props.className } vip-radio-component-item-label`,
 		} ) }
 	</>
 );
 
 const Radio = React.forwardRef(
-	( { disabled, defaultValue, onChange, name = '', options = [], ...props }, forwardRef ) => {
+	(
+		{ disabled, defaultValue, onChange, name = '', options = [], className, ...props },
+		forwardRef
+	) => {
 		const renderedOptions = useMemo(
 			() =>
 				options.map( option => (
@@ -89,7 +93,10 @@ const Radio = React.forwardRef(
 							minHeight: theme => `${ theme.space[ 4 ] - theme.space[ 2 ] }px`,
 						} }
 						key={ option.id }
-						className="vip-radio-group-item"
+						className={ classNames(
+							'vip-radio-component-item',
+							`vip-radio-component-item-${ option.id }`
+						) }
 					>
 						<input
 							type="radio"
@@ -98,12 +105,16 @@ const Radio = React.forwardRef(
 							value={ `${ option.value }` }
 							sx={ inputStyle }
 							onChange={ onChange }
-							className="vip-radio-group-item-input"
+							className={ classNames( 'vip-radio-component-item-input', option?.className ) }
 							checked={ `${ option.value }` === `${ defaultValue }` }
 						/>
 
 						{ typeof option.label === 'string' ? (
-							<Label className="vip-radio-group-item-label" htmlFor={ option.id } sx={ labelStyle }>
+							<Label
+								className={ classNames( 'vip-radio-component-item-label', option?.className ) }
+								htmlFor={ option.id }
+								sx={ labelStyle }
+							>
 								{ option.label }
 							</Label>
 						) : (
@@ -115,7 +126,15 @@ const Radio = React.forwardRef(
 		);
 
 		return (
-			<div className="vip-radio-button-group" ref={ forwardRef } { ...props }>
+			<div
+				className={ classNames(
+					'vip-radio-component',
+					`vip-radio-component-${ name }`,
+					className
+				) }
+				ref={ forwardRef }
+				{ ...props }
+			>
 				{ renderedOptions }
 			</div>
 		);

--- a/src/system/Form/Radio.js
+++ b/src/system/Form/Radio.js
@@ -4,7 +4,7 @@
 /**
  * External dependencies
  */
-import React, { useMemo } from 'react';
+import React from 'react';
 import PropTypes from 'prop-types';
 import classNames from 'classnames';
 import { Label } from './Label';
@@ -88,47 +88,43 @@ const Radio = React.forwardRef(
 		{ disabled, defaultValue, onChange, name = '', options = [], className, ...props },
 		forwardRef
 	) => {
-		const renderedOptions = useMemo(
-			() =>
-				options.map( option => (
-					<div
-						sx={ {
-							display: 'flex',
-							alignItems: 'center',
-							minHeight: theme => `${ theme.space[ 4 ] - theme.space[ 2 ] }px`,
-						} }
-						key={ option.id }
-						className={ classNames(
-							'vip-radio-component-item',
-							`vip-radio-component-item-${ option.id }`
-						) }
-					>
-						<input
-							type="radio"
-							id={ option.id }
-							name={ name }
-							value={ `${ option.value }` }
-							sx={ inputStyle }
-							onChange={ onChange }
-							className={ classNames( 'vip-radio-component-item-input', option?.className ) }
-							checked={ `${ option.value }` === `${ defaultValue }` }
-						/>
+		const renderedOptions = options.map( option => (
+			<div
+				sx={ {
+					display: 'flex',
+					alignItems: 'center',
+					minHeight: theme => `${ theme.space[ 4 ] - theme.space[ 2 ] }px`,
+				} }
+				key={ option.id }
+				className={ classNames(
+					'vip-radio-component-item',
+					`vip-radio-component-item-${ option.id }`
+				) }
+			>
+				<input
+					type="radio"
+					id={ option.id }
+					name={ name }
+					value={ `${ option.value }` }
+					sx={ inputStyle }
+					onChange={ onChange }
+					className={ classNames( 'vip-radio-component-item-input', option?.className ) }
+					checked={ `${ option.value }` === `${ defaultValue }` }
+				/>
 
-						{ typeof option.label === 'string' ? (
-							<Label
-								className={ classNames( 'vip-radio-component-item-label', option?.className ) }
-								htmlFor={ option.id }
-								sx={ labelStyle }
-							>
-								{ option.label }
-							</Label>
-						) : (
-							<CustomLabel>{ option.label }</CustomLabel>
-						) }
-					</div>
-				) ),
-			[ options ]
-		);
+				{ typeof option.label === 'string' ? (
+					<Label
+						className={ classNames( 'vip-radio-component-item-label', option?.className ) }
+						htmlFor={ option.id }
+						sx={ labelStyle }
+					>
+						{ option.label }
+					</Label>
+				) : (
+					<CustomLabel>{ option.label }</CustomLabel>
+				) }
+			</div>
+		) );
 
 		return (
 			<div

--- a/src/system/Form/Radio.js
+++ b/src/system/Form/Radio.js
@@ -115,6 +115,9 @@ Radio.displayName = 'Radio';
 
 Radio.propTypes = {
 	disabled: PropTypes.bool,
+	defaultValue: PropTypes.any,
+	onChange: PropTypes.func,
+	options: PropTypes.array,
 };
 
 export { Radio };

--- a/src/system/Form/Radio.js
+++ b/src/system/Form/Radio.js
@@ -67,6 +67,16 @@ const labelStyle = {
 	},
 };
 
+const CustomLabel = ( { children } ) => (
+	<>
+		{ React.cloneElement( React.Children.only( children ), {
+			...children.props,
+			sx: { ...labelStyle, ...children.props.sx },
+			className: `${ children.props.className } vip-radio-group-item-label`,
+		} ) }
+	</>
+);
+
 const Radio = React.forwardRef(
 	( { disabled, defaultValue, onChange, name = '', options = [], ...props }, forwardRef ) => {
 		const renderedOptions = useMemo(
@@ -97,7 +107,7 @@ const Radio = React.forwardRef(
 								{ option.label }
 							</Label>
 						) : (
-							option.label
+							<CustomLabel>{ option.label }</CustomLabel>
 						) }
 					</div>
 				) ),

--- a/src/system/Form/Radio.stories.jsx
+++ b/src/system/Form/Radio.stories.jsx
@@ -46,10 +46,7 @@ export const Default = () => {
 							},
 							{ value: 'b', label: 'All domains listed on this environment', id: 'option-b' },
 						] }
-						onChange={ e => {
-							setChecked( e.target.value );
-							console.log( e.target.value );
-						} }
+						onChange={ e => setChecked( e.target.value ) }
 					/>
 				</Flex>
 			</fieldset>

--- a/src/system/Form/Radio.stories.jsx
+++ b/src/system/Form/Radio.stories.jsx
@@ -11,6 +11,7 @@ import { useState } from 'react';
 import { Form } from '..';
 import { Radio } from './Radio';
 import { Flex } from '../Flex';
+import { Label } from './Label';
 
 export default {
 	title: 'Form/Radio',
@@ -19,6 +20,7 @@ export default {
 
 export const Default = () => {
 	const [ checked, setChecked ] = useState( 'a' );
+	const [ checked2, setChecked2 ] = useState( 'a' );
 
 	return (
 		<Form.Root>
@@ -47,6 +49,38 @@ export const Default = () => {
 							{ value: 'b', label: 'All domains listed on this environment', id: 'option-b' },
 						] }
 						onChange={ e => setChecked( e.target.value ) }
+					/>
+				</Flex>
+			</fieldset>
+
+			<fieldset>
+				<legend sx={ { mb: 0, fontSize: 2, fontWeight: 'bold' } }>With a custom Label</legend>
+
+				<Flex sx={ { alignItems: 'center' } }>
+					<Radio
+						name="the_option_custom"
+						defaultValue={ checked2 }
+						options={ [
+							{
+								value: 'a',
+								label: (
+									<Label
+										htmlFor="option-custom-a"
+										className="custom-class"
+										sx={ { color: 'primary' } }
+									>
+										(Custom) All domains listed on this environment, and all subdomains
+									</Label>
+								),
+								id: 'option-custom-a',
+							},
+							{
+								value: 'b',
+								label: 'All domains listed on this environment',
+								id: 'option-custom-b',
+							},
+						] }
+						onChange={ e => setChecked2( e.target.value ) }
 					/>
 				</Flex>
 			</fieldset>

--- a/src/system/Form/Radio.stories.jsx
+++ b/src/system/Form/Radio.stories.jsx
@@ -77,6 +77,7 @@ export const Default = () => {
 							{
 								value: 'b',
 								label: 'All domains listed on this environment',
+								className: 'custom-class-for-this',
 								id: 'option-custom-b',
 							},
 						] }

--- a/src/system/Form/Radio.stories.jsx
+++ b/src/system/Form/Radio.stories.jsx
@@ -1,3 +1,5 @@
+/** @jsxImportSource theme-ui */
+
 /**
  * External dependencies
  */
@@ -8,7 +10,6 @@ import { useState } from 'react';
  */
 import { Form } from '..';
 import { Radio } from './Radio';
-import { Label } from './Label';
 import { Flex } from '../Flex';
 
 export default {
@@ -35,30 +36,21 @@ export const Default = () => {
 
 				<Flex sx={ { alignItems: 'center' } }>
 					<Radio
-						name="includeSubdomains"
-						id="include-all-domains-opt"
-						onChange={ () => setChecked( 'a' ) }
-						value={ 'a' }
-						checked={ checked === 'a' }
+						name="the_option"
+						defaultValue={ checked }
+						options={ [
+							{
+								value: 'a',
+								label: 'All domains listed on this environment, and all subdomains',
+								id: 'option-a',
+							},
+							{ value: 'b', label: 'All domains listed on this environment', id: 'option-b' },
+						] }
+						onChange={ e => {
+							setChecked( e.target.value );
+							console.log( e.target.value );
+						} }
 					/>
-
-					<Label htmlFor="include-all-domains-opt" sx={ { mb: 0 } }>
-						All domains listed on this environment, and all subdomains
-					</Label>
-				</Flex>
-
-				<Flex sx={ { alignItems: 'center', mb: 1 } }>
-					<Radio
-						name="includeSubdomains"
-						id="include-subdomains-opt"
-						onChange={ () => setChecked( 'b' ) }
-						checked={ checked === 'b' }
-						value={ 'b' }
-					/>
-
-					<Label id="exclude-subdomains" htmlFor="include-subdomains-opt" sx={ { mb: 0 } }>
-						All domains listed on this environment
-					</Label>
 				</Flex>
 			</fieldset>
 		</Form.Root>


### PR DESCRIPTION
## Description

<img width="1418" alt="image" src="https://user-images.githubusercontent.com/3402/203727170-3783f84e-de6e-42ba-8f3d-dfe2f5d3dac3.png">


We are revamping the `Radio` component. Radio components only make sense to be used with two or more. That's the nature of Radios; you need two or more options.

The current implementation lets you choose only one Radio button. In this new implementation, you must pass an array of options (similar to other components). This will provide more clarity and avoid forms with one radio button, and this new implementation is accessible.

**BREAKING CHANGE**: The new implementation of the `<Radio>` will break current usage. Once you upgrade this component, you need to change the implementation. Follow the Storybook story to understand the new API.

## Checklist

- [ ] This PR has good automated test coverage
- [ ] The storybook for the component has been updated

## Steps to Test

1. Pull down PR.
2. `npm run dev`.
3. Open http://localhost:6006/?path=/story/form-radio--default
4. Test the functionality. Make sure you can click/select using the mouse or keyboard the toggle and the label
