### PR TITLE
PIE-3476 - Update TabsTrigger component to use forwardRef

### DIFF
--- a/src/system/NewTabs/TabsTrigger.js
+++ b/src/system/NewTabs/TabsTrigger.js
@@ -3,6 +3,7 @@
 /**
  * External dependencies
  */
+import React from 'react';
 import PropTypes from 'prop-types';
 import * as TabsPrimitive from '@radix-ui/react-tabs';
 import classNames from 'classnames';
@@ -56,4 +57,5 @@ TabsTrigger.propTypes = {
 	children: PropTypes.node.isRequired,
 };
 
+TabsTrigger.displayName = 'TabsTrigger';
 export { TabsTrigger };

--- a/src/system/NewTabs/TabsTrigger.js
+++ b/src/system/NewTabs/TabsTrigger.js
@@ -42,6 +42,7 @@ const TabsTrigger = React.forwardRef( ( { value, disabled = false, sx, children 
 			...styles,
 			...sx,
 		} }
+		tabIndex="0"
 		ref={ forwardRef }
 	>
 		{ children }

--- a/src/system/NewTabs/TabsTrigger.js
+++ b/src/system/NewTabs/TabsTrigger.js
@@ -33,7 +33,7 @@ const styles = {
 	'&:focus-visible': theme => theme.outline,
 };
 
-const TabsTrigger = ( { value, disabled = false, sx, children } ) => (
+const TabsTrigger = React.forwardRef( ( { value, disabled = false, sx, children }, forwardRef ) => (
 	<TabsPrimitive.TabsTrigger
 		className={ classNames( 'vip-tabs-trigger', `vip-tabs-trigger-${ value }` ) }
 		value={ value }
@@ -42,10 +42,11 @@ const TabsTrigger = ( { value, disabled = false, sx, children } ) => (
 			...styles,
 			...sx,
 		} }
+		ref={ forwardRef }
 	>
 		{ children }
 	</TabsPrimitive.TabsTrigger>
-);
+) );
 
 TabsTrigger.propTypes = {
 	sx: PropTypes.object,


### PR DESCRIPTION
## Description

Updating the TabsTrigger component to forward refs to the child component so we can use the ref to manually focus on the element for accessibility.

Jira ticket: https://vipjira.atlassian.net/browse/PIE-3476
Related VIP Dashboard PR: https://github.com/Automattic/vip-dashboard/pull/2482

## Checklist

- [ ] This PR has good automated test coverage
- [ N/A ] The storybook for the component has been updated

## Steps to Test

1. Pull down PR.
1. `npm run dev`.
1. Open Storybook: http://localhost:6006/?path=/story/tabs--default