### PR TITLE
PIE-3578 Fixes accordion responsive height

### DIFF
--- a/src/system/Accordion/Accordion.js
+++ b/src/system/Accordion/Accordion.js
@@ -103,6 +103,8 @@ export const Trigger = React.forwardRef(
 						color: 'icon.primary',
 						transform: 'rotate(90deg)',
 						transition: 'transform 300ms cubic-bezier(0.87, 0, 0.13, 1)',
+						minHeight: '20px',
+						minWidth: '20px',
 					} }
 					aria-hidden
 				/>

--- a/src/system/Accordion/Accordion.js
+++ b/src/system/Accordion/Accordion.js
@@ -72,7 +72,7 @@ export const Trigger = React.forwardRef(
 					all: 'unset',
 					fontFamily: 'inherit',
 					px: 3,
-					height: 45,
+					minHeight: 45,
 					flex: 1,
 					display: 'flex',
 					alignItems: 'center',

--- a/src/system/Accordion/Accordion.stories.jsx
+++ b/src/system/Accordion/Accordion.stories.jsx
@@ -23,33 +23,37 @@ const ExampleContent = () => (
 	</Box>
 );
 
-export const Default = () => (
-	<Box>
-		<Accordion.Root defaultValue="teamPermissions" sx={ { width: '450px' } }>
-			<Accordion.Item value="teamPermissions">
-				<Accordion.TriggerWithIcon icon={ <RiUserAddLine /> }>
-					Team & Permissions
-				</Accordion.TriggerWithIcon>
-				<Accordion.Content>
-					<ExampleContent />
-				</Accordion.Content>
-			</Accordion.Item>
-			<Accordion.Item value="addContentMedia">
-				<Accordion.TriggerWithIcon icon={ <BiBookContent /> }>
-					Add Content & Media
-				</Accordion.TriggerWithIcon>
-				<Accordion.Content>
-					<ExampleContent />
-				</Accordion.Content>
-			</Accordion.Item>
-			<Accordion.Item value="addCode">
-				<Accordion.TriggerWithIcon icon={ <RiCodeSSlashFill /> }>
-					Add Code
-				</Accordion.TriggerWithIcon>
-				<Accordion.Content>
-					<ExampleContent />
-				</Accordion.Content>
-			</Accordion.Item>
-		</Accordion.Root>
+const ExampleAccordion = () => (
+	<Accordion.Root defaultValue="teamPermissions" sx={ { width: '250px' } }>
+		<Accordion.Item value="teamPermissions">
+			<Accordion.TriggerWithIcon icon={ <RiUserAddLine /> }>
+				Team & Permissions
+			</Accordion.TriggerWithIcon>
+			<Accordion.Content>
+				<ExampleContent />
+			</Accordion.Content>
+		</Accordion.Item>
+		<Accordion.Item value="addContentMedia">
+			<Accordion.TriggerWithIcon icon={ <BiBookContent /> }>
+				Add Content & Media
+			</Accordion.TriggerWithIcon>
+			<Accordion.Content>
+				<ExampleContent />
+			</Accordion.Content>
+		</Accordion.Item>
+		<Accordion.Item value="addCode">
+			<Accordion.TriggerWithIcon icon={ <RiCodeSSlashFill /> }>Add Code</Accordion.TriggerWithIcon>
+			<Accordion.Content>
+				<ExampleContent />
+			</Accordion.Content>
+		</Accordion.Item>
+	</Accordion.Root>
+);
+
+export const Default = () => <ExampleAccordion />;
+
+export const WithLargeText = () => (
+	<Box sx={ { '.vip-heading-component > button': { fontSize: '25px' } } }>
+		<ExampleAccordion />
 	</Box>
 );


### PR DESCRIPTION
## Description

The items of the Accordion component were not responding well when the browser screen was zoomed in for accessibility. This problem was outlined by @kat3samsin on https://vipjira.atlassian.net/browse/PIE-3578.

I added an example with large text to showcase the issue:

![AccordionLargeBroken](https://user-images.githubusercontent.com/156388/224737540-6eb0eb96-598f-4ded-a0c9-33e1e9d21442.png)

I've fixed it the same way I fixed the buttons, by using `minHeight` instead of a fixed `height`:

![AccordionLargeFixed](https://user-images.githubusercontent.com/156388/224737737-9f6a8375-bc14-4214-af36-037d81d12186.png)

I've also noticed some arrows were smaller than the others, depending on the text width of the accordion item. So I made them all consistent.

![image](https://user-images.githubusercontent.com/156388/224738351-d5d4a117-1dbd-497c-8066-9ea5ce3b29a5.png)

![image](https://user-images.githubusercontent.com/156388/224738468-42e60a66-26c9-483f-9a9b-074cd64a8dd2.png)

## Checklist

- [ ] This PR has good automated test coverage
- [ ] The storybook for the component has been updated

## Steps to Test

1. Pull down PR.
1. `npm run dev`.
1. Open Storybook.
1. Go to the Accordion > With Large Text example
1. Make sure the items in the accordion expand with the text
