### PR TITLE
Fix spinner color

### DIFF
--- a/src/system/Spinner/Spinner.js
+++ b/src/system/Spinner/Spinner.js
@@ -13,7 +13,7 @@ const Spinner = React.forwardRef( ( { sx, className = null, ...props }, forwardR
 		strokeWidth={ 2 }
 		sx={ {
 			fill: 'none',
-			color: 'icon.primary',
+			color: 'link',
 		} }
 		className={ classNames( 'vip-spinner-component', className ) }
 		ref={ forwardRef }


### PR DESCRIPTION
## Description

We need to keep the Spinner as the link color. Looks like the link color is the most efficient for all situations.

## Checklist

- [ ] This PR has good automated test coverage
- [ ] The storybook for the component has been updated

## Steps to Test

1. Pull down PR.
2. `npm run dev`.
3. Open the [Spinner](http://localhost:6006/?path=/story/spinner--default) story. it should be orange as the link color
