### PR TITLE
Remove letter spacing from text caps variant / table headers

### DIFF
--- a/src/system/theme/textStyles.js
+++ b/src/system/theme/textStyles.js
@@ -41,6 +41,5 @@ export const textStyles = {
 		marginBottom: 2,
 		color: 'muted',
 		fontWeight: 'bold',
-		letterSpacing: '.05em',
 	},
 };


### PR DESCRIPTION
## Description

This PR removes the letter spacing from text caps variant / table headers.

| Before   | After |
|----------|:-------------:|
| ![before](https://user-images.githubusercontent.com/33168/218199327-3a78a81b-dc7e-45f1-a3f5-8241b49c91fc.jpg) |  ![after](https://user-images.githubusercontent.com/33168/218199471-0f7ec29f-74df-4449-8195-bba8d41e0462.jpg) |


## Checklist

- [N/A] This PR has good automated test coverage
- [N/A] The storybook for the component has been updated

## Steps to Test

Outline the steps to test and verify the PR here.

Example:

1. Pull down PR.
2. `npm run dev`.
3. Open http://localhost:6006/?path=/story/table--default.
