### PR TITLE
Fix New Invitation flow A11Y issues

### DIFF
--- a/src/system/Form/RadioBoxGroup.js
+++ b/src/system/Form/RadioBoxGroup.js
@@ -6,8 +6,8 @@
 import React, { useCallback } from 'react';
 import PropTypes from 'prop-types';
 import ScreenReaderText from '../ScreenReaderText';
-import { Label } from './Label';
 import { Validation } from './Validation';
+import { RequiredLabel } from './RequiredLabel';
 
 /**
  * Internal dependencies
@@ -154,12 +154,15 @@ const RadioBoxGroup = React.forwardRef(
 							: {} ),
 					} }
 					ref={ forwardRef }
+					aria-required={ required }
+					role="radiogroup"
 					{ ...props }
 				>
 					{ groupLabel ? (
-						<Label as="legend" sx={ { mb: 2 } } required={ required }>
+						<legend sx={ { mb: 2 } }>
 							{ groupLabel }
-						</Label>
+							{ required ? <RequiredLabel /> : null }
+						</legend>
 					) : (
 						<ScreenReaderText>Choose an option</ScreenReaderText>
 					) }


### PR DESCRIPTION
## Description
Jira: https://vipjira.atlassian.net/browse/PIE-3636

Fix for A11Y feedback from New Invitation flow [PR](https://github.com/Automattic/vip-dashboard/pull/2715).
- Updated `Label` as legend to `legend` semantic. 
- Added `aria-required` attribute to `input type='radio'`

## Checklist

- [ ] This PR has good automated test coverage
- [ ] The storybook for the component has been updated

## Steps to Test

**Radio Buttons**
- The radio buttons to select an organization role should have an aria-required attribute.
- The radio buttons to select an organization role are inside of a <fieldset>. This fieldset currently has a label as="legend". This does not work for a screen reader. Use the semantic <legend> instead, to ensure that the radio buttons are linked to the legend.

1. Navigate to [RadioBoxGroup](https://deploy-preview-203--vip-design-system-components.netlify.app/?path=/story/radioboxgroup--errors)
2. Enable VO
3. Make sure `required` is announced properly on the group level
4. Make sure radio options are announced properly


