### PR TITLE
Tabs: Pass className to Tab components

### DIFF
--- a/src/system/Tabs/Tabs.js
+++ b/src/system/Tabs/Tabs.js
@@ -20,7 +20,6 @@ const Tabs = React.forwardRef(
 			defaultValue = undefined,
 			value = undefined,
 			className = null,
-			sx = {},
 		},
 		ref
 	) => {
@@ -31,7 +30,6 @@ const Tabs = React.forwardRef(
 				defaultValue={ defaultValue }
 				onValueChange={ onValueChange }
 				className={ classNames( 'vip-tabs-component', className ) }
-				sx={ { ...sx } }
 			>
 				{ children }
 			</TabsPrimitive.Root>
@@ -41,7 +39,6 @@ const Tabs = React.forwardRef(
 
 Tabs.propTypes = {
 	className: PropTypes.any,
-	sx: PropTypes.object,
 	defaultValue: PropTypes.node,
 	value: PropTypes.node,
 	onValueChange: PropTypes.func,

--- a/src/system/Tabs/Tabs.stories.jsx
+++ b/src/system/Tabs/Tabs.stories.jsx
@@ -1,3 +1,5 @@
+/** @jsxImportSource theme-ui */
+
 /**
  * External dependencies
  */

--- a/src/system/Tabs/TabsContent.js
+++ b/src/system/Tabs/TabsContent.js
@@ -11,13 +11,12 @@ import classNames from 'classnames';
  * Internal dependencies
  */
 
-const TabsContent = ( { value, sx, children } ) => (
+const TabsContent = ( { value, children, className = null } ) => (
 	<TabsPrimitive.Content
-		className={ classNames( 'vip-tabs-content', `vip-tabs-content-${ value }` ) }
+		className={ classNames( 'vip-tabs-content', `vip-tabs-content-${ value }`, className ) }
 		value={ value }
 		sx={ {
 			mt: 4,
-			...sx,
 		} }
 	>
 		{ children }
@@ -25,7 +24,7 @@ const TabsContent = ( { value, sx, children } ) => (
 );
 
 TabsContent.propTypes = {
-	sx: PropTypes.object,
+	className: PropTypes.string,
 	value: PropTypes.string,
 	children: PropTypes.node.isRequired,
 };

--- a/src/system/Tabs/TabsList.js
+++ b/src/system/Tabs/TabsList.js
@@ -10,22 +10,21 @@ import * as TabsPrimitive from '@radix-ui/react-tabs';
  * Internal dependencies
  */
 
-const TabsList = ( { children, title, sx } ) => (
+const TabsList = ( { children, title, ...props } ) => (
 	<TabsPrimitive.List
 		sx={ {
 			borderBottom: '1px solid',
 			borderColor: 'borders.2',
 			display: 'flex',
-			...sx,
 		} }
 		aria-label={ title }
+		{ ...props }
 	>
 		{ children }
 	</TabsPrimitive.List>
 );
 
 TabsList.propTypes = {
-	sx: PropTypes.object,
 	title: PropTypes.string.isRequired,
 	children: PropTypes.node.isRequired,
 };

--- a/src/system/Tabs/TabsTrigger.js
+++ b/src/system/Tabs/TabsTrigger.js
@@ -35,23 +35,24 @@ const styles = {
 	'&:focus-visible': theme => theme.outline,
 };
 
-const TabsTrigger = React.forwardRef( ( { value, disabled = false, sx, children }, forwardRef ) => (
-	<TabsPrimitive.TabsTrigger
-		className={ classNames( 'vip-tabs-trigger', `vip-tabs-trigger-${ value }` ) }
-		value={ value }
-		disabled={ disabled }
-		sx={ {
-			...styles,
-			...sx,
-		} }
-		ref={ forwardRef }
-	>
-		{ children }
-	</TabsPrimitive.TabsTrigger>
-) );
+const TabsTrigger = React.forwardRef(
+	( { value, disabled = false, children, className = null }, forwardRef ) => (
+		<TabsPrimitive.TabsTrigger
+			className={ classNames( 'vip-tabs-trigger', `vip-tabs-trigger-${ value }`, className ) }
+			value={ value }
+			disabled={ disabled }
+			sx={ {
+				...styles,
+			} }
+			ref={ forwardRef }
+		>
+			{ children }
+		</TabsPrimitive.TabsTrigger>
+	)
+);
 
 TabsTrigger.propTypes = {
-	sx: PropTypes.object,
+	className: PropTypes.string,
 	value: PropTypes.string,
 	disabled: PropTypes.bool,
 	children: PropTypes.node.isRequired,


### PR DESCRIPTION
## Description

Currently several Tabs components attempt to capture the `sx` prop and pass it to the Radix primitives. This doesn't work where the theme-ui pragma is defined (e.g. in the Dashboard) since the sx prop isn't passed through. Instead we can pass through the `className` prop and Theme UI will automatically handle the rest.

## Checklist

- [ ] This PR has good automated test coverage
- [x] The storybook for the component has been updated

## Steps to Test

1. Pull down PR.
1. `npm run dev`.
1. Open Storybook.
1. Edit `Tabs.stories.jsx` to add styles to a component via the `sx` prop 
1. Verify the styles are reflected in the Storybook preview
