### PR TITLE
Remove caps variant from table header

### DIFF
--- a/src/system/Table/TableCell.js
+++ b/src/system/Table/TableCell.js
@@ -27,11 +27,7 @@ const TableCell = ( { head, children, ...rest } ) => {
 	return (
 		<Box as={ head ? 'th' : 'td' } { ...{ ...rest, sx } }>
 			{ head ? (
-				<Heading
-					variant="caps"
-					as="div"
-					sx={ { mb: 0, color: head ? 'table.heading' : 'table.text', fontSize: 2 } }
-				>
+				<Heading as="div" sx={ { mb: 0, color: 'table.heading', fontSize: 2, fontWeight: 'bold' } }>
 					{ children }
 				</Heading>
 			) : (

--- a/src/system/Table/TableCell.js
+++ b/src/system/Table/TableCell.js
@@ -9,7 +9,7 @@ import PropTypes from 'prop-types';
 /**
  * Internal dependencies
  */
-import { Heading, Box } from '../';
+import { Box } from '../';
 
 const TableCell = ( { head, children, ...rest } ) => {
 	const sx = {
@@ -27,9 +27,9 @@ const TableCell = ( { head, children, ...rest } ) => {
 	return (
 		<Box as={ head ? 'th' : 'td' } { ...{ ...rest, sx } }>
 			{ head ? (
-				<Heading as="div" sx={ { mb: 0, color: 'table.heading', fontSize: 2, fontWeight: 'bold' } }>
+				<span sx={ { mb: 0, color: 'table.heading', fontSize: 2, fontWeight: 'bold' } }>
 					{ children }
-				</Heading>
+				</span>
 			) : (
 				children
 			) }

--- a/src/system/theme/textStyles.js
+++ b/src/system/theme/textStyles.js
@@ -41,5 +41,6 @@ export const textStyles = {
 		marginBottom: 2,
 		color: 'muted',
 		fontWeight: 'bold',
+		letterSpacing: '.05em',
 	},
 };


### PR DESCRIPTION
## Description

This PR removes the caps variant from table header

| Before   | After |
|----------|:-------------:|
| ![before2](https://user-images.githubusercontent.com/33168/218468024-d1d442c7-9bed-4d90-b624-72bf210bc290.jpeg) | <img alt="after2" src="https://user-images.githubusercontent.com/33168/218467999-f7358d8c-9f44-4588-85a5-d9c00f0cba8c.png">  |




It also reverts the changes made on https://github.com/Automattic/vip-design-system/pull/183


## Checklist

- [ ] This PR has good automated test coverage
- [ ] The storybook for the component has been updated

## Steps to Test

1. Pull down PR.
2. `npm run dev`.
3. Open http://localhost:6006/?path=/story/table--default.
