### PR TITLE
Fix/Autocomplete reload options

### DIFF
--- a/src/system/NewForm/FormAutocomplete.js
+++ b/src/system/NewForm/FormAutocomplete.js
@@ -106,6 +106,7 @@ const FormAutocomplete = React.forwardRef(
 			isInline,
 			label,
 			loading,
+			loadingMessage = () => 'Loading…',
 			minLength = 0,
 			noOptionsMessage = () => 'No results found.',
 			onChange = () => {},
@@ -179,7 +180,7 @@ const FormAutocomplete = React.forwardRef(
 					}, debounce );
 				}
 			},
-			[ onInputChange, debounce, minLength ]
+			[ onInputChange, debounce, minLength, id ]
 		);
 
 		const suggest = useCallback(
@@ -206,10 +207,18 @@ const FormAutocomplete = React.forwardRef(
 		}, [ label ] );
 
 		useEffect( () => {
+			// accessible-autocomplete was created to call suggest() method only when typing in the input filter or clicking to open the options
+			// to have compatibility with our approach, updating the options list when something updates the options (such as the graphql), we created this bind click to force-call suggest() method
+			if ( ! autoFilter && isDirty ) {
+				global.document.querySelector( `#${ id }` ).click();
+			}
+		}, [ autoFilter, options ] );
+
+		useEffect( () => {
 			global.document.querySelector( `#${ id }` ).addEventListener( 'keydown', () => {
 				setIsDirty( true );
 			} );
-		}, [ setIsDirty ] );
+		}, [ id, setIsDirty ] );
 
 		return (
 			<div className={ classNames( 'vip-form-autocomplete-component', className ) }>
@@ -236,7 +245,7 @@ const FormAutocomplete = React.forwardRef(
 							defaultValue={ value }
 							displayMenu={ displayMenu }
 							onConfirm={ onValueChange }
-							tNoResults={ noOptionsMessage }
+							tNoResults={ loading ? loadingMessage : noOptionsMessage }
 							{ ...props }
 						/>
 						{ loading && <FormSelectLoading /> }
@@ -260,6 +269,7 @@ FormAutocomplete.propTypes = {
 	isInline: PropTypes.bool,
 	label: PropTypes.string,
 	loading: PropTypes.bool,
+	loadingMessage: PropTypes.func,
 	minLength: PropTypes.number,
 	noOptionsMessage: PropTypes.func,
 	onChange: PropTypes.func,

--- a/src/system/NewForm/FormAutocomplete.stories.jsx
+++ b/src/system/NewForm/FormAutocomplete.stories.jsx
@@ -104,12 +104,19 @@ export const WithLoading = () => {
 
 export const WithDebounce = () => {
 	const [ value, setValue ] = useState( null );
+	const [ loading, setLoading ] = useState( null );
 	const customArgs = {
 		...args,
+		loading,
+		autoFilter: false,
 		minLength: 3,
 		debounce: 300,
 		onInputChange: query => {
+			setLoading( true );
 			setValue( query );
+			setTimeout( () => {
+				setLoading( false );
+			}, 2000 );
 		},
 	};
 


### PR DESCRIPTION
## Description

- `accessible-autocomplete` was created to call suggest() method only when typing in the input filter or clicking to open the options;
- To have compatibility with our approach, updating the options list when something updates the options (such as the graphql), we created this bind click to force-call `suggest()` method;
- Add loadingMessage to show loading message when graphql is loading;
- Special thanks to @djalmaaraujo for the testing today and the discussion about possible fixes;

<img width="545" alt="image" src="https://user-images.githubusercontent.com/199867/206040280-ec66c6ad-7abf-4ee2-ad67-1be154badabe.png">

## Checklist

- [ ] This PR has good automated test coverage
- [x] The storybook for the component has been updated

## Steps to Test

Outline the steps to test and verify the PR here.

Example:

1. Pull down PR.
1. `npm run dev`.
1. Open [Storybook](https://deploy-preview-154--vip-design-system-components.netlify.app/?path=/story/form-autocomplete--with-debounce).
1. Verify if loading is appearing to get the new options list from props.
