### PR TITLE
Add hasError support in FormSelect

### DIFF
--- a/src/system/NewForm/FormSelect.js
+++ b/src/system/NewForm/FormSelect.js
@@ -13,6 +13,7 @@ import { Label } from '../Form/Label';
 import { FormSelectArrow } from './FormSelectArrow';
 import { FormSelectContent } from './FormSelectContent';
 import { baseControlStyle } from '../Form/Input.styles';
+import { Validation } from '../Form';
 
 const MAX_SUGGESTED_OPTIONS = 15;
 const isDev = process.env.NODE_ENV !== 'production';
@@ -55,6 +56,8 @@ const FormSelect = React.forwardRef(
 			getOptionLabel,
 			getOptionValue,
 			onChange,
+			hasError,
+			errorMessage,
 			...props
 		},
 		forwardRef
@@ -119,9 +122,14 @@ const FormSelect = React.forwardRef(
 								: renderOption( optionLabel( option ), optionValue( option ) )
 						) }
 					</select>
-
 					<FormSelectArrow />
 				</FormSelectContent>
+
+				{ hasError && errorMessage && (
+					<Validation isValid={ false } describedId={ forLabel }>
+						{ errorMessage }
+					</Validation>
+				) }
 			</>
 		);
 	}
@@ -137,6 +145,8 @@ FormSelect.propTypes = {
 	options: PropTypes.array,
 	getOptionLabel: PropTypes.func,
 	getOptionValue: PropTypes.func,
+	hasError: PropTypes.bool,
+	errorMessage: PropTypes.string,
 	onChange: PropTypes.func,
 };
 

--- a/src/system/NewForm/FormSelect.stories.jsx
+++ b/src/system/NewForm/FormSelect.stories.jsx
@@ -75,6 +75,15 @@ Default.args = {
 	options,
 };
 
+export const WithErrors = DefaultComponent.bind( {} );
+WithErrors.args = {
+	placeholder: '- Select -',
+	required: true,
+	hasError: true,
+	errorMessage: 'This is an error message',
+	options,
+};
+
 export const WithGroup = DefaultComponent.bind( {} );
 
 WithGroup.args = {

--- a/src/system/NewForm/FormSelect.test.js
+++ b/src/system/NewForm/FormSelect.test.js
@@ -48,6 +48,27 @@ describe( '<FormSelect />', () => {
 		await expect( await axe( container ) ).toHaveNoViolations();
 	} );
 
+	it( 'renders the FormSelect component with an error if hasError=true', async () => {
+		const errorMessage = 'This is an error message';
+		const { container } = render(
+			<FormSelect
+				id="my_desert_list"
+				hasError={ true }
+				errorMessage={ errorMessage }
+				{ ...defaultProps }
+			/>
+		);
+
+		expect( screen.getByLabelText( defaultProps.label ) ).toBeInTheDocument();
+		expect( screen.getByRole( 'combobox' ) ).toBeInTheDocument();
+		expect( screen.getAllByRole( 'option' ) ).toHaveLength( 3 );
+		expect( screen.queryByRole( 'group' ) ).not.toBeInTheDocument();
+		expect( screen.getByText( errorMessage ) ).toBeInTheDocument();
+
+		// Check for accessibility issues
+		await expect( await axe( container ) ).toHaveNoViolations();
+	} );
+
 	it( 'renders the FormSelect component with optgroup when options are grouped', async () => {
 		const { container } = render( <FormSelect id="my_desert_list" { ...groupedProps } /> );
 


### PR DESCRIPTION
## Description
<img width="335" alt="Screenshot Form  Select - With Errors ⋅ Storybook 2023-01-23 16-44-40(1)" src="https://user-images.githubusercontent.com/668251/214083199-718c66d8-8fcd-4bd6-953d-f1f8baf418aa.png">

This PR introduces error support in the FormSelect

## Checklist

- [X] This PR has good automated test coverage
- [X] The storybook for the component has been updated

## Steps to Test

Outline the steps to test and verify the PR here.

Example:

1. Pull down PR.
1. `npm run dev`.
1. Open Storybook http://localhost:6006/?path=/story/form-select--with-errors and check that the errors are shown
1. `npm t` should pass. 
