### PR TITLE
Add/autocomplete loading

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -1,12 +1,12 @@
 {
 	"name": "@automattic/vip-design-system",
-	"version": "0.27.4",
+	"version": "0.27.5",
 	"lockfileVersion": 2,
 	"requires": true,
 	"packages": {
 		"": {
 			"name": "@automattic/vip-design-system",
-			"version": "0.27.4",
+			"version": "0.27.5",
 			"dependencies": {
 				"@radix-ui/react-accordion": "^1.0.1",
 				"@radix-ui/react-checkbox": "^1.0.0",

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
 	"name": "@automattic/vip-design-system",
-	"version": "0.27.4",
+	"version": "0.27.5",
 	"main": "build/system/index.js",
 	"scripts": {
 		"build-storybook": "build-storybook",

--- a/src/system/NewForm/FormAutocomplete.js
+++ b/src/system/NewForm/FormAutocomplete.js
@@ -16,6 +16,7 @@ import { FormSelectContent } from './FormSelectContent';
 import { FormSelectArrow } from './FormSelectArrow';
 import { Label } from '../Form/Label';
 import { FormSelectSearch } from './FormSelectSearch';
+import { FormSelectLoading } from './FormSelectLoading';
 
 const defaultStyles = {
 	width: '100%',
@@ -105,6 +106,7 @@ const FormAutocomplete = React.forwardRef(
 			value,
 			showAllValues = true,
 			searchIcon = false,
+			loading = false,
 			displayMenu = 'overlay',
 			noOptionsMessage = () => 'No results found.',
 			id = 'vip-autocomplete',
@@ -212,6 +214,7 @@ const FormAutocomplete = React.forwardRef(
 							tNoResults={ noOptionsMessage }
 							{ ...props }
 						/>
+						{ loading && <FormSelectLoading /> }
 						<FormSelectArrow />
 					</FormSelectContent>
 				</div>
@@ -224,6 +227,7 @@ FormAutocomplete.propTypes = {
 	id: PropTypes.string,
 	showAllValues: PropTypes.bool,
 	searchIcon: PropTypes.bool,
+	loading: PropTypes.bool,
 	isInline: PropTypes.bool,
 	forLabel: PropTypes.string,
 	value: PropTypes.string,

--- a/src/system/NewForm/FormAutocomplete.js
+++ b/src/system/NewForm/FormAutocomplete.js
@@ -205,6 +205,7 @@ const FormAutocomplete = React.forwardRef(
 						{ searchIcon && <FormSelectSearch /> }
 						<Autocomplete
 							id={ id }
+							aria-busy={ loading }
 							showAllValues={ showAllValues }
 							ref={ forwardRef }
 							source={ suggest }

--- a/src/system/NewForm/FormAutocomplete.stories.jsx
+++ b/src/system/NewForm/FormAutocomplete.stories.jsx
@@ -88,6 +88,19 @@ export const WithSearchIcon = () => {
 	);
 };
 
+export const WithLoading = () => {
+	const customArgs = {
+		...args,
+		loading: true,
+	};
+
+	return (
+		<>
+			<DefaultComponent { ...customArgs } />
+		</>
+	);
+};
+
 export const WithCustomMessages = () => {
 	const customArgs = {
 		...args,

--- a/src/system/NewForm/FormSelectLoading.js
+++ b/src/system/NewForm/FormSelectLoading.js
@@ -1,0 +1,31 @@
+/** @jsxImportSource theme-ui */
+
+/**
+ * External dependencies
+ */
+import React from 'react';
+import { AiOutlineLoading3Quarters } from 'react-icons/ai';
+import { keyframes } from '@emotion/react';
+
+const kf = keyframes( {
+	from: { transform: 'rotate(0deg)' },
+	to: { transform: 'rotate(360deg) ' },
+} );
+
+export const FormSelectLoading = React.forwardRef( ( props, forwardRef ) => (
+	<AiOutlineLoading3Quarters
+		ref={ forwardRef }
+		aria-hidden="true"
+		size={ 18 }
+		sx={ {
+			position: 'absolute',
+			right: 40,
+			pointerEvents: 'none',
+			animation: `${ kf } 1s infinite linear`,
+			opacity: 0.5,
+		} }
+		{ ...props }
+	/>
+) );
+
+FormSelectLoading.displayName = 'FormSelectLoading';


### PR DESCRIPTION
## Description

Feature to add Loading prop on Autocomplete component

![Loading_1](https://user-images.githubusercontent.com/199867/204055469-004118b5-705a-40f4-accf-29df719c5629.gif)


## Checklist

- [ ] This PR has good automated test coverage
- [x] The storybook for the component has been updated

## Steps to Test

Outline the steps to test and verify the PR here.

Example:

1. Pull down PR.
1. `npm run dev`.
1. Open [Storybook](https://deploy-preview-147--vip-design-system-components.netlify.app/?path=/story/form-autocomplete--with-loading).
1. Verify if loading icon is spinning.
