### PR TITLE
Improve Radio button to accept flexible props

### DIFF
--- a/.storybook/decorators/withColorMode.jsx
+++ b/.storybook/decorators/withColorMode.jsx
@@ -21,7 +21,7 @@ export const backgrounds = {
 };
 
 function ThemeChanger( { background } ) {
-	const [ colorMode, setColorMode ] = useColorMode();
+	const [ _, setColorMode ] = useColorMode();
 	const newColorMode = darkBackground === background ? 'dark' : 'default';
 
 	useEffect( () => {

--- a/package-lock.json
+++ b/package-lock.json
@@ -1,12 +1,12 @@
 {
 	"name": "@automattic/vip-design-system",
-	"version": "0.27.1",
+	"version": "0.27.2",
 	"lockfileVersion": 2,
 	"requires": true,
 	"packages": {
 		"": {
 			"name": "@automattic/vip-design-system",
-			"version": "0.27.1",
+			"version": "0.27.2",
 			"dependencies": {
 				"@radix-ui/react-accordion": "^1.0.1",
 				"@radix-ui/react-checkbox": "^1.0.0",

--- a/package-lock.json
+++ b/package-lock.json
@@ -1,12 +1,12 @@
 {
 	"name": "@automattic/vip-design-system",
-	"version": "0.27.0",
+	"version": "0.27.1",
 	"lockfileVersion": 2,
 	"requires": true,
 	"packages": {
 		"": {
 			"name": "@automattic/vip-design-system",
-			"version": "0.27.0",
+			"version": "0.27.1",
 			"dependencies": {
 				"@radix-ui/react-accordion": "^1.0.1",
 				"@radix-ui/react-checkbox": "^1.0.0",

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
 	"name": "@automattic/vip-design-system",
-	"version": "0.27.0",
+	"version": "0.27.1",
 	"main": "build/system/index.js",
 	"scripts": {
 		"build-storybook": "build-storybook",

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
 	"name": "@automattic/vip-design-system",
-	"version": "0.27.1",
+	"version": "0.27.2",
 	"main": "build/system/index.js",
 	"scripts": {
 		"build-storybook": "build-storybook",

--- a/src/system/Form/Radio.js
+++ b/src/system/Form/Radio.js
@@ -86,7 +86,7 @@ CustomLabel.propTypes = {
 
 const Radio = React.forwardRef(
 	(
-		{ disabled, defaultValue, onChange, name = '', options = [], className = undefined, ...props },
+		{ disabled, defaultValue, onChange, name = '', options = [], className, ...props },
 		forwardRef
 	) => {
 		const onChangeHandler = useCallback( e => {

--- a/src/system/Form/Radio.js
+++ b/src/system/Form/Radio.js
@@ -10,6 +10,14 @@ import classNames from 'classnames';
 import { Label } from './Label';
 import { screenReaderTextClass } from '../ScreenReaderText/ScreenReaderText';
 
+const prefix = 'vip-radio-component-';
+
+const itemStyle = {
+	display: 'flex',
+	alignItems: 'center',
+	minHeight: theme => `${ theme.space[ 4 ] - theme.space[ 2 ] }px`,
+};
+
 const inputStyle = {
 	...screenReaderTextClass,
 	width: '16px',
@@ -68,13 +76,14 @@ const labelStyle = {
 	},
 };
 
-const CustomLabel = ( { children } ) => {
+const CustomLabel = ( { children, ...restLabel } ) => {
 	return (
 		<>
 			{ React.cloneElement( React.Children.only( children ), {
 				...children.props,
 				sx: { ...labelStyle, ...children.props.sx },
-				className: `${ children.props.className } vip-radio-component-item-label`,
+				className: `${ children.props.className } ${ prefix }item-label`,
+				...restLabel,
 			} ) }
 		</>
 	);
@@ -82,6 +91,55 @@ const CustomLabel = ( { children } ) => {
 
 CustomLabel.propTypes = {
 	children: PropTypes.any,
+};
+
+const RadioOption = ( {
+	option: { id, value, className, label, labelProps = {}, ...restOption },
+	name,
+	onChangeHandler,
+	checked,
+} ) => (
+	<div
+		sx={ itemStyle }
+		className={ classNames(
+			`${ prefix }item`,
+			`${ prefix }item-${ id }`,
+			checked ? `${ prefix }item-checked` : '',
+			className
+		) }
+	>
+		<input
+			type="radio"
+			id={ id }
+			name={ name }
+			value={ `${ value }` }
+			sx={ inputStyle }
+			onChange={ onChangeHandler }
+			className={ `${ prefix }item-input` }
+			checked={ checked }
+			{ ...restOption }
+		/>
+
+		{ typeof label === 'string' ? (
+			<Label
+				className={ `${ prefix }item-label` }
+				htmlFor={ id }
+				sx={ labelStyle }
+				{ ...labelProps }
+			>
+				{ label }
+			</Label>
+		) : (
+			<CustomLabel { ...labelProps }>{ label }</CustomLabel>
+		) }
+	</div>
+);
+
+RadioOption.propTypes = {
+	option: PropTypes.object,
+	name: PropTypes.string,
+	onChangeHandler: PropTypes.func,
+	checked: PropTypes.bool,
 };
 
 const Radio = React.forwardRef(
@@ -96,52 +154,19 @@ const Radio = React.forwardRef(
 			onChange( e, optionTriggered );
 		}, [] );
 
-		const renderedOptions = options.map(
-			( { id, className: optionClassName, value, label, labelProps = {}, ...restOption } ) => (
-				<div
-					sx={ {
-						display: 'flex',
-						alignItems: 'center',
-						minHeight: theme => `${ theme.space[ 4 ] - theme.space[ 2 ] }px`,
-					} }
-					key={ id }
-					className={ classNames( 'vip-radio-component-item', `vip-radio-component-item-${ id }` ) }
-				>
-					<input
-						type="radio"
-						id={ id }
-						name={ name }
-						value={ `${ value }` }
-						sx={ inputStyle }
-						onChange={ onChangeHandler }
-						className={ classNames( 'vip-radio-component-item-input', optionClassName ) }
-						checked={ `${ value }` === `${ defaultValue }` }
-						{ ...restOption }
-					/>
-
-					{ typeof label === 'string' ? (
-						<Label
-							className={ classNames( 'vip-radio-component-item-label', optionClassName ) }
-							htmlFor={ id }
-							sx={ labelStyle }
-							{ ...labelProps }
-						>
-							{ label }
-						</Label>
-					) : (
-						<CustomLabel { ...labelProps }>{ label }</CustomLabel>
-					) }
-				</div>
-			)
-		);
+		const renderedOptions = options.map( option => (
+			<RadioOption
+				key={ option?.id }
+				name={ name }
+				option={ option }
+				onChangeHandler={ onChangeHandler }
+				checked={ `${ defaultValue }` === `${ option?.value }` }
+			/>
+		) );
 
 		return (
 			<div
-				className={ classNames(
-					'vip-radio-component',
-					`vip-radio-component-${ name }`,
-					className
-				) }
+				className={ classNames( prefix, `${ prefix }${ name }`, className ) }
 				ref={ forwardRef }
 				{ ...props }
 			>

--- a/src/system/Form/Radio.stories.jsx
+++ b/src/system/Form/Radio.stories.jsx
@@ -20,7 +20,7 @@ export default {
 
 export const Default = () => {
 	const [ checked, setChecked ] = useState( 'a' );
-	const [ checked2, setChecked2 ] = useState( 'a' );
+	const [ checked2, setChecked2 ] = useState( 'b' );
 
 	return (
 		<Form.Root>
@@ -67,7 +67,7 @@ export const Default = () => {
 									<Label
 										htmlFor="option-custom-a"
 										className="custom-class"
-										sx={ { color: 'primary' } }
+										sx={ { color: 'error' } }
 									>
 										(Custom) All domains listed on this environment, and all subdomains
 									</Label>
@@ -77,14 +77,22 @@ export const Default = () => {
 							{
 								value: 'b',
 								label: 'All domains listed on this environment',
+								labelProps: {
+									id: 'label-option-custom-b-custom-props',
+								},
 								className: 'custom-class-for-this',
+								'aria-describedby': 'describe-radio-all-domains-subdomains',
 								id: 'option-custom-b',
 							},
 						] }
-						onChange={ e => setChecked2( e.target.value ) }
+						onChange={ ( _, option ) => setChecked2( option.value ) }
 					/>
 				</Flex>
 			</fieldset>
+
+			<p id="describe-radio-all-domains-subdomains" sx={ { mt: 2 } }>
+				This is a explanation for custom option b
+			</p>
 		</Form.Root>
 	);
 };


### PR DESCRIPTION
## Description

Adding the ability to pass custom props to input and label. This will increase flexibility.

## Checklist

- [ ] This PR has good automated test coverage
- [ ] The storybook for the component has been updated

## Steps to Test

Outline the steps to test and verify the PR here.

Example:

1. Pull down PR.
2. `npm run dev`.
3. Open http://localhost:6006/?path=/story/form-radio--default
4. Verify still works correctly and accepts more props (Check HTML)
