### PR TITLE
[Table] Puts the component classname on the root element

### DIFF
--- a/src/system/Table/Table.js
+++ b/src/system/Table/Table.js
@@ -17,10 +17,13 @@ const Table = React.forwardRef(
 		}
 
 		return (
-			<Box sx={ { width: '100%', overflowX: 'auto' } }>
+			<Box
+				className={ classNames( 'vip-table-component', className ) }
+				sx={ { width: '100%', overflowX: 'auto' } }
+			>
 				<table
 					sx={ { width: '100%', minWidth: '1024px', borderSpacing: 0, ...sx } }
-					className={ classNames( 'vip-table-component', className ) }
+					className={ classNames( 'vip-table-component-element', className ) }
 					ref={ forwardRef }
 					{ ...props }
 				>


### PR DESCRIPTION
## Description

On a previous PR, I added a div element around the table component to allow for horizontal scrolling. Doing that made some E2E tests break because the root element of that component no longer a table. This PR makes the root element have the component class. Additional changes must also be made on the E2E tests as to not use `> table` selector directly and instead use the component class name: ` > .vip-table-component`.

## Checklist

- [ ] This PR has good automated test coverage
- [ ] The storybook for the component has been updated

## Steps to Test

1. Pull down PR.
1. `npm run dev`.
1. Open Storybook.
1. Open the Table example
1. Inspect the DOM and verify the table parent div has the `vip-component-table` class.
