### PR TITLE
Updates on Label and Wizard components

### DIFF
--- a/src/system/Form/Input.js
+++ b/src/system/Form/Input.js
@@ -12,10 +12,6 @@ import PropTypes from 'prop-types';
 import { Validation, Label } from '../';
 import { Input as ThemeInput } from 'theme-ui';
 
-const RequiredLabel = () => (
-	<span sx={ { color: 'error', display: 'inline-block', ml: 2, fontSize: 1 } }>(Required)</span>
-);
-
 const inputStyles = {
 	unset: 'all',
 	border: '1px solid',
@@ -44,9 +40,8 @@ const Input = React.forwardRef(
 	( { variant, label, forLabel, hasError, required, sx = {}, errorMessage, ...props }, ref ) => (
 		<React.Fragment>
 			{ label && (
-				<Label htmlFor={ forLabel }>
+				<Label required={ required } htmlFor={ forLabel }>
 					{ label }
-					{ required && <RequiredLabel /> }
 				</Label>
 			) }
 

--- a/src/system/Form/Label.js
+++ b/src/system/Form/Label.js
@@ -9,8 +9,9 @@ import PropTypes from 'prop-types';
 /**
  * Internal dependencies
  */
+import { RequiredLabel } from './RequiredLabel';
 
-const Label = React.forwardRef( ( { sx, ...rest }, forwardRef ) => (
+const Label = React.forwardRef( ( { sx, children, required, ...rest }, forwardRef ) => (
 	<label
 		sx={ {
 			fontWeight: 500,
@@ -23,10 +24,15 @@ const Label = React.forwardRef( ( { sx, ...rest }, forwardRef ) => (
 		} }
 		ref={ forwardRef }
 		{ ...rest }
-	/>
+	>
+		{ children }
+		{ required && <RequiredLabel /> }
+	</label>
 ) );
 
 Label.propTypes = {
+	children: PropTypes.object,
+	required: PropTypes.bool,
 	sx: PropTypes.object,
 };
 

--- a/src/system/Form/Label.stories.jsx
+++ b/src/system/Form/Label.stories.jsx
@@ -1,0 +1,36 @@
+/** @jsxImportSource theme-ui */
+
+/**
+ * Internal dependencies
+ */
+import { Form, Label } from '..';
+
+export default {
+	title: 'Form/Label',
+};
+
+const DefaultComponent = props => (
+	<Form.Root>
+		<Label { ...props }>Label</Label>
+	</Form.Root>
+);
+
+export const Default = () => {
+	return (
+		<>
+			<DefaultComponent />
+		</>
+	);
+};
+
+export const Required = () => {
+	const args = {
+		required: true,
+	};
+
+	return (
+		<>
+			<DefaultComponent { ...args } />
+		</>
+	);
+};

--- a/src/system/Form/RequiredLabel.js
+++ b/src/system/Form/RequiredLabel.js
@@ -1,0 +1,15 @@
+/** @jsxImportSource theme-ui */
+
+/**
+ * External dependencies
+ */
+
+/**
+ * Internal dependencies
+ */
+
+const RequiredLabel = () => (
+	<span sx={ { color: 'error', display: 'inline-block', ml: 2, fontSize: 1 } }>(Required)</span>
+);
+
+export { RequiredLabel };

--- a/src/system/NewForm/FormAutocomplete.js
+++ b/src/system/NewForm/FormAutocomplete.js
@@ -105,8 +105,9 @@ const FormAutocomplete = React.forwardRef(
 			onInputChange,
 			value,
 			showAllValues = true,
-			searchIcon = false,
-			loading = false,
+			searchIcon,
+			loading,
+			required,
 			displayMenu = 'overlay',
 			noOptionsMessage = () => 'No results found.',
 			id = 'vip-autocomplete',
@@ -117,7 +118,11 @@ const FormAutocomplete = React.forwardRef(
 	) => {
 		const [ isDirty, setIsDirty ] = useState( false );
 
-		const SelectLabel = () => <Label htmlFor={ forLabel || id }>{ label }</Label>;
+		const SelectLabel = () => (
+			<Label required={ required } htmlFor={ forLabel || id }>
+				{ label }
+			</Label>
+		);
 
 		const inlineLabel = !! ( isInline && label );
 
@@ -229,6 +234,7 @@ FormAutocomplete.propTypes = {
 	showAllValues: PropTypes.bool,
 	searchIcon: PropTypes.bool,
 	loading: PropTypes.bool,
+	required: PropTypes.bool,
 	isInline: PropTypes.bool,
 	forLabel: PropTypes.string,
 	value: PropTypes.string,

--- a/src/system/NewForm/FormAutocomplete.stories.jsx
+++ b/src/system/NewForm/FormAutocomplete.stories.jsx
@@ -44,7 +44,7 @@ const DefaultComponent = ( { label = 'Label', width = 250, ...rest } ) => (
 export const Default = () => {
 	return (
 		<>
-			<DefaultComponent { ...args } />
+			<DefaultComponent required { ...args } />
 		</>
 	);
 };

--- a/src/system/NewForm/FormSelect.js
+++ b/src/system/NewForm/FormSelect.js
@@ -58,6 +58,7 @@ const FormSelect = React.forwardRef(
 			placeholder,
 			forLabel,
 			options,
+			required,
 			label,
 			getOptionLabel,
 			getOptionValue,
@@ -105,7 +106,11 @@ const FormSelect = React.forwardRef(
 			[ onChange, getOptionByValue ]
 		);
 
-		const SelectLabel = () => <Label htmlFor={ forLabel || props.id }>{ label }</Label>;
+		const SelectLabel = () => (
+			<Label required={ required } htmlFor={ forLabel || props.id }>
+				{ label }
+			</Label>
+		);
 
 		const inlineLabel = !! ( isInline && label );
 
@@ -133,6 +138,7 @@ const FormSelect = React.forwardRef(
 FormSelect.propTypes = {
 	id: PropTypes.string,
 	isInline: PropTypes.bool,
+	required: PropTypes.bool,
 	forLabel: PropTypes.string,
 	placeholder: PropTypes.string,
 	label: PropTypes.string,

--- a/src/system/NewForm/FormSelect.stories.jsx
+++ b/src/system/NewForm/FormSelect.stories.jsx
@@ -70,6 +70,7 @@ const DefaultComponent = ( { label = 'Label', width = 250, onChange, ...rest } )
 export const Default = DefaultComponent.bind( {} );
 Default.args = {
 	placeholder: '- Select -',
+	required: true,
 	options,
 };
 

--- a/src/system/Wizard/Wizard.stories.jsx
+++ b/src/system/Wizard/Wizard.stories.jsx
@@ -8,12 +8,19 @@ import React from 'react';
 /**
  * Internal dependencies
  */
-import { Wizard, Box, Label, Input, Button } from '..';
+import { Wizard, Box, Label, Input, Button, Form } from '..';
 
 export default {
 	title: 'Wizard',
 	component: Wizard,
 };
+
+const options = [
+	{ value: 'chocolate', label: 'Chocolate' },
+	{ value: 'strawberry', label: 'Strawberry' },
+	{ value: 'vanilla', label: 'Vanilla' },
+	{ value: 'coffee', label: 'Coffee' },
+];
 
 export const Default = () => {
 	const steps = [
@@ -25,7 +32,8 @@ export const Default = () => {
 				<Box>
 					<Label>Domain</Label>
 					<Input autoFocus placeholder="yourdomain.com" />
-					<Button>Continue</Button>
+					<Form.Autocomplete label="Autocomplete" options={ options } />
+					<Button sx={ { mt: 3 } }>Continue</Button>
 				</Box>
 			),
 		},

--- a/src/system/Wizard/WizardStep.js
+++ b/src/system/Wizard/WizardStep.js
@@ -50,6 +50,7 @@ const WizardStep = React.forwardRef(
 					},
 					borderColor: active ? 'primary' : 'borders.2',
 					borderLeftColor: borderLeftColor,
+					overflow: 'inherit',
 				} }
 				data-step={ order }
 				data-active={ active || undefined }


### PR DESCRIPTION
## Description

### Label

Add `required` as a prop for Label component using RequiredLabel.
Add Label on storybook 

<img width="460" alt="image" src="https://user-images.githubusercontent.com/199867/204390941-7dd659d8-5eaf-4dcb-ad5c-dc61a7809e8e.png">

<img width="434" alt="image" src="https://user-images.githubusercontent.com/199867/204390904-c38961cb-c6b5-4ab7-939d-8b2502100d0a.png">

### Wizard

Fixed wizard overflow issue.


<img width="1813" alt="image" src="https://user-images.githubusercontent.com/199867/204411339-f5cf2efa-4223-480a-8088-3c5760ff4c71.png">

## Checklist

- [ ] This PR has good automated test coverage
- [x] The storybook for the component has been updated

## Steps to Test

1. Pull down PR.
1. `npm run dev`.
1. Open Storybook.
1. Verify Label default and required sections.
1. Verify if the section is hidden the step content (ie: with Autocomplete open).
