### PR TITLE
Add support for Wizard title autofocus when switching tabs

### DIFF
--- a/src/system/Wizard/Wizard.js
+++ b/src/system/Wizard/Wizard.js
@@ -3,7 +3,7 @@
 /**
  * External dependencies
  */
-import React, { useLayoutEffect } from 'react';
+import React, { useLayoutEffect, useRef } from 'react';
 import PropTypes from 'prop-types';
 import classNames from 'classnames';
 import { MdArrowForward } from 'react-icons/md';
@@ -26,11 +26,12 @@ const Wizard = React.forwardRef(
 		},
 		forwardRef
 	) => {
-		const [ initialStep, setInitialStep ] = React.useState( activeStep );
+		const didMount = useRef( false );
+		// didMount helps us to track the initial render, so we can focus the title only subsequent renders
+		// to avoid stealing the focus from the page we're in.
 		useLayoutEffect( () => {
-			if ( titleAutofocus && activeStep !== initialStep ) {
-				// After the initial page load, the initial step can be focused
-				setInitialStep( -1 );
+			if ( ! didMount.current ) {
+				didMount.current = true;
 			}
 		}, [ activeStep ] );
 		return (
@@ -70,9 +71,7 @@ const Wizard = React.forwardRef(
 							subTitle={ subTitle }
 							title={ title }
 							titleVariant={ titleVariant }
-							shouldFocusTitle={
-								titleAutofocus && activeStep !== initialStep && index === activeStep
-							}
+							shouldFocusTitle={ titleAutofocus && didMount.current }
 						>
 							{ children }
 						</WizardStep>

--- a/src/system/Wizard/Wizard.js
+++ b/src/system/Wizard/Wizard.js
@@ -3,7 +3,7 @@
 /**
  * External dependencies
  */
-import React from 'react';
+import React, { useLayoutEffect } from 'react';
 import PropTypes from 'prop-types';
 import classNames from 'classnames';
 import { MdArrowForward } from 'react-icons/md';
@@ -14,7 +14,25 @@ import { MdArrowForward } from 'react-icons/md';
 import { Box, WizardStep, Flex, WizardStepHorizontal } from '..';
 
 const Wizard = React.forwardRef(
-	( { steps, activeStep, variant, completed = [], className = null, ...props }, forwardRef ) => {
+	(
+		{
+			steps,
+			activeStep,
+			variant,
+			completed = [],
+			className = null,
+			titleAutofocus = false,
+			...props
+		},
+		forwardRef
+	) => {
+		const [ initialStep, setInitialStep ] = React.useState( activeStep );
+		useLayoutEffect( () => {
+			if ( titleAutofocus && activeStep !== initialStep ) {
+				// After the initial page load, the initial step can be focused
+				setInitialStep( -1 );
+			}
+		}, [ activeStep ] );
 		return (
 			<Box className={ classNames( 'vip-wizard-component', className ) } ref={ forwardRef }>
 				{ variant === 'horizontal' ? (
@@ -52,6 +70,7 @@ const Wizard = React.forwardRef(
 							subTitle={ subTitle }
 							title={ title }
 							titleVariant={ titleVariant }
+							shouldFocusTitle={ titleAutofocus && activeStep !== initialStep }
 						>
 							{ children }
 						</WizardStep>
@@ -70,6 +89,7 @@ Wizard.propTypes = {
 	variant: PropTypes.string,
 	completed: PropTypes.array,
 	className: PropTypes.any,
+	titleAutofocus: PropTypes.bool,
 };
 
 export { Wizard };

--- a/src/system/Wizard/Wizard.js
+++ b/src/system/Wizard/Wizard.js
@@ -70,7 +70,9 @@ const Wizard = React.forwardRef(
 							subTitle={ subTitle }
 							title={ title }
 							titleVariant={ titleVariant }
-							shouldFocusTitle={ titleAutofocus && activeStep !== initialStep }
+							shouldFocusTitle={
+								titleAutofocus && activeStep !== initialStep && index === activeStep
+							}
 						>
 							{ children }
 						</WizardStep>

--- a/src/system/Wizard/Wizard.stories.jsx
+++ b/src/system/Wizard/Wizard.stories.jsx
@@ -61,6 +61,7 @@ export const Default = () => {
 
 export const WithTitleAutoFocus = () => {
 	const [ activeStep, setActiveStep ] = React.useState( 0 );
+	const [ autoFocus, setAutoFocus ] = React.useState( true );
 	const steps = [
 		{
 			title: 'Choose Domain',
@@ -94,8 +95,19 @@ export const WithTitleAutoFocus = () => {
 				<Wizard
 					activeStep={ activeStep }
 					steps={ steps }
-					titleAutofocus={ true }
+					titleAutofocus={ autoFocus }
 					className="vip-wizard-xyz"
+				/>
+			</Box>
+			<Box mt={ 4 }>
+				<Form.Select
+					label="Autofocus status"
+					value={ autoFocus }
+					onChange={ e => setAutoFocus( e.value ) }
+					options={ [
+						{ value: true, label: 'On' },
+						{ value: false, label: 'Off' },
+					] }
 				/>
 			</Box>
 		</React.Fragment>

--- a/src/system/Wizard/Wizard.stories.jsx
+++ b/src/system/Wizard/Wizard.stories.jsx
@@ -101,6 +101,7 @@ export const WithTitleAutoFocus = () => {
 			</Box>
 			<Box mt={ 4 }>
 				<Form.Select
+					id="wizard-autofocus"
 					label="Autofocus status"
 					value={ autoFocus }
 					onChange={ e => setAutoFocus( e.value ) }

--- a/src/system/Wizard/Wizard.stories.jsx
+++ b/src/system/Wizard/Wizard.stories.jsx
@@ -59,6 +59,49 @@ export const Default = () => {
 	);
 };
 
+export const WithTitleAutoFocus = () => {
+	const [ activeStep, setActiveStep ] = React.useState( 0 );
+	const steps = [
+		{
+			title: 'Choose Domain',
+			titleVariant: 'h2',
+			children: (
+				<Box>
+					<Label>Domain</Label>
+					<Input placeholder="yourdomain.com" />
+					<Button sx={ { mt: 3 } } onClick={ () => setActiveStep( 1 ) }>
+						Continue
+					</Button>
+				</Box>
+			),
+		},
+		{
+			title: 'Configure DNS',
+			titleVariant: 'h2',
+			children: (
+				<Box>
+					<Label>DNS</Label>
+					<Button sx={ { mt: 3 } } onClick={ () => setActiveStep( 0 ) }>
+						back
+					</Button>
+				</Box>
+			),
+		},
+	];
+	return (
+		<React.Fragment>
+			<Box mt={ 4 }>
+				<Wizard
+					activeStep={ activeStep }
+					steps={ steps }
+					titleAutofocus={ true }
+					className="vip-wizard-xyz"
+				/>
+			</Box>
+		</React.Fragment>
+	);
+};
+
 export const CustomTitle = () => {
 	const steps = [
 		{

--- a/src/system/Wizard/WizardStep.js
+++ b/src/system/Wizard/WizardStep.js
@@ -27,6 +27,7 @@ const WizardStep = React.forwardRef(
 		forwardRef
 	) => {
 		const titleRef = React.useRef( null );
+
 		let borderLeftColor = 'border';
 
 		if ( complete ) {
@@ -82,6 +83,7 @@ const WizardStep = React.forwardRef(
 							fontWeight: active ? 'bold' : 'normal',
 						} }
 						ref={ titleRef }
+						tabIndex={ shouldFocusTitle ? -1 : undefined }
 					>
 						<MdCheckCircle
 							aria-hidden="true"

--- a/src/system/Wizard/WizardStep.js
+++ b/src/system/Wizard/WizardStep.js
@@ -3,7 +3,7 @@
 /**
  * External dependencies
  */
-import React from 'react';
+import React, { useLayoutEffect } from 'react';
 import { MdCheckCircle } from 'react-icons/md';
 import PropTypes from 'prop-types';
 
@@ -14,9 +14,19 @@ import { Card, Heading, Text, Flex } from '..';
 
 const WizardStep = React.forwardRef(
 	(
-		{ title, subTitle, complete = false, children, active, order, titleVariant = 'h3' },
+		{
+			title,
+			subTitle,
+			complete = false,
+			children,
+			active,
+			order,
+			shouldFocusTitle,
+			titleVariant = 'h3',
+		},
 		forwardRef
 	) => {
+		const titleRef = React.useRef( null );
 		let borderLeftColor = 'border';
 
 		if ( complete ) {
@@ -32,7 +42,11 @@ const WizardStep = React.forwardRef(
 		} else if ( active ) {
 			color = 'heading';
 		}
-
+		useLayoutEffect( () => {
+			if ( active && titleRef?.current && shouldFocusTitle ) {
+				titleRef.current.focus();
+			}
+		}, [ active, shouldFocusTitle ] );
 		return (
 			<Card
 				as="section"
@@ -67,6 +81,7 @@ const WizardStep = React.forwardRef(
 							fontSize: 2,
 							fontWeight: active ? 'bold' : 'normal',
 						} }
+						ref={ titleRef }
 					>
 						<MdCheckCircle
 							aria-hidden="true"
@@ -102,6 +117,7 @@ WizardStep.propTypes = {
 	subTitle: PropTypes.node,
 	title: PropTypes.node,
 	titleVariant: PropTypes.string,
+	shouldFocusTitle: PropTypes.bool,
 };
 
 export { WizardStep };


### PR DESCRIPTION
## Description
This PR Adds support for autofocusing the Wizard step title without the need to pass down many ref.

Useful because when you navigate with the keyboard you want the steps to be focused.

## Checklist

- [ ] This PR has good automated test coverage
- [X] The storybook for the component has been updated

## Steps to Test

Outline the steps to test and verify the PR here.

Example:

1. Pull down PR.
1. `npm run dev`.
1. Open Storybook. http://localhost:6006/?path=/story/wizard--with-title-auto-focus
1. Navigate between the steps with keyboard only, each time you move back and forth if you press tab you should be focusing the button (because it's the next component after the title)
1. Always with the keyboard, disable the autofocus in the example, if you play a couple of times (going back and forth between the continue/back buttons) you'll notice that at one point the focus goes away from the wizard and focuses on the Autofocus selectbox 
