### PR TITLE
Add role radio to RadioBoxGroup

### DIFF
--- a/src/system/Form/RadioBoxGroup.js
+++ b/src/system/Form/RadioBoxGroup.js
@@ -55,7 +55,6 @@ const RadioOption = ( {
 		>
 			<input
 				ref={ ref }
-				role="radio"
 				checked={ checked }
 				type="radio"
 				name={ name }

--- a/src/system/Form/RadioBoxGroup.js
+++ b/src/system/Form/RadioBoxGroup.js
@@ -20,10 +20,9 @@ const RadioOption = ( {
 	onChangeHandler,
 } ) => {
 	const forLabel = id || value;
+	const checked = `${ defaultValue }` === `${ value }`;
 	return (
 		<div
-			key={ value }
-			value={ value }
 			id={ `o${ forLabel }` }
 			sx={ {
 				width,
@@ -41,7 +40,7 @@ const RadioOption = ( {
 					backgroundColor: 'input.radio-box.background.hover',
 					borderColor: 'input.radio-box.border.default',
 				},
-				...( `${ defaultValue }` === `${ value }` && {
+				...( checked && {
 					borderColor: 'input.radio-box.border.active',
 				} ),
 				...( disabled && {
@@ -50,7 +49,8 @@ const RadioOption = ( {
 			} }
 		>
 			<input
-				checked={ `${ defaultValue }` === `${ value }` }
+				role="radio"
+				checked={ checked }
 				type="radio"
 				name={ name }
 				id={ forLabel }
@@ -59,28 +59,25 @@ const RadioOption = ( {
 				sx={ { mr: 3, mt: 3 } }
 				{ ...restOption }
 			/>
-			<label
-				htmlFor={ forLabel }
+			<div
 				sx={ { mb: 0, color: 'input.radio-box.label.primary.default', p: 3, pr: 0, flex: 'auto' } }
-				{ ...labelProps }
 			>
-				{ label }
+				<label htmlFor={ forLabel } { ...labelProps }>
+					{ label }
+				</label>
 				{ description && (
-					<>
-						<ScreenReaderText>.</ScreenReaderText>
-						<span
-							sx={ {
-								color: 'input.radio-box.label.secondary.default',
-								mb: 0,
-								fontSize: 1,
-								display: 'block',
-							} }
-						>
-							{ description }
-						</span>
-					</>
+					<span
+						sx={ {
+							color: 'input.radio-box.label.secondary.default',
+							mb: 0,
+							fontSize: 1,
+							display: 'block',
+						} }
+					>
+						{ description }
+					</span>
 				) }
-			</label>
+			</div>
 		</div>
 	);
 };

--- a/src/system/Form/RadioBoxGroup.js
+++ b/src/system/Form/RadioBoxGroup.js
@@ -6,6 +6,7 @@
 import React, { useCallback } from 'react';
 import PropTypes from 'prop-types';
 import ScreenReaderText from '../ScreenReaderText';
+import { Label } from './Label';
 
 /**
  * Internal dependencies
@@ -21,6 +22,7 @@ const RadioOption = ( {
 } ) => {
 	const forLabel = id || value;
 	const checked = `${ defaultValue }` === `${ value }`;
+	const ref = React.useRef( null );
 	return (
 		<div
 			id={ `o${ forLabel }` }
@@ -47,8 +49,12 @@ const RadioOption = ( {
 					borderColor: 'input.radio-box.border.disabled',
 				} ),
 			} }
+			onClick={ () => {
+				ref.current?.click();
+			} }
 		>
 			<input
+				ref={ ref }
 				role="radio"
 				checked={ checked }
 				type="radio"
@@ -131,8 +137,6 @@ const RadioBoxGroup = React.forwardRef(
 		return (
 			<fieldset
 				sx={ {
-					display: 'flex',
-					gap: 2,
 					border: 0,
 					padding: 0,
 				} }
@@ -140,11 +144,20 @@ const RadioBoxGroup = React.forwardRef(
 				{ ...props }
 			>
 				{ groupLabel ? (
-					<legend>{ groupLabel }</legend>
+					<Label as="legend" sx={ { mb: 2 } }>
+						{ groupLabel }
+					</Label>
 				) : (
 					<ScreenReaderText>Choose an option</ScreenReaderText>
 				) }
-				{ renderedOptions }
+				<div
+					sx={ {
+						display: 'flex',
+						gap: 2,
+					} }
+				>
+					{ renderedOptions }
+				</div>
 			</fieldset>
 		);
 	}


### PR DESCRIPTION
## Description

Added `role="radio"` and input label with only the option title. The description now is inside a span to keep using the same test structure as before. The voiceover is the same as before.

<img width="571" alt="image" src="https://user-images.githubusercontent.com/199867/218121669-3e0f489b-d32b-4172-8420-904c7623d1dd.png">

## Checklist

- [ ] This PR has good automated test coverage
- [x] The storybook for the component has been updated

## Steps to Test

1. Pull down PR.
1. `npm run dev`.
1. Open Storybook.
1. Turn on the Voiceover.
1. Test the Radio Button Group component using the keyboard.