### PR TITLE
Wizard - Remove duplicated current step announcement for screen readers

### DIFF
--- a/src/system/Wizard/WizardStep.js
+++ b/src/system/Wizard/WizardStep.js
@@ -36,7 +36,7 @@ const WizardStep = React.forwardRef(
 		let statusText = 'Step not completed';
 		if ( active ) {
 			status = 'active';
-			statusText = 'Current step';
+			statusText = ''; // not adding the status text for active step since it's announced by aria-current
 		} else if ( complete ) {
 			status = 'complete';
 			statusText = 'Step completed';
@@ -44,7 +44,9 @@ const WizardStep = React.forwardRef(
 			status = 'skipped';
 			statusText = 'Step skipped';
 		}
-		statusText = `Status: ${ statusText }`;
+		if ( statusText !== '' ) {
+			statusText = `Status: ${ statusText }`;
+		}
 		const stepText = `Step ${ order } of ${ totalSteps }`;
 
 		const borderLeftColor = `wizard.step.border.${ status }`;


### PR DESCRIPTION
## Description

This PR is a followup to #189 which introduced the announcements of the statuses.

Since the `aria-current="step"` is working fine, we're removing the duplicate information we added.

## Checklist

- [ ] This PR has good automated test coverage
- [ ] The storybook for the component has been updated

## Steps to Test

Outline the steps to test and verify the PR here.

Example:

1. Pull down PR.
1. `npm run dev`.
1. Navigate with voiceover the wizard page http://localhost:6006/?path=/story/wizard--default
1. The active/current step should be announced correctly with no duplication of the "Status: Current step", which is now removed.
