### PR TITLE
Form.Autocomplete - Customized Arrow (Defaults to none)

### DIFF
--- a/src/system/NewForm/FormAutocomplete.css
+++ b/src/system/NewForm/FormAutocomplete.css
@@ -1,166 +1,167 @@
 .autocomplete__wrapper {
-  position: relative;
+	position: relative;
 }
 
 .autocomplete__hint,
 .autocomplete__input {
-  -webkit-appearance: none;
-  border: 2px solid #0b0c0c;
-  border-radius: 0; /* Safari 10 on iOS adds implicit border rounding. */
-  box-sizing: border-box;
-  -moz-box-sizing: border-box;
-  -webkit-box-sizing: border-box;
-  margin-bottom: 0; /* BUG: Safari 10 on macOS seems to add an implicit margin. */
-  width: 100%;
+	-webkit-appearance: none;
+	border: 2px solid #0b0c0c;
+	border-radius: 0; /* Safari 10 on iOS adds implicit border rounding. */
+	box-sizing: border-box;
+	-moz-box-sizing: border-box;
+	-webkit-box-sizing: border-box;
+	margin-bottom: 0; /* BUG: Safari 10 on macOS seems to add an implicit margin. */
+	width: 100%;
 }
 
 .autocomplete__input {
-  background-color: transparent;
-  position: relative;
+	background-color: transparent;
+	position: relative;
 }
 
 .autocomplete__hint {
-  color: #b1b4b6;
-  position: absolute;
+	color: #b1b4b6;
+	position: absolute;
 }
 
 .autocomplete__input--default {
-  padding: 5px;
+	padding: 5px;
 }
 .autocomplete__input--focused {
-  outline: 3px solid #fd0;
-  outline-offset: 0;
-  box-shadow: inset 0 0 0 2px;
+	outline: 3px solid #fd0;
+	outline-offset: 0;
+	box-shadow: inset 0 0 0 2px;
 }
 
 .autocomplete__input--show-all-values {
-  padding: 5px 34px 5px 5px; /* Space for arrow. Other padding should match .autocomplete__input--default. */
-  cursor: pointer;
+	padding: 5px 34px 5px 5px; /* Space for arrow. Other padding should match .autocomplete__input--default. */
+	cursor: pointer;
 }
 
 .autocomplete__dropdown-arrow-down {
-  z-index: -1;
-  display: inline-block;
-  position: absolute;
-  right: 8px;
-  width: 24px;
-  height: 24px;
-  top: 10px;
+	z-index: -1;
+	display: inline-block;
+	position: absolute;
+	right: 8px;
+	width: 24px;
+	height: 24px;
+	top: 10px;
+	pointer-events: none;
 }
 
 .autocomplete__menu {
-  background-color: #fff;
-  border: 2px solid #0B0C0C;
-  border-top: 0;
-  color: #0B0C0C;
-  margin: 0;
-  max-height: 342px;
-  overflow-x: hidden;
-  padding: 0;
-  width: 100%;
-  width: calc(100% - 4px);
+	background-color: #fff;
+	border: 2px solid #0b0c0c;
+	border-top: 0;
+	color: #0b0c0c;
+	margin: 0;
+	max-height: 342px;
+	overflow-x: hidden;
+	padding: 0;
+	width: 100%;
+	width: calc( 100% - 4px );
 }
 
 .autocomplete__menu--visible {
-  display: block;
+	display: block;
 }
 
 .autocomplete__menu--hidden {
-  display: none;
+	display: none;
 }
 
 .autocomplete__menu--overlay {
-  box-shadow: rgba(0, 0, 0, 0.256863) 0px 2px 6px;
-  left: 0;
-  position: absolute;
-  top: 100%;
-  z-index: 100;
+	box-shadow: rgba( 0, 0, 0, 0.256863 ) 0px 2px 6px;
+	left: 0;
+	position: absolute;
+	top: 100%;
+	z-index: 100;
 }
 
 .autocomplete__menu--inline {
-  position: relative;
+	position: relative;
 }
 
 .autocomplete__option {
-  border-bottom: solid #b1b4b6;
-  border-width: 1px 0;
-  cursor: pointer;
-  display: block;
-  position: relative;
+	border-bottom: solid #b1b4b6;
+	border-width: 1px 0;
+	cursor: pointer;
+	display: block;
+	position: relative;
 }
 
 .autocomplete__option > * {
-  pointer-events: none;
+	pointer-events: none;
 }
 
 .autocomplete__option:first-of-type {
-  border-top-width: 0;
+	border-top-width: 0;
 }
 
 .autocomplete__option:last-of-type {
-  border-bottom-width: 0;
+	border-bottom-width: 0;
 }
 
 .autocomplete__option--odd {
-  background-color: #FAFAFA;
+	background-color: #fafafa;
 }
 
 .autocomplete__option--focused,
 .autocomplete__option:hover {
-  background-color: #1d70b8;
-  border-color: #1d70b8;
-  color: white;
-  outline: none;
+	background-color: #1d70b8;
+	border-color: #1d70b8;
+	color: white;
+	outline: none;
 }
 
