### PR TITLE
PIE-3577 Fixes some issues when page text has zoom

### DIFF
--- a/src/system/Button/Button.js
+++ b/src/system/Button/Button.js
@@ -28,7 +28,7 @@ const Button = React.forwardRef( ( { disabled, onClick, sx, ...props }, forwardR
 				display: 'inline-flex',
 				alignItems: 'center',
 				justifyContent: 'center',
-				height: '36px',
+				minHeight: '36px',
 				py: 0,
 				textDecoration: 'none',
 				'&:hover': {

--- a/src/system/Button/Button.stories.jsx
+++ b/src/system/Button/Button.stories.jsx
@@ -1,3 +1,5 @@
+/** @jsxImportSource theme-ui */
+
 /**
  * External dependencies
  */
@@ -58,6 +60,12 @@ const Template = args => (
 			<BiCalendarHeart size={ 24 } />
 			<ScreenReaderText>domain.com</ScreenReaderText>
 		</Button>
+
+		<div sx={ { maxWidth: '100px', mt: 3 } }>
+			<Button variant="secondary" href="https://google/com" { ...args }>
+				Button with constrained width
+			</Button>
+		</div>
 	</React.Fragment>
 );
 

--- a/src/system/Form/Input.js
+++ b/src/system/Form/Input.js
@@ -17,7 +17,7 @@ const inputStyles = {
 	unset: 'all',
 	...baseControlStyle,
 	lineHeight: 'inherit',
-	height: '36px',
+	minHeight: '36px',
 	px: 3,
 	py: 2,
 	fontSize: 2,

--- a/src/system/Table/Table.js
+++ b/src/system/Table/Table.js
@@ -7,6 +7,7 @@ import React from 'react';
 import PropTypes from 'prop-types';
 import classNames from 'classnames';
 import { screenReaderTextClass } from '../ScreenReaderText/ScreenReaderText';
+import { Box } from '../';
 
 const Table = React.forwardRef(
 	( { sx, className, children, caption = null, ...props }, forwardRef ) => {
@@ -16,15 +17,17 @@ const Table = React.forwardRef(
 		}
 
 		return (
-			<table
-				sx={ { width: '100%', minWidth: 1024, borderSpacing: 0, ...sx } }
-				className={ classNames( 'vip-table-component', className ) }
-				ref={ forwardRef }
-				{ ...props }
-			>
-				{ caption && <caption sx={ screenReaderTextClass }>{ caption }</caption> }
-				{ children }
-			</table>
+			<Box sx={ { width: '100%', overflowX: 'auto' } }>
+				<table
+					sx={ { width: '100%', minWidth: '1024px', borderSpacing: 0, ...sx } }
+					className={ classNames( 'vip-table-component', className ) }
+					ref={ forwardRef }
+					{ ...props }
+				>
+					{ caption && <caption sx={ screenReaderTextClass }>{ caption }</caption> }
+					{ children }
+				</table>
+			</Box>
 		);
 	}
 );

--- a/src/system/Table/Table.stories.jsx
+++ b/src/system/Table/Table.stories.jsx
@@ -10,8 +10,8 @@ export default {
 	component: Table,
 };
 
-export const Default = () => (
-	<Table caption="Storybook Example">
+const ExampleTable = ( { caption } ) => (
+	<Table caption={ caption }>
 		<thead>
 			<TableRow head cells={ [ 'User', 'Command', 'Duration', 'Time' ] } />
 		</thead>
@@ -47,4 +47,12 @@ export const Default = () => (
 			</TableRow>
 		</tbody>
 	</Table>
+);
+
+export const Default = () => <ExampleTable caption="Example Table" />;
+
+export const WithHorizontalScroll = () => (
+	<div sx={ { maxWidth: '800px' } }>
+		<ExampleTable caption="Horizontal Scroll Example" />
+	</div>
 );

--- a/src/system/Table/Table.stories.jsx
+++ b/src/system/Table/Table.stories.jsx
@@ -1,6 +1,11 @@
 /** @jsxImportSource theme-ui */
 
 /**
+ * External dependencies
+ */
+import PropTypes from 'prop-types';
+
+/**
  * Internal dependencies
  */
 import { Table, TableRow, Flex, Text, TableCell } from '..';
@@ -48,6 +53,10 @@ const ExampleTable = ( { caption } ) => (
 		</tbody>
 	</Table>
 );
+
+ExampleTable.propTypes = {
+	caption: PropTypes.string.isRequired,
+};
 
 export const Default = () => <ExampleTable caption="Example Table" />;
 


### PR DESCRIPTION
## Description

This PR adds a scrollable wrapper around tables so they get their own scrollbar. This should help avoid having horizontal scroll on the entire page specially when page has 200% zoom.

![image](https://user-images.githubusercontent.com/156388/224324385-dfbc8083-e523-440d-b045-f791570a2c4c.png)

**Note**: In order for the scrollbar to show up, some parent container must have fixed width. This can be merged on the Dashboard without problems, but in order for the horizontal scrollbar to appear on the table, additional changes must be added there. I'll send a PR to the Dashboard soon.

**Note**: I've decided to keep the `minWidth: 1024px` otherwise table columns would get smaller and don't look so nice. Since we will have horizontal scroll, I figured it would be OK to keep it.

I've also replaced `height: 36px` by `minHeight: 36px` on `<Input>` and `<Button>` so that they can grow when the text is zoomed:

![image](https://user-images.githubusercontent.com/156388/224325167-fac2f4a5-08c2-473f-9e5b-1e8983307623.png)

as opposed to:

![image](https://user-images.githubusercontent.com/156388/224325820-39d99d94-c770-4a10-a59f-e5157e3aeff3.png)

### JIRA
- https://vipjira.atlassian.net/browse/PIE-3577

## Checklist

- [ ] This PR has good automated test coverage
- [x] The storybook for the component has been updated

## Steps to Test

**Table**

1. Pull down PR.
1. `npm run dev`.
1. Open Storybook.
1. Visit the storybook example `Table > With Horizontal Scroll` and make sure it works.

**Button**

1. Pull down PR.
1. `npm run dev`.
1. Open Storybook.
1. Visit the storybook example `Button` and check the button with constrained width. The button background should follow the text.