### PR TITLE
[PIE-3491] Button aria-disabled

### DIFF
--- a/src/system/Button/Button.js
+++ b/src/system/Button/Button.js
@@ -12,9 +12,11 @@ const Button = React.forwardRef( ( { disabled, onClick, sx, ...props }, forwardR
 	const handleOnClick = useCallback(
 		event => {
 			if ( disabled ) {
-				event.preventDefault();
-			} else if ( onClick ) {
-				onClick( event );
+				return event.preventDefault();
+			}
+
+			if ( onClick ) {
+				return onClick( event );
 			}
 		},
 		[ disabled, onClick ]

--- a/src/system/Button/Button.js
+++ b/src/system/Button/Button.js
@@ -32,7 +32,7 @@ const Button = React.forwardRef( ( { disabled, sx, ...props }, forwardRef ) => {
 				},
 				'&:focus': theme => theme.outline,
 				'&:focus-visible': theme => theme.outline,
-				'&:disabled': {
+				'&[aria-disabled]': {
 					opacity: 0.7,
 					cursor: 'not-allowed',
 					pointerEvents: 'all',

--- a/src/system/Button/Button.js
+++ b/src/system/Button/Button.js
@@ -8,14 +8,16 @@ import PropTypes from 'prop-types';
 import classNames from 'classnames';
 import { Button as ThemeButton } from 'theme-ui';
 
-const Button = React.forwardRef( ( { disabled, sx, ...props }, forwardRef ) => {
-	const onClick = useCallback(
+const Button = React.forwardRef( ( { disabled, onClick, sx, ...props }, forwardRef ) => {
+	const handleOnClick = useCallback(
 		event => {
 			if ( disabled ) {
 				event.preventDefault();
+			} else if ( onClick ) {
+				onClick( event );
 			}
 		},
-		[ disabled ]
+		[ disabled, onClick ]
 	);
 	return (
 		<ThemeButton
@@ -32,16 +34,16 @@ const Button = React.forwardRef( ( { disabled, sx, ...props }, forwardRef ) => {
 				},
 				'&:focus': theme => theme.outline,
 				'&:focus-visible': theme => theme.outline,
-				'&[aria-disabled]': {
+				'&[aria-disabled="true"]': {
 					opacity: 0.7,
 					cursor: 'not-allowed',
 					pointerEvents: 'all',
 				},
 				...sx,
 			} }
-			className={ classNames( 'vip-button-component', props.className ) }
 			aria-disabled={ disabled }
-			onClick={ onClick }
+			className={ classNames( 'vip-button-component', props.className ) }
+			onClick={ handleOnClick }
 			{ ...props }
 			ref={ forwardRef }
 		/>
@@ -51,9 +53,10 @@ const Button = React.forwardRef( ( { disabled, sx, ...props }, forwardRef ) => {
 Button.displayName = 'Button';
 
 Button.propTypes = {
-	disabled: PropTypes.bool,
-	sx: PropTypes.object,
 	className: PropTypes.any,
+	disabled: PropTypes.bool,
+	onClick: PropTypes.func,
+	sx: PropTypes.object,
 };
 
 export { Button };

--- a/src/system/Button/Button.js
+++ b/src/system/Button/Button.js
@@ -3,42 +3,55 @@
 /**
  * External dependencies
  */
-import React from 'react';
+import React, { useCallback } from 'react';
 import PropTypes from 'prop-types';
 import classNames from 'classnames';
 import { Button as ThemeButton } from 'theme-ui';
 
-const Button = React.forwardRef( ( { sx, ...props }, forwardRef ) => (
-	<ThemeButton
-		sx={ {
-			verticalAlign: 'middle',
-			display: 'inline-flex',
-			alignItems: 'center',
-			justifyContent: 'center',
-			height: '36px',
-			py: 0,
-			textDecoration: 'none',
-			'&:hover': {
+const Button = React.forwardRef( ( { disabled, sx, ...props }, forwardRef ) => {
+	const onClick = useCallback(
+		event => {
+			if ( disabled ) {
+				event.preventDefault();
+			}
+		},
+		[ disabled ]
+	);
+	return (
+		<ThemeButton
+			sx={ {
+				verticalAlign: 'middle',
+				display: 'inline-flex',
+				alignItems: 'center',
+				justifyContent: 'center',
+				height: '36px',
+				py: 0,
 				textDecoration: 'none',
-			},
-			'&:focus': theme => theme.outline,
-			'&:focus-visible': theme => theme.outline,
-			'&:disabled': {
-				opacity: 0.7,
-				cursor: 'not-allowed',
-				pointerEvents: 'all',
-			},
-			...sx,
-		} }
-		className={ classNames( 'vip-button-component', props.className ) }
-		{ ...props }
-		ref={ forwardRef }
-	/>
-) );
+				'&:hover': {
+					textDecoration: 'none',
+				},
+				'&:focus': theme => theme.outline,
+				'&:focus-visible': theme => theme.outline,
+				'&:disabled': {
+					opacity: 0.7,
+					cursor: 'not-allowed',
+					pointerEvents: 'all',
+				},
+				...sx,
+			} }
+			className={ classNames( 'vip-button-component', props.className ) }
+			aria-disabled={ disabled }
+			onClick={ onClick }
+			{ ...props }
+			ref={ forwardRef }
+		/>
+	);
+} );
 
 Button.displayName = 'Button';
 
 Button.propTypes = {
+	disabled: PropTypes.bool,
 	sx: PropTypes.object,
 	className: PropTypes.any,
 };

--- a/src/system/Button/Button.stories.jsx
+++ b/src/system/Button/Button.stories.jsx
@@ -1,7 +1,6 @@
 /**
  * External dependencies
  */
-import React from 'react';
 
 /**
  * Internal dependencies
@@ -11,16 +10,33 @@ import { Button } from '..';
 export default {
 	title: 'Button',
 	component: Button,
+	argTypes: {
+		children: {
+			table: {
+				type: { summary: 'node' },
+			},
+			control: { type: 'text' },
+			type: { required: true },
+		},
+		variant: {
+			table: {
+				type: { summary: 'string' },
+				defaultValue: { summary: 'primary' },
+			},
+			control: {
+				type: 'select',
+				options: [ 'primary', 'secondary', 'text' ],
+			},
+		},
+	},
 };
 
-export const Default = () => (
-	<React.Fragment>
-		<Button sx={ { mr: 2 } }>Primary</Button>
-		<Button variant="secondary" sx={ { ml: 2 } }>
-			Secondary
-		</Button>
-		<Button variant="text" sx={ { ml: 2 } } as="a" href="https://google/com">
-			Button link
-		</Button>
-	</React.Fragment>
-);
+const Template = args => <Button { ...args }>Submit</Button>;
+
+export const Default = Template.bind( {} );
+
+export const Link = Template.bind( {} );
+Link.args = {
+	as: 'a',
+	href: 'https://www.google.com',
+};

--- a/src/system/Button/Button.stories.jsx
+++ b/src/system/Button/Button.stories.jsx
@@ -40,3 +40,11 @@ Link.args = {
 	as: 'a',
 	href: 'https://www.google.com',
 };
+
+export const WithOnClick = Template.bind( {} );
+Link.args = {
+	onClick: () => {
+		// eslint-disable-next-line no-undef
+		alert( 'Clicked' );
+	},
+};

--- a/src/system/Button/Button.stories.jsx
+++ b/src/system/Button/Button.stories.jsx
@@ -37,6 +37,7 @@ export const Default = Template.bind( {} );
 
 export const Link = Template.bind( {} );
 Link.args = {
+	variant: 'text',
 	as: 'a',
 	href: 'https://www.google.com',
 };

--- a/src/system/Button/Button.test.js
+++ b/src/system/Button/Button.test.js
@@ -1,7 +1,7 @@
 /**
  * External dependencies
  */
-import { render, screen } from '@testing-library/react';
+import { fireEvent, render, screen } from '@testing-library/react';
 import { axe } from 'jest-axe';
 
 /**
@@ -9,23 +9,38 @@ import { axe } from 'jest-axe';
  */
 import { Button } from './Button';
 
+const BUTTON_TEXT = 'Button Text';
+
 describe( '<Button />', () => {
 	it( 'renders the Button component', async () => {
-		const { container } = render( <Button>Button text</Button> );
+		const onClick = jest.fn( () => {} );
+		const { container } = render( <Button onClick={ onClick }>{ BUTTON_TEXT }</Button> );
+		const component = screen.getByText( BUTTON_TEXT );
 
-		expect( screen.getByText( 'Button text' ) ).toBeInTheDocument();
+		expect( component ).toBeInTheDocument();
+
+		fireEvent.click( component );
+		expect( onClick ).toHaveBeenCalledTimes( 1 );
 
 		// Check for accessibility issues
 		await expect( await axe( container ) ).toHaveNoViolations();
 	} );
 
 	it( 'renders the Button with aria-disabled prop', async () => {
-		const { container } = render( <Button disabled>Button text</Button> );
-		const component = screen.getByText( 'Button text' );
+		const onClick = jest.fn( () => {} );
+		const { container } = render(
+			<Button disabled onClick={ onClick }>
+				{ BUTTON_TEXT }
+			</Button>
+		);
+		const component = screen.getByText( BUTTON_TEXT );
 
 		expect( component ).toBeInTheDocument();
 		expect( component ).toHaveAttribute( 'aria-disabled', 'true' );
 		expect( component ).not.toHaveAttribute( 'disabled' );
+
+		fireEvent.click( component );
+		expect( onClick ).toHaveBeenCalledTimes( 0 );
 
 		// Check for accessibility issues
 		await expect( await axe( container ) ).toHaveNoViolations();

--- a/src/system/Button/Button.test.js
+++ b/src/system/Button/Button.test.js
@@ -26,7 +26,7 @@ describe( '<Button />', () => {
 		await expect( await axe( container ) ).toHaveNoViolations();
 	} );
 
-	it( 'renders the Button with aria-disabled prop', async () => {
+	it( 'renders the Button with disabled prop', async () => {
 		const onClick = jest.fn( () => {} );
 		const { container } = render(
 			<Button disabled onClick={ onClick }>

--- a/src/system/Button/Button.test.js
+++ b/src/system/Button/Button.test.js
@@ -18,4 +18,16 @@ describe( '<Button />', () => {
 		// Check for accessibility issues
 		await expect( await axe( container ) ).toHaveNoViolations();
 	} );
+
+	it( 'renders the Button with aria-disabled prop', async () => {
+		const { container } = render( <Button disabled>Button text</Button> );
+		const component = screen.getByText( 'Button text' );
+
+		expect( component ).toBeInTheDocument();
+		expect( component ).toHaveAttribute( 'aria-disabled', 'true' );
+		expect( component ).not.toHaveAttribute( 'disabled' );
+
+		// Check for accessibility issues
+		await expect( await axe( container ) ).toHaveNoViolations();
+	} );
 } );


### PR DESCRIPTION
## Description

https://vipjira.atlassian.net/browse/PIE-3491?atlOrigin=eyJpIjoiMTQ1OTRiYjNlNTI0NDc5Nzk5NGYyYjNmNjAxZjg4NDMiLCJwIjoiaiJ9

- I also added the controls to the Button storybook. Now, we can control the props to test them.

### References

https://a11y-101.com/development/aria-disabled
https://www.smashingmagazine.com/2021/08/frustrating-design-patterns-disabled-buttons/
https://css-tricks.com/making-disabled-buttons-more-inclusive/


## Checklist

- [x] This PR has good automated test coverage
- [x] The storybook for the component has been updated

## Steps to Test

1. Pull down PR.
1. `npm run dev`.
1. Open Storybook > https://deploy-preview-160--vip-design-system-components.netlify.app/?path=/story/button--default&args=disabled:true
1. Open Controls tab and set "disabled" as true. Click on the button and you should not be redirected to google
1. Set "disabled" as false. Click on the button and you should redirected to google