-@media (-ms-high-contrast: active), (forced-colors: active) {
-  .autocomplete__menu {
-    border-color: FieldText;
-  }
+@media ( -ms-high-contrast: active ), ( forced-colors: active ) {
+	.autocomplete__menu {
+		border-color: FieldText;
+	}
 
-  .autocomplete__option {
-    background-color: Field;
-    color: FieldText;
-  }
+	.autocomplete__option {
+		background-color: Field;
+		color: FieldText;
+	}
 
-  .autocomplete__option--focused,
-  .autocomplete__option:hover {
-    forced-color-adjust: none; /* prevent backplate from obscuring text */
-    background-color: Highlight;
-    border-color: Highlight;
-    color: HighlightText;
+	.autocomplete__option--focused,
+	.autocomplete__option:hover {
+		forced-color-adjust: none; /* prevent backplate from obscuring text */
+		background-color: Highlight;
+		border-color: Highlight;
+		color: HighlightText;
 
-    /* Prefer SelectedItem / SelectedItemText in browsers that support it */
-    background-color: SelectedItem;
-    border-color: SelectedItem;
-    color: SelectedItemText;
-    outline-color: SelectedItemText;
-  }
+		/* Prefer SelectedItem / SelectedItemText in browsers that support it */
+		background-color: SelectedItem;
+		border-color: SelectedItem;
+		color: SelectedItemText;
+		outline-color: SelectedItemText;
+	}
 }
 
 .autocomplete__option--no-results {
-  background-color: #FAFAFA;
-  color: #646b6f;
-  cursor: not-allowed;
+	background-color: #fafafa;
+	color: #646b6f;
+	cursor: not-allowed;
 }
 
 .autocomplete__hint,
 .autocomplete__input,
 .autocomplete__option {
-  font-size: 16px;
-  line-height: 1.25;
+	font-size: 16px;
+	line-height: 1.25;
 }
 
 .autocomplete__hint,
 .autocomplete__option {
-  padding: 5px;
+	padding: 5px;
 }
 
-@media (min-width: 641px) {
-  .autocomplete__hint,
-  .autocomplete__input,
-  .autocomplete__option {
-    font-size: 19px;
-    line-height: 1.31579;
-  }
+@media ( min-width: 641px ) {
+	.autocomplete__hint,
+	.autocomplete__input,
+	.autocomplete__option {
+		font-size: 19px;
+		line-height: 1.31579;
+	}
 }

--- a/src/system/NewForm/FormAutocomplete.css
+++ b/src/system/NewForm/FormAutocomplete.css
@@ -38,7 +38,7 @@
 	cursor: pointer;
 }
 
-.autocomplete__dropdown-arrow-down {
+/* .autocomplete__dropdown-arrow-down {
 	z-index: -1;
 	display: inline-block;
 	position: absolute;
@@ -47,7 +47,7 @@
 	height: 24px;
 	top: 10px;
 	pointer-events: none;
-}
+} */
 
 .autocomplete__menu {
 	background-color: #fff;

--- a/src/system/NewForm/FormAutocomplete.js
+++ b/src/system/NewForm/FormAutocomplete.js
@@ -92,6 +92,8 @@ const searchIconStyles = {
 	},
 };
 
+const DefaultArrow = config => <FormSelectArrow classNames={ config.className } />;
+
 const FormAutocomplete = React.forwardRef(
 	(
 		{
@@ -113,7 +115,8 @@ const FormAutocomplete = React.forwardRef(
 			required,
 			searchIcon,
 			showAllValues = true,
-			showArrowDown = false,
+			dropdownArrow = DefaultArrow,
+			showDropdownArrow = false,
 			source,
 			value,
 			hasError,
@@ -265,10 +268,10 @@ const FormAutocomplete = React.forwardRef(
 							onConfirm={ onValueChange }
 							tNoResults={ noOptionsMessage }
 							required={ required }
+							dropdownArrow={ showDropdownArrow ? dropdownArrow : () => '' }
 							{ ...props }
 						/>
 						{ loading && <FormSelectLoading /> }
-						{ showArrowDown && <FormSelectArrow /> }
 					</FormSelectContent>
 				</div>
 
@@ -305,7 +308,8 @@ FormAutocomplete.propTypes = {
 	showAllValues: PropTypes.bool,
 	source: PropTypes.func,
 	value: PropTypes.string,
-	showArrowDown: PropTypes.bool,
+	dropdownArrow: PropTypes.node,
+	showDropdownArrow: PropTypes.bool,
 };
 
 FormAutocomplete.displayName = 'FormAutocomplete';

--- a/src/system/NewForm/FormAutocomplete.js
+++ b/src/system/NewForm/FormAutocomplete.js
@@ -271,7 +271,8 @@ const FormAutocomplete = React.forwardRef(
 							dropdownArrow={ showDropdownArrow ? dropdownArrow : () => '' }
 							{ ...props }
 						/>
-						{ loading && <FormSelectLoading /> }
+
+						{ loading && <FormSelectLoading sx={ { right: showDropdownArrow ? 40 : 10 } } /> }
 					</FormSelectContent>
 				</div>
 

--- a/src/system/NewForm/FormAutocomplete.js
+++ b/src/system/NewForm/FormAutocomplete.js
@@ -113,6 +113,7 @@ const FormAutocomplete = React.forwardRef(
 			required,
 			searchIcon,
 			showAllValues = true,
+			showArrowDown = false,
 			source,
 			value,
 			hasError,
@@ -267,7 +268,7 @@ const FormAutocomplete = React.forwardRef(
 							{ ...props }
 						/>
 						{ loading && <FormSelectLoading /> }
-						<FormSelectArrow />
+						{ showArrowDown && <FormSelectArrow /> }
 					</FormSelectContent>
 				</div>
 
@@ -304,6 +305,7 @@ FormAutocomplete.propTypes = {
 	showAllValues: PropTypes.bool,
 	source: PropTypes.func,
 	value: PropTypes.string,
+	showArrowDown: PropTypes.bool,
 };
 
 FormAutocomplete.displayName = 'FormAutocomplete';

--- a/src/system/NewForm/FormAutocomplete.js
+++ b/src/system/NewForm/FormAutocomplete.js
@@ -101,26 +101,25 @@ const FormAutocomplete = React.forwardRef(
 			className,
 			debounce = 0,
 			displayMenu = 'overlay',
+			dropdownArrow = DefaultArrow,
+			errorMessage,
 			forLabel = 'vip-autocomplete',
 			getOptionLabel,
 			getOptionValue,
+			hasError,
 			isInline,
 			label,
 			loading,
 			minLength = 0,
-			noOptionsMessage = () => 'No results found.',
+			noOptionsMessage = () => 'No results found. Type to search.',
 			onChange = () => {},
 			onInputChange,
 			options = [],
 			required,
 			searchIcon,
-			showAllValues = true,
-			dropdownArrow = DefaultArrow,
-			showDropdownArrow = false,
+			showAllValues = false,
 			source,
 			value,
-			hasError,
-			errorMessage,
 			...props
 		},
 		forwardRef
@@ -268,11 +267,11 @@ const FormAutocomplete = React.forwardRef(
 							onConfirm={ onValueChange }
 							tNoResults={ noOptionsMessage }
 							required={ required }
-							dropdownArrow={ showDropdownArrow ? dropdownArrow : () => '' }
+							dropdownArrow={ showAllValues ? dropdownArrow : () => '' }
 							{ ...props }
 						/>
 
-						{ loading && <FormSelectLoading sx={ { right: showDropdownArrow ? 40 : 10 } } /> }
+						{ loading && <FormSelectLoading sx={ { right: showAllValues ? 40 : 10 } } /> }
 					</FormSelectContent>
 				</div>
 
@@ -310,7 +309,6 @@ FormAutocomplete.propTypes = {
 	source: PropTypes.func,
 	value: PropTypes.string,
 	dropdownArrow: PropTypes.node,
-	showDropdownArrow: PropTypes.bool,
 };
 
 FormAutocomplete.displayName = 'FormAutocomplete';

--- a/src/system/NewForm/FormAutocomplete.stories.jsx
+++ b/src/system/NewForm/FormAutocomplete.stories.jsx
@@ -32,20 +32,31 @@ const args = {
 };
 
 // eslint-disable-next-line react/prop-types
-const DefaultComponent = ( { label = 'Label', width = 250, ...rest } ) => (
-	<>
-		<Form.Root>
-			<div sx={ { width } }>
-				<Form.Autocomplete forLabel="form-autocomplete" label={ label } { ...rest } />
-			</div>
-		</Form.Root>
-	</>
-);
+const DefaultComponent = ( { label = 'Label', width = 250, ...rest } ) => {
+	const [ selectedValue, setSelectedValue ] = useState( null );
+	return (
+		<>
+			<Form.Root>
+				<div sx={ { width } }>
+					<Form.Autocomplete
+						forLabel="form-autocomplete"
+						label={ label }
+						onChange={ ( obj, val ) => {
+							setSelectedValue( val );
+						} }
+						{ ...rest }
+					/>
+				</div>
+				<div sx={ { mt: 3 } }>Selected value: { selectedValue }</div>
+			</Form.Root>
+		</>
+	);
+};
 
 export const Default = () => {
 	return (
 		<>
-			<DefaultComponent required { ...args } />
+			<DefaultComponent required { ...args } placeholder="Start typing..." />
 		</>
 	);
 };
@@ -152,7 +163,7 @@ export const WithErrors = () => {
 export const WithArrow = () => {
 	const customArgs = {
 		...args,
-		showDropdownArrow: true,
+		showAllValues: true,
 	};
 
 	return (
@@ -165,7 +176,7 @@ export const WithArrow = () => {
 export const WithCustomArrow = () => {
 	const customArgs = {
 		...args,
-		showDropdownArrow: true,
+		showAllValues: true,
 		// eslint-disable-next-line react/display-name
 		dropdownArrow: () => (
 			<span sx={ { position: 'absolute', top: '2px', right: '10px', pointerEvents: 'none' } }>

--- a/src/system/NewForm/FormAutocomplete.stories.jsx
+++ b/src/system/NewForm/FormAutocomplete.stories.jsx
@@ -148,3 +148,37 @@ export const WithErrors = () => {
 		</>
 	);
 };
+
+export const WithArrow = () => {
+	const customArgs = {
+		...args,
+		showDropdownArrow: true,
+	};
+
+	return (
+		<>
+			<DefaultComponent { ...customArgs } />
+		</>
+	);
+};
+
+export const WithCustomArrow = () => {
+	const customArgs = {
+		...args,
+		showDropdownArrow: true,
+		// eslint-disable-next-line react/display-name
+		dropdownArrow: () => (
+			<span sx={ { position: 'absolute', top: '2px', right: '10px', pointerEvents: 'none' } }>
+				👇
+			</span>
+		),
+	};
+
+	return (
+		<>
+			<DefaultComponent { ...customArgs } />
+		</>
+	);
+};
+
+WithCustomArrow.displayName = 'WithCustomArrow';

--- a/src/system/NewForm/FormSelectArrow.js
+++ b/src/system/NewForm/FormSelectArrow.js
@@ -23,6 +23,7 @@ export const FormSelectArrow = React.forwardRef( ( props, forwardRef ) => (
 			borderLeftStyle: borderStyle.borderStyle,
 			borderLeftColor: borderStyle.borderColor,
 			right: '10px',
+			top: '7px',
 			pointerEvents: 'none',
 			svg: {
 				fill: borderStyle.borderColor,

--- a/src/system/NewForm/FormSelectLoading.js
+++ b/src/system/NewForm/FormSelectLoading.js
@@ -4,6 +4,7 @@
  * External dependencies
  */
 import React from 'react';
+import PropTypes from 'prop-types';
 import { AiOutlineLoading3Quarters } from 'react-icons/ai';
 import { keyframes } from '@emotion/react';
 
@@ -17,23 +18,28 @@ const kf = keyframes( {
 	to: { transform: 'rotate(360deg) ' },
 } );
 
-export const FormSelectLoading = React.forwardRef( ( props, forwardRef ) => (
+export const FormSelectLoading = React.forwardRef( ( { sx = {}, ...rest }, forwardRef ) => (
 	<AiOutlineLoading3Quarters
 		ref={ forwardRef }
 		aria-hidden="true"
 		size={ 18 }
 		sx={ {
 			position: 'absolute',
-			right: 40,
+			right: 10,
 			pointerEvents: 'none',
 			animation: `${ kf } 1s infinite linear`,
 			opacity: 0.5,
 			svg: {
 				fill: inputBaseText,
 			},
+			...sx,
 		} }
-		{ ...props }
+		{ ...rest }
 	/>
 ) );
+
+FormSelectLoading.propTypes = {
+	sx: PropTypes.object,
+};
 
 FormSelectLoading.displayName = 'FormSelectLoading';


### PR DESCRIPTION
## Description

During a previous discussion about the Form.Autocomplete component, we decided to remove the dropdown arrow so users don't get confused about this being a select vs. autocomplete.

This Pull request not only removes the default behavior of the autocomplete dropdown arrow but also makes the usage of the built-in `dropdownArrow` property from the autocomplete original component.

## Checklist

- [ ] This PR has good automated test coverage
- [x] The storybook for the component has been updated

## Steps to Test

1. Open https://deploy-preview-176--vip-design-system-components.netlify.app/?path=/story/form-autocomplete--default
2. Dropdown should not appear by default
3. Open https://deploy-preview-176--vip-design-system-components.netlify.app/?path=/story/form-autocomplete--with-arrow
4. Dropdown shows as used to be
5. Open https://deploy-preview-176--vip-design-system-components.netlify.app/?path=/story/form-autocomplete--with-custom-arrow
6. Dropdown is custom
