### PR TITLE
Fixes a11y issue where scrollable element must be keyboard accessible.

### DIFF
--- a/src/system/Table/Table.js
+++ b/src/system/Table/Table.js
@@ -20,6 +20,7 @@ const Table = React.forwardRef(
 			<Box
 				className={ classNames( 'vip-table-component', className ) }
 				sx={ { width: '100%', overflowX: 'auto' } }
+				tabIndex={ 0 }
 			>
 				<table
 					sx={ { width: '100%', minWidth: '1024px', borderSpacing: 0, ...sx } }

--- a/src/system/Table/Table.js
+++ b/src/system/Table/Table.js
@@ -3,11 +3,16 @@
 /**
  * External dependencies
  */
-import React from 'react';
+import React, { useMemo } from 'react';
 import PropTypes from 'prop-types';
 import classNames from 'classnames';
+
+/**
+ * Internal dependencies
+ */
 import { screenReaderTextClass } from '../ScreenReaderText/ScreenReaderText';
 import { Box } from '../';
+import { generateId } from '../utils/random';
 
 const Table = React.forwardRef(
 	( { sx, className, children, caption = null, ...props }, forwardRef ) => {
@@ -16,10 +21,17 @@ const Table = React.forwardRef(
 			console.warn( '[A11Y] Please, add a caption to your table.' );
 		}
 
+		const captionId = useMemo( () => `table_caption_${ generateId() }`, [] );
+
 		return (
 			<Box
 				className={ classNames( 'vip-table-component', className ) }
 				sx={ { width: '100%', overflowX: 'auto' } }
+				role="region"
+				ariaLabelledby={ captionId }
+				// Because this container is scrollable, it needs to be focusable.
+				// A tabIndex value of 0 makes it focusable by keyboard and does not
+				// interfere with the tab order.
 				tabIndex={ 0 }
 			>
 				<table
@@ -28,7 +40,11 @@ const Table = React.forwardRef(
 					ref={ forwardRef }
 					{ ...props }
 				>
-					{ caption && <caption sx={ screenReaderTextClass }>{ caption }</caption> }
+					{ caption && (
+						<caption id={ captionId } sx={ screenReaderTextClass }>
+							{ caption }
+						</caption>
+					) }
 					{ children }
 				</table>
 			</Box>

--- a/src/system/Table/Table.stories.jsx
+++ b/src/system/Table/Table.stories.jsx
@@ -32,7 +32,6 @@ const ExampleTable = ( { caption } ) => (
 					</Text>,
 					<Text key="time">11th Mar 2020, 16:49:22</Text>,
 				] }
-				gbc
 			/>
 			<TableRow>
 				<TableCell>

--- a/src/system/utils/random.js
+++ b/src/system/utils/random.js
@@ -1,0 +1,3 @@
+export function generateId() {
+	return Math.random().toString( 36 ).substring( 2, 15 );
+}


### PR DESCRIPTION
## Description

This fixes an issue found by the recently added accessibility test automation capabilities on the Dashboard. See https://github.com/Automattic/vip-dashboard/suites/11534339782/artifacts/596756508 for more information.

I've tried to reproduce this with unit testing:

```js
// Check for accessibility issues
expect( await axe( container ) ).toHaveNoViolations();
```

But, unfortunately, was unable to do so. I think jest running on JSDOM has some issues.

**Before**

![image](https://user-images.githubusercontent.com/156388/225101016-bf571e15-6a6d-48bf-83a3-6edcbdb83c48.png)

**After**

![image](https://user-images.githubusercontent.com/156388/225101118-79c38214-be44-4e99-8a10-a35515f7931d.png)

## Checklist

- [ ] This PR has good automated test coverage
- [ ] The storybook for the component has been updated

## Steps to Test

1. Pull down PR.
1. `npm run dev`.
1. Open Storybook.
1. Visit http://localhost:6006/?path=/story/table--with-horizontal-scroll
1. Make sure there are no accessibility violations
