### PR TITLE
Forms/errors and describedby

### DIFF
--- a/src/system/Button/Button.stories.jsx
+++ b/src/system/Button/Button.stories.jsx
@@ -9,7 +9,7 @@ import { BiCalendarHeart } from 'react-icons/bi';
  */
 import ScreenReaderText from '../ScreenReaderText';
 import { Button } from '..';
-import { variants } from '.';
+import variants from './variants';
 
 export default {
 	title: 'Button',

--- a/src/system/Button/ButtonSubmit.js
+++ b/src/system/Button/ButtonSubmit.js
@@ -31,17 +31,12 @@ export const ButtonSubmit = React.forwardRef(
 			disabled = false,
 			loadingIcon = DefaultSpinner,
 			loadingIconSize = 20,
-			loadingIconColor = undefined,
 			...rest
 		},
 		forwardRef
 	) => {
 		if ( ! show ) {
 			return null;
-		}
-
-		if ( ! loadingIconColor && variant === 'display' ) {
-			loadingIconColor = 'button.display.label.default';
 		}
 
 		return (
@@ -71,5 +66,4 @@ ButtonSubmit.propTypes = {
 	show: PropTypes.bool,
 	loadingIcon: PropTypes.any,
 	loadingIconSize: PropTypes.number,
-	loadingIconColor: PropTypes.string,
 };

--- a/src/system/Button/ButtonSubmit.js
+++ b/src/system/Button/ButtonSubmit.js
@@ -8,7 +8,7 @@ import PropTypes from 'prop-types';
 import { Button } from './Button';
 import { Spinner } from '../Spinner';
 import classNames from 'classnames';
-import { variants } from '.';
+import variants from './variants';
 
 const DefaultSpinner = ( { size, color = 'link' } ) => (
 	<Spinner size={ size } sx={ { ml: 2, color } } className="vip-button-submit-spinner" />
@@ -25,7 +25,7 @@ export const ButtonSubmit = React.forwardRef(
 	(
 		{
 			show = true,
-			variant = 'secondary',
+			variant = variants[ 1 ],
 			label,
 			loading = false,
 			disabled = false,
@@ -54,7 +54,8 @@ export const ButtonSubmit = React.forwardRef(
 				{ ...rest }
 			>
 				{ label }{ ' ' }
-				{ !! loading && loadingIcon( { size: loadingIconSize, color: loadingIconColor } ) }
+				{ !! loading &&
+					loadingIcon( { size: loadingIconSize, color: `button.${ variant }.label.default` } ) }
 			</Button>
 		);
 	}

--- a/src/system/Button/ButtonSubmit.stories.jsx
+++ b/src/system/Button/ButtonSubmit.stories.jsx
@@ -7,7 +7,7 @@ import React from 'react';
  * Internal dependencies
  */
 import { ButtonSubmit } from '..';
-import { variants } from '.';
+import variants from './variants';
 
 export default {
 	title: 'ButtonSubmit',

--- a/src/system/Button/index.js
+++ b/src/system/Button/index.js
@@ -2,18 +2,7 @@
  * Internal dependencies
  */
 
-const variants = [
-	'primary',
-	'secondary',
-	'text',
-	'icon',
-	'tertiary',
-	'ghost',
-	'danger',
-	'display',
-];
-
 import { Button } from './Button';
 import { ButtonSubmit } from './ButtonSubmit';
 
-export { Button, ButtonSubmit, variants };
+export { Button, ButtonSubmit };

--- a/src/system/Button/variants.js
+++ b/src/system/Button/variants.js
@@ -1,0 +1,1 @@
+export default [ 'primary', 'secondary', 'text', 'icon', 'tertiary', 'ghost', 'danger', 'display' ];

--- a/src/system/Form/Input.js
+++ b/src/system/Form/Input.js
@@ -38,6 +38,7 @@ const Input = React.forwardRef(
 				ref={ ref }
 				id={ forLabel }
 				required={ required }
+				aria-required={ required }
 				aria-describedby={ hasError ? `describe-${ forLabel }-validation` : undefined }
 				sx={ { ...inputStyles, ...sx } }
 				{ ...props }

--- a/src/system/Form/Radio.js
+++ b/src/system/Form/Radio.js
@@ -183,12 +183,12 @@ const Radio = React.forwardRef(
 Radio.displayName = 'Radio';
 
 Radio.propTypes = {
-	disabled: PropTypes.bool,
+	className: PropTypes.any,
 	defaultValue: PropTypes.any,
+	disabled: PropTypes.bool,
+	name: PropTypes.string,
 	onChange: PropTypes.func,
 	options: PropTypes.any,
-	name: PropTypes.string,
-	className: PropTypes.any,
 };
 
 export { Radio };

--- a/src/system/NewForm/FormAutocomplete.js
+++ b/src/system/NewForm/FormAutocomplete.js
@@ -211,6 +211,12 @@ const FormAutocomplete = React.forwardRef(
 		}, [ label ] );
 
 		useEffect( () => {
+			const input = global.document.querySelector( `#${ forLabel }` );
+
+			input.setAttribute( 'aria-required', required );
+		}, [ required ] );
+
+		useEffect( () => {
 			global.document.querySelector( `#${ forLabel }` ).addEventListener( 'keydown', () => {
 				setIsDirty( true );
 			} );
@@ -254,7 +260,6 @@ const FormAutocomplete = React.forwardRef(
 							onConfirm={ onValueChange }
 							tNoResults={ noOptionsMessage }
 							required={ required }
-							aria-required={ required }
 							{ ...props }
 						/>
 						{ loading && <FormSelectLoading /> }

--- a/src/system/NewForm/FormAutocomplete.js
+++ b/src/system/NewForm/FormAutocomplete.js
@@ -213,6 +213,10 @@ const FormAutocomplete = React.forwardRef(
 		useEffect( () => {
 			const input = global.document.querySelector( `#${ forLabel }` );
 
+			if ( ! input || required === undefined ) {
+				return;
+			}
+
 			input.setAttribute( 'aria-required', required );
 		}, [ required ] );
 
@@ -226,7 +230,7 @@ const FormAutocomplete = React.forwardRef(
 		useEffect( () => {
 			const input = global.document.querySelector( `#${ forLabel }` );
 
-			input.setAttribute(
+			input?.setAttribute(
 				'aria-describedby',
 				`describe-${ forLabel }-validation ${ input.getAttribute( 'aria-describedby' ) }`
 			);

--- a/src/system/NewForm/FormAutocomplete.js
+++ b/src/system/NewForm/FormAutocomplete.js
@@ -99,10 +99,9 @@ const FormAutocomplete = React.forwardRef(
 			className,
 			debounce = 0,
 			displayMenu = 'overlay',
-			forLabel,
+			forLabel = 'vip-autocomplete',
 			getOptionLabel,
 			getOptionValue,
-			id = 'vip-autocomplete',
 			isInline,
 			label,
 			loading,
@@ -126,7 +125,7 @@ const FormAutocomplete = React.forwardRef(
 		let debounceTimeout;
 
 		const SelectLabel = () => (
-			<Label required={ required } htmlFor={ forLabel || id }>
+			<Label required={ required } htmlFor={ forLabel }>
 				{ label }
 			</Label>
 		);
@@ -212,10 +211,20 @@ const FormAutocomplete = React.forwardRef(
 		}, [ label ] );
 
 		useEffect( () => {
-			global.document.querySelector( `#${ id }` ).addEventListener( 'keydown', () => {
+			global.document.querySelector( `#${ forLabel }` ).addEventListener( 'keydown', () => {
 				setIsDirty( true );
 			} );
 		}, [ setIsDirty ] );
+
+		// For accessibility, we need to add the error message to the aria-describedby attribute
+		useEffect( () => {
+			const input = global.document.querySelector( `#${ forLabel }` );
+
+			input.setAttribute(
+				'aria-describedby',
+				`describe-${ forLabel }-validation ${ input.getAttribute( 'aria-describedby' ) }`
+			);
+		}, [] );
 
 		return (
 			<div className={ classNames( 'vip-form-autocomplete-component', className ) }>
@@ -233,8 +242,9 @@ const FormAutocomplete = React.forwardRef(
 						label={ inlineLabel ? <SelectLabel /> : null }
 					>
 						{ searchIcon && <FormSelectSearch /> }
+
 						<Autocomplete
-							id={ id }
+							id={ forLabel }
 							aria-busy={ loading }
 							showAllValues={ showAllValues }
 							ref={ forwardRef }
@@ -243,6 +253,8 @@ const FormAutocomplete = React.forwardRef(
 							displayMenu={ displayMenu }
 							onConfirm={ onValueChange }
 							tNoResults={ noOptionsMessage }
+							required={ required }
+							aria-required={ required }
 							{ ...props }
 						/>
 						{ loading && <FormSelectLoading /> }
@@ -265,10 +277,11 @@ FormAutocomplete.propTypes = {
 	className: PropTypes.any,
 	debounce: PropTypes.number,
 	displayMenu: PropTypes.string,
+	errorMessage: PropTypes.string,
 	forLabel: PropTypes.string,
 	getOptionLabel: PropTypes.func,
 	getOptionValue: PropTypes.func,
-	id: PropTypes.string,
+	hasError: PropTypes.bool,
 	isInline: PropTypes.bool,
 	label: PropTypes.string,
 	loading: PropTypes.bool,
@@ -282,8 +295,6 @@ FormAutocomplete.propTypes = {
 	showAllValues: PropTypes.bool,
 	source: PropTypes.func,
 	value: PropTypes.string,
-	hasError: PropTypes.bool,
-	errorMessage: PropTypes.string,
 };
 
 FormAutocomplete.displayName = 'FormAutocomplete';

--- a/src/system/NewForm/FormAutocomplete.stories.jsx
+++ b/src/system/NewForm/FormAutocomplete.stories.jsx
@@ -36,7 +36,7 @@ const DefaultComponent = ( { label = 'Label', width = 250, ...rest } ) => (
 	<>
 		<Form.Root>
 			<div sx={ { width } }>
-				<Form.Autocomplete id="form-autocomplete" label={ label } { ...rest } />
+				<Form.Autocomplete forLabel="form-autocomplete" label={ label } { ...rest } />
 			</div>
 		</Form.Root>
 	</>
@@ -138,7 +138,8 @@ export const WithErrors = () => {
 	const customArgs = {
 		...args,
 		hasError: true,
-		errorMessage: 'Please select a value',
+		errorMessage: 'Please select a value.',
+		required: true,
 	};
 
 	return (

--- a/src/system/NewForm/FormAutocomplete.test.js
+++ b/src/system/NewForm/FormAutocomplete.test.js
@@ -23,7 +23,7 @@ const defaultProps = {
 describe( '<FormAutocomplete />', () => {
 	it( 'renders the FormAutocomplete component', async () => {
 		const { container } = render(
-			<FormAutocomplete id="my_desert_list" label="This is a label" />
+			<FormAutocomplete forLabel="my_desert_list" label="This is a label" />
 		);
 
 		// Check for accessibility issues
@@ -31,7 +31,9 @@ describe( '<FormAutocomplete />', () => {
 	} );
 
 	it( 'renders the FormAutocomplete component with options', async () => {
-		const { container } = render( <FormAutocomplete id="my_desert_list" { ...defaultProps } /> );
+		const { container } = render(
+			<FormAutocomplete forLabel="my_desert_list" { ...defaultProps } />
+		);
 
 		expect( screen.getByLabelText( defaultProps.label ) ).toBeInTheDocument();
 

--- a/src/system/NewForm/FormSelect.js
+++ b/src/system/NewForm/FormSelect.js
@@ -49,7 +49,7 @@ const FormSelect = React.forwardRef(
 		{
 			isInline,
 			placeholder,
-			forLabel,
+			forLabel = 'vip-form-select',
 			options,
 			required,
 			label,

--- a/src/system/NewForm/FormSelect.js
+++ b/src/system/NewForm/FormSelect.js
@@ -144,18 +144,18 @@ const FormSelect = React.forwardRef(
 );
 
 FormSelect.propTypes = {
-	id: PropTypes.string,
-	isInline: PropTypes.bool,
-	required: PropTypes.bool,
+	errorMessage: PropTypes.string,
 	forLabel: PropTypes.string,
-	placeholder: PropTypes.string,
-	label: PropTypes.string,
-	options: PropTypes.array,
 	getOptionLabel: PropTypes.func,
 	getOptionValue: PropTypes.func,
 	hasError: PropTypes.bool,
-	errorMessage: PropTypes.string,
+	id: PropTypes.string,
+	isInline: PropTypes.bool,
+	label: PropTypes.string,
 	onChange: PropTypes.func,
+	options: PropTypes.array,
+	placeholder: PropTypes.string,
+	required: PropTypes.bool,
 };
 
 FormSelect.displayName = 'FormSelect';

--- a/src/system/NewForm/FormSelect.js
+++ b/src/system/NewForm/FormSelect.js
@@ -121,6 +121,7 @@ const FormSelect = React.forwardRef(
 						required={ required }
 						aria-required={ required }
 						aria-describedby={ hasError ? `describe-${ forLabel }-validation` : undefined }
+						id={ forLabel }
 						{ ...props }
 					>
 						{ placeholder && <option>{ placeholder }</option> }

--- a/src/system/NewForm/FormSelect.js
+++ b/src/system/NewForm/FormSelect.js
@@ -114,7 +114,15 @@ const FormSelect = React.forwardRef(
 				{ label && ! isInline && <SelectLabel /> }
 
 				<FormSelectContent isInline={ inlineLabel } label={ inlineLabel ? <SelectLabel /> : null }>
-					<select onChange={ onValueChange } ref={ forwardRef } sx={ defaultStyles } { ...props }>
+					<select
+						onChange={ onValueChange }
+						ref={ forwardRef }
+						sx={ defaultStyles }
+						required={ required }
+						aria-required={ required }
+						aria-describedby={ hasError ? `describe-${ forLabel }-validation` : undefined }
+						{ ...props }
+					>
 						{ placeholder && <option>{ placeholder }</option> }
 						{ options.map( ( { options: groupOptions, ...option } ) =>
 							groupOptions

--- a/src/system/NewForm/FormSelect.js
+++ b/src/system/NewForm/FormSelect.js
@@ -102,7 +102,7 @@ const FormSelect = React.forwardRef(
 		);
 
 		const SelectLabel = () => (
-			<Label required={ required } htmlFor={ forLabel || props.id }>
+			<Label required={ required } htmlFor={ forLabel }>
 				{ label }
 			</Label>
 		);
@@ -149,7 +149,6 @@ FormSelect.propTypes = {
 	getOptionLabel: PropTypes.func,
 	getOptionValue: PropTypes.func,
 	hasError: PropTypes.bool,
-	id: PropTypes.string,
 	isInline: PropTypes.bool,
 	label: PropTypes.string,
 	onChange: PropTypes.func,

--- a/src/system/NewForm/FormSelect.stories.jsx
+++ b/src/system/NewForm/FormSelect.stories.jsx
@@ -62,7 +62,7 @@ const DefaultComponent = ( { label = 'Label', width = 250, onChange, ...rest } )
 		</p>
 		<Form.Root>
 			<div sx={ { width } }>
-				<Form.Select id="form-select" label={ label } onChange={ onChange } { ...rest } />
+				<Form.Select forLabel="form-select" label={ label } onChange={ onChange } { ...rest } />
 			</div>
 		</Form.Root>
 	</>


### PR DESCRIPTION
## Description

Adds support to `aria-required`, `aria-describedby` to the following components:

- Form.Autocomplete
- Form.Selector

## Checklist

- [x] This PR has good automated test coverage
- [x] The storybook for the component has been updated

## Steps to Test - Autocomplete

1. Pull down PR.
2. `npm run dev`.
3. Open http://localhost:6006/?path=/story/form-autocomplete--with-errors
4. Form errors should appear and `aria-describedby` from the HINT is linked to the input HTML

## Steps to Test - Select

1. Pull down PR.
2. `npm run dev`.
3. Open http://localhost:6006/?path=/story/form-select--with-errors
4. Form errors should appear and `aria-describedby` from the HINT is linked to the input HTML