### PR TITLE
Fix Autocomplete search icon and input margin styles

### DIFF
--- a/src/system/NewForm/FormAutocomplete.js
+++ b/src/system/NewForm/FormAutocomplete.js
@@ -29,6 +29,7 @@ const baseBorderTextColors = {
 
 const defaultStyles = {
 	width: '100%',
+	mb: 2,
 	...baseBorderTextColors,
 
 	py: 0,
@@ -87,8 +88,8 @@ const inlineStyles = {
 };
 
 const searchIconStyles = {
-	'& .autocomplete__input.autocomplete__input--show-all-values': {
-		paddingLeft: '30px',
+	'& .autocomplete__input.autocomplete__input': {
+		paddingLeft: 4,
 	},
 };
 

--- a/src/system/NewForm/FormAutocomplete.stories.jsx
+++ b/src/system/NewForm/FormAutocomplete.stories.jsx
@@ -91,6 +91,7 @@ export const WithSearchIcon = () => {
 	const customArgs = {
 		...args,
 		searchIcon: true,
+		placeholder: 'Type to search',
 	};
 
 	return (


### PR DESCRIPTION
## Description

This PR fixes two things:

- Search icon alignment

Before:

<img width="558" alt="image" src="https://user-images.githubusercontent.com/3402/217911324-503dd171-4350-4f37-95de-250ca1679395.png">

After:
<img width="703" alt="image" src="https://user-images.githubusercontent.com/3402/217910476-963e5ca5-ed5a-4d68-b03b-48354c4cf168.png">

- Input+Validation margin bottom

Before:

<img width="489" alt="image" src="https://user-images.githubusercontent.com/3402/217911423-41f54ab7-d86b-4c70-99d3-9a6bd2ef743b.png">

After:

<img width="628" alt="image" src="https://user-images.githubusercontent.com/3402/217911463-57faa45a-94cd-4878-8d21-d942d20be248.png">



## Checklist

- [ ] This PR has good automated test coverage
- [x] The storybook for the component has been updated

## Steps to Test

1. Pull down PR.
2. `npm run dev`.
3. Open http://localhost:6006/?path=/story/form-autocomplete--with-search-icon
4. Search icon should match the second screenshot
5. Open http://localhost:6006/?path=/story/form-autocomplete--with-errors
6. Verify that validation error below the input has the correct margin
