### PR TITLE
Dark mode improvements - New batch

### DIFF
--- a/src/system/NewDialog/DialogOverlay.js
+++ b/src/system/NewDialog/DialogOverlay.js
@@ -19,9 +19,7 @@ export const DialogOverlay = React.forwardRef( ( props, forwardedRef ) => (
 			bottom: 0,
 			inset: 0,
 			opacity: 0.7,
-			background:
-				// eslint-disable-next-line max-len
-				'linear-gradient(198.09deg,#E5F0F6 2.01%, rgba(235, 238, 242, 0) 43.18%,rgba(249, 234, 232, 0) 47.86%, #FFE9D1 94.31%), linear-gradient(98.65deg, #FFE8E6 0.58%, rgba(255, 233, 214, 0) 52.45%, rgba(255, 233, 219, 0) 53.76%,#FFE9D1 105.86%), #F5F2F1',
+			backgroundColor: 'backgrounds.overlay',
 		} }
 		{ ...props }
 		ref={ forwardedRef }

--- a/src/system/Notice/Notice.js
+++ b/src/system/Notice/Notice.js
@@ -25,7 +25,7 @@ const NoticeIcon = ( { color, variant } ) => {
 		case 'info':
 			Icon = MdInfo;
 			break;
-		case 'alert':
+		case 'error':
 			Icon = MdError;
 			break;
 		case 'success':

--- a/src/system/Notice/Notice.stories.jsx
+++ b/src/system/Notice/Notice.stories.jsx
@@ -45,6 +45,11 @@ export const Default = () => (
 			<Link href="/?path=/story/avatar--default">A link to Avatar</Link>
 		</Notice>
 
+		<Notice variant="alert" sx={ { mb: 4 } } title="Please read this first">
+			This notice has a title and children and{ ' ' }
+			<Link href="/?path=/story/avatar--default">A link to Avatar</Link>
+		</Notice>
+
 		<Notice
 			variant="alert"
 			sx={ { mb: 4 } }

--- a/src/system/OptionRow/OptionRow.js
+++ b/src/system/OptionRow/OptionRow.js
@@ -47,7 +47,8 @@ const OptionRow = React.forwardRef(
 			disabled = false,
 			order = null,
 			className = null,
-			variant = 'h3',
+			titleVariant = 'h3',
+			variant = 'default',
 			...props
 		},
 		forwardRef
@@ -78,8 +79,8 @@ const OptionRow = React.forwardRef(
 								display: [ 'inline-block', 'inline-block', 'block' ],
 								p: small ? 12 : 20,
 								flex: '0 0 auto',
-								bg: 'optionRow.iconBackground',
-								color: 'optionRow.icon',
+								bg: `optionRow.${ variant }.background`,
+								color: `optionRow.${ variant }.icon`,
 								borderRadius: 1,
 								...mergedCard,
 							} }
@@ -95,7 +96,7 @@ const OptionRow = React.forwardRef(
 
 				<Box sx={ { flex: '1 1 auto' } }>
 					<Heading
-						variant={ variant }
+						titleVariant={ titleVariant }
 						sx={ { mb: subTitle || body ? 1 : 0, fontSize: 2, fontWeight: 'bold' } }
 					>
 						<Link
@@ -149,7 +150,8 @@ OptionRow.propTypes = {
 	disabled: PropTypes.bool,
 	order: PropTypes.number,
 	className: PropTypes.any,
-	variant: PropTypes.string,
+	titleVariant: PropTypes.string,
+	variant: PropTypes.oneOf( [ 'default', 'alt' ] ),
 };
 
 export { OptionRow };

--- a/src/system/OptionRow/OptionRow.stories.jsx
+++ b/src/system/OptionRow/OptionRow.stories.jsx
@@ -14,7 +14,8 @@ export default {
 	component: OptionRow,
 };
 
-export const Default = () => (
+// eslint-disable-next-line react/prop-types
+const Base = ( { variant } ) => (
 	<Box>
 		<OptionRow
 			image={ <BiAddToQueue size={ 24 } /> }
@@ -22,6 +23,7 @@ export const Default = () => (
 			subTitle="Mostly used to link off to other pages."
 			as="a"
 			href="http://google.com/"
+			variant={ variant }
 		/>
 		<OptionRow
 			image={ <BiCalendarHeart size={ 24 } /> }
@@ -30,6 +32,7 @@ export const Default = () => (
 			as="a"
 			href="http://google.com/"
 			order={ 2 }
+			variant={ variant }
 		/>
 
 		<OptionRow
@@ -38,8 +41,13 @@ export const Default = () => (
 			subTitle="Use the variant prop to adjust the heading structure"
 			as="a"
 			href="http://google.com/"
-			variant="h2"
+			titleVariant="h2"
 			meta=""
+			variant={ variant }
 		/>
 	</Box>
 );
+
+export const Default = () => <Base />;
+
+export const Alternative = () => <Base variant="alt" />;

--- a/src/system/theme/generated/valet-theme-light.json
+++ b/src/system/theme/generated/valet-theme-light.json
@@ -947,6 +947,28 @@
       "description": "Use for the pseudo terminal window background color."
     }
   },
+  "option-row": {
+    "default": {
+      "background": {
+        "value": "#d29137",
+        "type": "color"
+      },
+      "icon": {
+        "value": "#1b1918",
+        "type": "color"
+      }
+    },
+    "alt": {
+      "background": {
+        "value": "#13191e",
+        "type": "color"
+      },
+      "icon": {
+        "value": "#f4f3f2",
+        "type": "color"
+      }
+    }
+  },
   "rem": {
     "value": 16,
     "type": "other",

--- a/src/system/theme/index.js
+++ b/src/system/theme/index.js
@@ -104,8 +104,9 @@ const getComponentColors = ( theme, gColor, gVariants ) => ( {
 	},
 
 	optionRow: {
+		...theme[ 'option-row' ],
 		hover: 'rgba(0,0,0,.02)',
-		border: gColor( 'border', '1' ),
+		border: gColor( 'border', '2' ),
 		text: gColor( 'text', 'secondary' ),
 		textAccent: gColor( 'link', 'default' ),
 		icon: gColor( 'icon', 'inverse' ),

--- a/tokens/valet-core/wpvip-expressive-type.json
+++ b/tokens/valet-core/wpvip-expressive-type.json
@@ -58,7 +58,7 @@
     "4-short": {
       "value": {
         "fontFamily": "{fontFamily.sans}",
-        "fontWeight": "{fontWeight.light}",
+        "fontWeight": "{fontWeight.regular}",
         "lineHeight": "{lineHeight.4}",
         "fontSize": "{fontSize.static.5}"
       },
@@ -244,7 +244,7 @@
         "fontFamily": "{fontFamily.display}",
         "fontWeight": "{fontWeight.regular}",
         "lineHeight": "{lineHeight.4}",
-        "fontSize": "{fontSize.responsive.9}",
+        "fontSize": "{fontSize.responsive.8}",
         "letterSpacing": "{letterSpacing.tight}"
       },
       "type": "typography"

--- a/tokens/valet-core/wpvip-productive-color.json
+++ b/tokens/valet-core/wpvip-productive-color.json
@@ -946,5 +946,27 @@
       "type": "color",
       "description": "Use for the pseudo terminal window background color."
     }
+  },
+  "option-row": {
+    "default": {
+      "background": {
+        "value": "{color.gold.40}",
+        "type": "color"
+      },
+      "icon": {
+        "value": "{color.gray.93}",
+        "type": "color"
+      }
+    },
+    "alt": {
+      "background": {
+        "value": "{layer.inverse}",
+        "type": "color"
+      },
+      "icon": {
+        "value": "{icon.inverse}",
+        "type": "color"
+      }
+    }
   }
 }


### PR DESCRIPTION
## Description

General dark mode improvements reported by the design team:

- :ok:Dark mode bits - logs page:
- :ok: Logs list scrolled -> filters sticky.
- :ok: The help center (UI overlay, option-row & accordion)
- :ok: Option-rows with borders:
- :ok: Domains page - success icons
- :ok: Database backups page:
- :ok: Deployment detail page:
- :ok: WP-CLI Commands page:
- :ok: Form field error messages (field adjacent helper text)

## Checklist

- [ ] This PR has good automated test coverage
- [x] The storybook for the component has been updated

## Steps to Test

N/A