### PR TITLE
Fix the input placeholder color for a better contrast on light theme

### DIFF
--- a/src/system/Form/Input.js
+++ b/src/system/Form/Input.js
@@ -33,6 +33,7 @@ const inputStyles = {
 	},
 	'&::placeholder': {
 		color: 'placeholder',
+		opacity: 1,
 	},
 };
 

--- a/src/system/theme/generated/valet-theme.json
+++ b/src/system/theme/generated/valet-theme.json
@@ -96,7 +96,7 @@
     "placeholder": {
       "type": "color",
       "description": "Use for placeholder text in fields",
-      "value": "#8f8c8b"
+      "value": "#757575"
     },
     "disabled": {
       "type": "color",


### PR DESCRIPTION
## Description

Our current placeholder color has a lower contrast than 4.5 when using the Input background as white. This PR fixes the placeholder color with #757575, which is at least 4.6.

The design team might adjust this, but doing this now can fix a lot of issues for accessibility.

<img width="821" alt="image" src="https://user-images.githubusercontent.com/3402/205149121-9f068e03-5cbc-49cb-b9fd-5c10fd6b7992.png">

## Steps to Test

1. Pull down PR.
2. `npm run dev`.
3. Open http://localhost:6006/?path=/story/form-input--default
4. Inspect the Input CSS. The computed color for the placeholder should match #757575

<img width="503" alt="image" src="https://user-images.githubusercontent.com/3402/205149466-5929fd84-4828-4f4c-a9d4-d50f8e32860a.png">
