### PR TITLE
Add hasErrors support to Form.Autocomplete

### DIFF
--- a/src/system/NewForm/FormAutocomplete.js
+++ b/src/system/NewForm/FormAutocomplete.js
@@ -18,6 +18,7 @@ import { Label } from '../Form/Label';
 import { FormSelectSearch } from './FormSelectSearch';
 import { FormSelectLoading } from './FormSelectLoading';
 import { baseControlBorderStyle, inputBaseBackground, inputBaseText } from '../Form/Input.styles';
+import { Validation } from '../Form';
 
 const baseBorderTextColors = {
 	...baseControlBorderStyle,
@@ -115,6 +116,8 @@ const FormAutocomplete = React.forwardRef(
 			showAllValues = true,
 			source,
 			value,
+			hasError,
+			errorMessage,
 			...props
 		},
 		forwardRef
@@ -246,6 +249,12 @@ const FormAutocomplete = React.forwardRef(
 						<FormSelectArrow />
 					</FormSelectContent>
 				</div>
+
+				{ hasError && errorMessage && (
+					<Validation isValid={ false } describedId={ forLabel }>
+						{ errorMessage }
+					</Validation>
+				) }
 			</div>
 		);
 	}
@@ -273,6 +282,8 @@ FormAutocomplete.propTypes = {
 	showAllValues: PropTypes.bool,
 	source: PropTypes.func,
 	value: PropTypes.string,
+	hasError: PropTypes.bool,
+	errorMessage: PropTypes.string,
 };
 
 FormAutocomplete.displayName = 'FormAutocomplete';

--- a/src/system/NewForm/FormAutocomplete.stories.jsx
+++ b/src/system/NewForm/FormAutocomplete.stories.jsx
@@ -134,3 +134,16 @@ export const WithCustomMessages = () => {
 		</>
 	);
 };
+export const WithErrors = () => {
+	const customArgs = {
+		...args,
+		hasError: true,
+		errorMessage: 'Please select a value',
+	};
+
+	return (
+		<>
+			<DefaultComponent { ...customArgs } />
+		</>
+	);
+};


### PR DESCRIPTION
## Description
<img width="234" alt=" Autocomplete - With Errors ⋅ Storybook 2023-01-19 12-39-32" src="https://user-images.githubusercontent.com/668251/213433155-b71b16f4-12f8-4527-bc27-977c272883d8.png">


Right now the autocomplete element didn't have a way to show hints.
This PR adds that to the autocomplete.

## Checklist

- [ ] This PR has good automated test coverage
- [X] The storybook for the component has been updated

## Steps to Test

1. Pull down PR.
1. `npm run dev`.
1. Open Storybook http://localhost:6006/?path=/story/form-autocomplete--with-errors and check that the error is shown correctly. 
