### PR TITLE
Fix Form Autocomplete to filter only dirty inputs

### DIFF
--- a/src/system/NewForm/FormAutocomplete.js
+++ b/src/system/NewForm/FormAutocomplete.js
@@ -185,13 +185,16 @@ const FormAutocomplete = React.forwardRef(
 
 		const suggest = useCallback(
 			( query, populateResults ) => {
+				let data = options;
 				if ( isDirty && onInputChange ) {
 					handleInputChange( query );
 				}
-				const data = autoFilter ? handleTypeChange( query ) : options;
+				if ( isDirty && autoFilter ) {
+					data = handleTypeChange( query );
+				}
 				populateResults( data?.map( option => optionLabel( option ) ) );
 			},
-			[ options, isDirty ]
+			[ autoFilter, isDirty, onInputChange, options ]
 		);
 
 		useEffect( () => {


### PR DESCRIPTION
## Description

FIX: `autoFilter`prop should filter options, only when the user types something in the input (when the input is not dirty).

## Checklist

- [ ] This PR has good automated test coverage
- [ ] The storybook for the component has been updated

## Steps to Test

1. Pull down PR.
1. `npm run dev`.
1. Open Storybook.
1. Verify if Autocomplete will filter the options when you type something.
