### PR TITLE
Improve Wizard autofocus on rerenders

### DIFF
--- a/src/system/Wizard/Wizard.js
+++ b/src/system/Wizard/Wizard.js
@@ -3,7 +3,7 @@
 /**
  * External dependencies
  */
-import React, { useLayoutEffect, useRef } from 'react';
+import React, { useLayoutEffect, useState } from 'react';
 import PropTypes from 'prop-types';
 import classNames from 'classnames';
 import { MdArrowForward } from 'react-icons/md';
@@ -26,14 +26,15 @@ const Wizard = React.forwardRef(
 		},
 		forwardRef
 	) => {
-		const didMount = useRef( false );
+		const [ didMount, setDidMount ] = useState( false );
+		const [ initialStep ] = useState( activeStep );
 		// didMount helps us to track the initial render, so we can focus the title only subsequent renders
 		// to avoid stealing the focus from the page we're in.
 		useLayoutEffect( () => {
-			if ( ! didMount.current ) {
-				didMount.current = true;
+			if ( ! didMount && activeStep !== initialStep ) {
+				setDidMount( true );
 			}
-		}, [ activeStep ] );
+		}, [ initialStep, activeStep, didMount, setDidMount ] );
 		return (
 			<Box className={ classNames( 'vip-wizard-component', className ) } ref={ forwardRef }>
 				{ variant === 'horizontal' ? (
@@ -71,7 +72,7 @@ const Wizard = React.forwardRef(
 							subTitle={ subTitle }
 							title={ title }
 							titleVariant={ titleVariant }
-							shouldFocusTitle={ titleAutofocus && didMount.current }
+							shouldFocusTitle={ titleAutofocus && didMount }
 						>
 							{ children }
 						</WizardStep>

--- a/src/system/Wizard/Wizard.stories.jsx
+++ b/src/system/Wizard/Wizard.stories.jsx
@@ -102,6 +102,7 @@ export const WithTitleAutoFocus = () => {
 			<Box mt={ 4 }>
 				<Form.Select
 					id="wizard-autofocus"
+					forLabel="wizard-autofocus"
 					label="Autofocus status"
 					value={ autoFocus }
 					onChange={ e => setAutoFocus( e.value ) }


### PR DESCRIPTION
## Description

Followup to #175 to improve autofocus on rerendering.
Issue was that, when rerendering, the autofocus would be triggered before it was needed (on "first" render).
To avoid this, I've moved the logic from using a ref, to using a mix of states. 
Using the `initialState` ast the starting point. 

## Checklist

- [ ] This PR has good automated test coverage
- [x] The storybook for the component has been updated

## Steps to Test

see #175 
