### PR TITLE
A11Y - remove hover effect from badge

### DIFF
--- a/src/system/Badge/Badge.js
+++ b/src/system/Badge/Badge.js
@@ -27,16 +27,13 @@ const Badge = React.forwardRef(
 				display: 'inline-block',
 				borderRadius: 1,
 				fontWeight: 'heading',
-				'&:hover, &:focus': {
-					backgroundColor: `tag.${ variant }.hover`,
-				},
 				a: {
 					color: `tag.${ variant }.text`,
 					'&:hover, &:focus, &:active': {
 						textDecoration: 'none',
 					},
-					'&:active': {
-						color: `${ variant }.active`,
+					'&:active, &:visited': {
+						color: `tag.${ variant }.text`,
 					},
 				},
 				...sx,

--- a/src/system/Button/ButtonSubmit.js
+++ b/src/system/Button/ButtonSubmit.js
@@ -63,7 +63,7 @@ export const ButtonSubmit = React.forwardRef(
 ButtonSubmit.displayName = 'ButtonSubmit';
 
 ButtonSubmit.propTypes = {
-	label: PropTypes.string.isRequired,
+	label: PropTypes.node.isRequired,
 	disabled: PropTypes.bool,
 	loading: PropTypes.bool,
 	variant: PropTypes.oneOf( variants ),


### PR DESCRIPTION
## Description

<img width="1012" alt="image" src="https://user-images.githubusercontent.com/3402/214680079-f90d7463-aa4d-412e-bb52-ce624791766e.png">


Per A11Y recommendation:

"The usage by application app has labels "Inactive", these labels are not clickable, but they do have a hover state, which would indicate that they are clickable. Remove the hover state."

## Checklist

- [ ] This PR has good automated test coverage
- [ ] The storybook for the component has been updated

## Steps to Test

1. Pull down PR.
2. `npm run dev`.
3. Open http://localhost:6006/?path=/story/badge--default
4. Regular badge without links has no hover effect
