### PR TITLE
Set label from theme-ui to use the as property

### DIFF
--- a/src/system/Form/Label.js
+++ b/src/system/Form/Label.js
@@ -5,7 +5,7 @@
  */
 import React from 'react';
 import PropTypes from 'prop-types';
-
+import { Box } from 'theme-ui';
 /**
  * Internal dependencies
  */
@@ -19,26 +19,31 @@ export const baseLabelStyle = {
 	color: baseLabelColor,
 };
 
-const Label = React.forwardRef( ( { sx, children, required, ...rest }, forwardRef ) => (
-	<label
-		sx={ {
-			...baseLabelStyle,
-			display: 'block',
-			mb: 2,
-			...sx,
-		} }
-		ref={ forwardRef }
-		{ ...rest }
-	>
-		{ children }
-		{ required && <RequiredLabel /> }
-	</label>
-) );
+const Label = React.forwardRef(
+	( { sx, children, required, as = 'label', ...rest }, forwardRef ) => (
+		<Box
+			as={ as }
+			sx={ {
+				all: 'unset',
+				...baseLabelStyle,
+				display: 'block',
+				mb: 2,
+				...sx,
+			} }
+			ref={ forwardRef }
+			{ ...rest }
+		>
+			{ children }
+			{ required && <RequiredLabel /> }
+		</Box>
+	)
+);
 
 Label.propTypes = {
 	children: PropTypes.any,
 	required: PropTypes.bool,
 	sx: PropTypes.object,
+	as: PropTypes.node,
 };
 
 Label.displayName = 'Label';


### PR DESCRIPTION
## Description

Use `Box` as the base component to be able to use `as` prop and other internal props.

## Steps to Test

1. Pull down PR.
2. `npm run dev`.
3. Open http://localhost:6006/?path=/story/form-label--default
4. Label is the same
