### PR TITLE
Reset Form.Autocomplete input properly when the user clears the input

### DIFF
--- a/src/system/NewForm/FormAutocomplete.js
+++ b/src/system/NewForm/FormAutocomplete.js
@@ -291,6 +291,7 @@ const FormAutocomplete = React.forwardRef(
 
 		useEffect( () => {
 			global.document.querySelector( `#${ forLabel }` ).addEventListener( 'blur', () => {
+				setInputQuery( global.document.querySelector( `#${ forLabel }` ).value );
 				resetInputState();
 			} );
 		}, [ forwardRef ] );


### PR DESCRIPTION
## Description

This is a Followup to #171 .

It seems like the `source` function is not called by the parent component when the user clears the input.
This PR adds an extra line of code to make sure they're in sync.

_PS: I was quite sure to have tested it in the previous PR #171 so I'm confused why it stopped working._ 
## Checklist

- [ ] This PR has good automated test coverage
- [ ] The storybook for the component has been updated

## Steps to Test

1. Visit http://localhost:6006/?path=/story/form-autocomplete--default&args=resetOnBlur:true (ensure you have `resetOnBlur` set to true in the controls tab
2. Select a value (search vanilla for example)
3. Delete the value with the keyboard
4. Move the focus away from the input, the selected value below the input should reset to empty.