### PR TITLE
Add/errors to autocomplete & RadioBoxGroup

### DIFF
--- a/src/system/Form/RadioBoxGroup.js
+++ b/src/system/Form/RadioBoxGroup.js
@@ -146,7 +146,7 @@ const RadioBoxGroup = React.forwardRef(
 				<fieldset
 					sx={ {
 						border: 0,
-						padding: 2,
+						p: hasError ? 2 : 0,
 						display: 'inline-block',
 						mb: 2,
 						...( hasError

--- a/src/system/Form/RadioBoxGroup.js
+++ b/src/system/Form/RadioBoxGroup.js
@@ -7,6 +7,7 @@ import React, { useCallback } from 'react';
 import PropTypes from 'prop-types';
 import ScreenReaderText from '../ScreenReaderText';
 import { Label } from './Label';
+import { Validation } from './Validation';
 
 /**
  * Internal dependencies
@@ -111,6 +112,9 @@ const RadioBoxGroup = React.forwardRef(
 			defaultValue,
 			options,
 			disabled,
+			errorMessage,
+			hasError,
+			required,
 			...props
 		},
 		forwardRef
@@ -138,30 +142,43 @@ const RadioBoxGroup = React.forwardRef(
 		) );
 
 		return (
-			<fieldset
-				sx={ {
-					border: 0,
-					padding: 0,
-				} }
-				ref={ forwardRef }
-				{ ...props }
-			>
-				{ groupLabel ? (
-					<Label as="legend" sx={ { mb: 2 } }>
-						{ groupLabel }
-					</Label>
-				) : (
-					<ScreenReaderText>Choose an option</ScreenReaderText>
-				) }
-				<div
+			<div>
+				<fieldset
 					sx={ {
-						display: 'flex',
-						gap: 2,
+						border: 0,
+						padding: 2,
+						display: 'inline-block',
+						mb: 2,
+						...( hasError
+							? { border: '1px solid', borderColor: 'input.border.error', borderRadius: 2 }
+							: {} ),
 					} }
+					ref={ forwardRef }
+					{ ...props }
 				>
-					{ renderedOptions }
-				</div>
-			</fieldset>
+					{ groupLabel ? (
+						<Label as="legend" sx={ { mb: 2 } } required={ required }>
+							{ groupLabel }
+						</Label>
+					) : (
+						<ScreenReaderText>Choose an option</ScreenReaderText>
+					) }
+					<div
+						sx={ {
+							display: 'flex',
+							gap: 2,
+						} }
+					>
+						{ renderedOptions }
+					</div>
+				</fieldset>
+
+				{ hasError && errorMessage && (
+					<Validation isValid={ false } describedId={ groupLabel }>
+						{ errorMessage }
+					</Validation>
+				) }
+			</div>
 		);
 	}
 );
@@ -175,7 +192,11 @@ RadioBoxGroup.propTypes = {
 	name: PropTypes.string,
 	disabled: PropTypes.bool,
 	groupLabel: PropTypes.string,
+	id: PropTypes.string,
 	optionWidth: PropTypes.string,
+	errorMessage: PropTypes.string,
+	hasError: PropTypes.bool,
+	required: PropTypes.bool,
 };
 
 export { RadioBoxGroup };

--- a/src/system/Form/RadioBoxGroup.stories.jsx
+++ b/src/system/Form/RadioBoxGroup.stories.jsx
@@ -42,3 +42,19 @@ export const Default = () => {
 		/>
 	);
 };
+
+export const Errors = () => {
+	const [ value, setValue ] = useState( null );
+
+	return (
+		<RadioBoxGroup
+			defaultValue={ value }
+			onChange={ e => setValue( e.target.value ) }
+			options={ options }
+			required
+			groupLabel="Radio Box Group"
+			hasError={ true }
+			errorMessage="This is an error message"
+		/>
+	);
+};

--- a/src/system/NewForm/FormAutocomplete.js
+++ b/src/system/NewForm/FormAutocomplete.js
@@ -103,10 +103,10 @@ const FormAutocomplete = React.forwardRef(
 			debounce = 0,
 			displayMenu = 'overlay',
 			dropdownArrow = DefaultArrow,
-			errorMessage,
 			forLabel = 'vip-autocomplete',
 			getOptionLabel,
 			getOptionValue,
+			errorMessage,
 			hasError,
 			isInline,
 			label,
@@ -304,6 +304,7 @@ const FormAutocomplete = React.forwardRef(
 						...defaultStyles,
 						...( isInline && inlineStyles ),
 						...( searchIcon && searchIconStyles ),
+						...( hasError ? { borderColor: 'input.border.error' } : {} ),
 					} }
 				>
 					<FormSelectContent


### PR DESCRIPTION
## Description

Adding error styles for two components:

![SCR-20230307-q74](https://user-images.githubusercontent.com/3402/223562411-4561f94d-5077-4651-a997-6c50f3d198ca.png)

<img width="628" alt="image" src="https://user-images.githubusercontent.com/3402/223562447-45f9703f-83af-4749-b4a5-e186b664b690.png">


## Checklist

- [ ] This PR has good automated test coverage
- [x] The storybook for the component has been updated

## Steps to Test

1. Pull down PR.
2. `npm run dev`.
3. Open http://localhost:6006/?path=/story/form-autocomplete--with-errors and see input border red
4. Open http://localhost:6006/?path=/story/radioboxgroup--errors and see error border and message below
