### PR TITLE
Input > Ability to add an adjacent component to the Input box

### DIFF
--- a/src/system/Form/Input.js
+++ b/src/system/Form/Input.js
@@ -27,7 +27,17 @@ const inputStyles = {
 
 const Input = React.forwardRef(
 	(
-		{ variant, label, forLabel, hasError = false, required, sx = {}, errorMessage, ...props },
+		{
+			variant,
+			label,
+			forLabel,
+			hasError = false,
+			required,
+			sx = {},
+			errorMessage,
+			flexComponent = null,
+			...props
+		},
 		ref
 	) => (
 		<React.Fragment>
@@ -36,21 +46,22 @@ const Input = React.forwardRef(
 					{ label }
 				</Label>
 			) }
-
-			<ThemeInput
-				ref={ ref }
-				id={ forLabel }
-				required={ required }
-				aria-required={ required }
-				aria-describedby={ hasError ? `describe-${ forLabel }-validation` : undefined }
-				sx={ {
-					...inputStyles,
-					...sx,
-					...( hasError ? { borderColor: 'input.border.error' } : {} ),
-				} }
-				{ ...props }
-			/>
-
+			<div sx={ flexComponent && flexComponent.display === 'flex' ? { display: 'flex' } : {} }>
+				<ThemeInput
+					ref={ ref }
+					id={ forLabel }
+					required={ required }
+					aria-required={ required }
+					aria-describedby={ hasError ? `describe-${ forLabel }-validation` : undefined }
+					sx={ {
+						...inputStyles,
+						...sx,
+						...( hasError ? { borderColor: 'input.border.error' } : {} ),
+					} }
+					{ ...props }
+				/>
+				{ flexComponent && <div sx={ { ml: 2 } }>{ flexComponent.component }</div> }
+			</div>
 			{ hasError && errorMessage && (
 				<Validation isValid={ false } describedId={ forLabel }>
 					{ errorMessage }

--- a/src/system/Form/Input.js
+++ b/src/system/Form/Input.js
@@ -35,7 +35,7 @@ const Input = React.forwardRef(
 			required,
 			sx = {},
 			errorMessage,
-			flexComponent = null,
+			flexComponent = {},
 			...props
 		},
 		ref
@@ -79,6 +79,7 @@ Input.propTypes = {
 	forLabel: PropTypes.string,
 	errorMessage: PropTypes.string,
 	sx: PropTypes.object,
+	flexComponent: PropTypes.object,
 };
 
 Input.displayName = 'Input';

--- a/src/system/Form/Input.stories.jsx
+++ b/src/system/Form/Input.stories.jsx
@@ -48,7 +48,7 @@ export const WithFlexComponent = () => (
 			flexComponent={ {
 				display: 'flex',
 				component: (
-					<Button sx={ { height: '40px' } }>
+					<Button sx={ { height: '40px' } } aria-label="copy">
 						<MdContentCopy />
 					</Button>
 				),

--- a/src/system/Form/Input.stories.jsx
+++ b/src/system/Form/Input.stories.jsx
@@ -4,8 +4,6 @@
  * Internal dependencies
  */
 import { Form } from '..';
-import { Button } from '../Button';
-import { MdContentCopy } from 'react-icons/md';
 
 export default {
 	title: 'Form/Input',
@@ -36,25 +34,5 @@ export const Default = () => (
 
 		<Form.Label htmlFor="input-with-custom-label">Custom Label outside the Input</Form.Label>
 		<Form.Input forLabel="input-with-custom-label" required />
-	</Form.Root>
-);
-
-export const WithFlexComponent = () => (
-	<Form.Root>
-		<Form.Input
-			placeholder="Your input here..."
-			label="Always add a label to inputs"
-			forLabel="input-simple"
-			flexComponent={ {
-				display: 'flex',
-				component: (
-					<Button sx={ { height: '40px' } } aria-label="copy">
-						<MdContentCopy />
-					</Button>
-				),
-			} }
-			errorMessage="Please type numeric characters only"
-			hasError
-		/>
 	</Form.Root>
 );

--- a/src/system/Form/Input.stories.jsx
+++ b/src/system/Form/Input.stories.jsx
@@ -4,6 +4,8 @@
  * Internal dependencies
  */
 import { Form } from '..';
+import { Button } from '../Button';
+import { MdContentCopy } from 'react-icons/md';
 
 export default {
 	title: 'Form/Input',
@@ -34,5 +36,25 @@ export const Default = () => (
 
 		<Form.Label htmlFor="input-with-custom-label">Custom Label outside the Input</Form.Label>
 		<Form.Input forLabel="input-with-custom-label" required />
+	</Form.Root>
+);
+
+export const WithFlexComponent = () => (
+	<Form.Root>
+		<Form.Input
+			placeholder="Your input here..."
+			label="Always add a label to inputs"
+			forLabel="input-simple"
+			flexComponent={ {
+				display: 'flex',
+				component: (
+					<Button sx={ { height: '40px' } }>
+						<MdContentCopy />
+					</Button>
+				),
+			} }
+			errorMessage="Please type numeric characters only"
+			hasError
+		/>
 	</Form.Root>
 );

--- a/src/system/Form/InputWithCopyButton.js
+++ b/src/system/Form/InputWithCopyButton.js
@@ -5,11 +5,13 @@
  */
 import React from 'react';
 import PropTypes from 'prop-types';
+import { MdContentCopy } from 'react-icons/md';
+import { Button } from 'theme-ui';
 
 /**
  * Internal dependencies
  */
-import { Validation, Label } from '../';
+import { Validation, Label } from '..';
 import { Input as ThemeInput } from 'theme-ui';
 import { baseControlStyle } from './Input.styles';
 
@@ -25,7 +27,7 @@ const inputStyles = {
 	variant: 'inputs.default',
 };
 
-const Input = React.forwardRef(
+const InputWithCopyButton = React.forwardRef(
 	(
 		{ variant, label, forLabel, hasError = false, required, sx = {}, errorMessage, ...props },
 		ref
@@ -36,19 +38,26 @@ const Input = React.forwardRef(
 					{ label }
 				</Label>
 			) }
-			<ThemeInput
-				ref={ ref }
-				id={ forLabel }
-				required={ required }
-				aria-required={ required }
-				aria-describedby={ hasError ? `describe-${ forLabel }-validation` : undefined }
-				sx={ {
-					...inputStyles,
-					...sx,
-					...( hasError ? { borderColor: 'input.border.error' } : {} ),
-				} }
-				{ ...props }
-			/>
+			<div sx={ { display: 'flex' } }>
+				<ThemeInput
+					ref={ ref }
+					id={ forLabel }
+					required={ required }
+					aria-required={ required }
+					aria-describedby={ hasError ? `describe-${ forLabel }-validation` : undefined }
+					sx={ {
+						...inputStyles,
+						...sx,
+						...( hasError ? { borderColor: 'input.border.error' } : {} ),
+					} }
+					{ ...props }
+				/>
+				<div sx={ { ml: 2 } }>
+					<Button sx={ { height: '40px' } } aria-label={ `Copy ${ label }` }>
+						<MdContentCopy />
+					</Button>
+				</div>
+			</div>
 			{ hasError && errorMessage && (
 				<Validation isValid={ false } describedId={ forLabel }>
 					{ errorMessage }
@@ -58,7 +67,7 @@ const Input = React.forwardRef(
 	)
 );
 
-Input.propTypes = {
+InputWithCopyButton.propTypes = {
 	variant: PropTypes.string,
 	label: PropTypes.string,
 	hasError: PropTypes.bool,
@@ -68,6 +77,6 @@ Input.propTypes = {
 	sx: PropTypes.object,
 };
 
-Input.displayName = 'Input';
+InputWithCopyButton.displayName = 'InputWithCopyButton';
 
-export { Input };
+export { InputWithCopyButton };

--- a/src/system/Form/InputWithCopyButton.js
+++ b/src/system/Form/InputWithCopyButton.js
@@ -28,7 +28,17 @@ const inputStyles = {
 
 const InputWithCopyButton = React.forwardRef(
 	(
-		{ variant, label, forLabel, hasError = false, required, sx = {}, errorMessage, ...props },
+		{
+			variant,
+			label,
+			forLabel,
+			hasError = false,
+			required,
+			sx = {},
+			errorMessage,
+			copyHandler,
+			...props
+		},
 		ref
 	) => {
 		if ( ! ref ) {
@@ -37,17 +47,11 @@ const InputWithCopyButton = React.forwardRef(
 
 		const handleCopy = e => {
 			e.preventDefault();
-			if ( ! ref.current ) {
-				return;
+			const clipboard = navigator.clipboard;
+			clipboard.writeText( ref.current.value );
+			if ( copyHandler ) {
+				copyHandler( ref.current.value );
 			}
-			const originalTypeStatus = ref.current.getAttribute( 'type' ) || '';
-			if ( ref.current.getAttribute( 'value' ) === '' ) {
-				ref.current.setAttribute( 'value', '    ' );
-			}
-			ref.current.setAttribute( 'type', 'text' );
-			ref.current.select();
-			document.execCommand( 'copy' ); // eslint-disable-line no-undef
-			ref.current?.setAttribute( 'type', originalTypeStatus );
 		};
 		return (
 			<React.Fragment>
@@ -100,6 +104,7 @@ InputWithCopyButton.propTypes = {
 	forLabel: PropTypes.string,
 	errorMessage: PropTypes.string,
 	sx: PropTypes.object,
+	copyHandler: PropTypes.func,
 };
 
 InputWithCopyButton.displayName = 'InputWithCopyButton';

--- a/src/system/Form/InputWithCopyButton.js
+++ b/src/system/Form/InputWithCopyButton.js
@@ -6,12 +6,11 @@
 import React from 'react';
 import PropTypes from 'prop-types';
 import { MdContentCopy } from 'react-icons/md';
-import { Button } from 'theme-ui';
 
 /**
  * Internal dependencies
  */
-import { Validation, Label } from '..';
+import { Button, Validation, Label } from '..';
 import { Input as ThemeInput } from 'theme-ui';
 import { baseControlStyle } from './Input.styles';
 
@@ -76,8 +75,10 @@ const InputWithCopyButton = React.forwardRef(
 							sx={ { height: '40px' } }
 							aria-label={ `Copy ${ label }` }
 							onClick={ handleCopy }
+							variant="ghost"
 						>
-							<MdContentCopy />
+							<MdContentCopy sx={ { mr: 2 } } />
+							Copy
 						</Button>
 					</div>
 				</div>

--- a/src/system/Form/InputWithCopyButton.js
+++ b/src/system/Form/InputWithCopyButton.js
@@ -31,40 +31,64 @@ const InputWithCopyButton = React.forwardRef(
 	(
 		{ variant, label, forLabel, hasError = false, required, sx = {}, errorMessage, ...props },
 		ref
-	) => (
-		<React.Fragment>
-			{ label && (
-				<Label required={ required } htmlFor={ forLabel }>
-					{ label }
-				</Label>
-			) }
-			<div sx={ { display: 'flex' } }>
-				<ThemeInput
-					ref={ ref }
-					id={ forLabel }
-					required={ required }
-					aria-required={ required }
-					aria-describedby={ hasError ? `describe-${ forLabel }-validation` : undefined }
-					sx={ {
-						...inputStyles,
-						...sx,
-						...( hasError ? { borderColor: 'input.border.error' } : {} ),
-					} }
-					{ ...props }
-				/>
-				<div sx={ { ml: 2 } }>
-					<Button sx={ { height: '40px' } } aria-label={ `Copy ${ label }` }>
-						<MdContentCopy />
-					</Button>
+	) => {
+		if ( ! ref ) {
+			ref = React.createRef();
+		}
+
+		const handleCopy = e => {
+			e.preventDefault();
+			if ( ! ref.current ) {
+				return;
+			}
+			const originalTypeStatus = ref.current.getAttribute( 'type' ) || '';
+			if ( ref.current.getAttribute( 'value' ) === '' ) {
+				ref.current.setAttribute( 'value', '    ' );
+			}
+			ref.current.setAttribute( 'type', 'text' );
+			ref.current.select();
+			document.execCommand( 'copy' ); // eslint-disable-line no-undef
+			ref.current?.setAttribute( 'type', originalTypeStatus );
+		};
+		return (
+			<React.Fragment>
+				{ label && (
+					<Label required={ required } htmlFor={ forLabel }>
+						{ label }
+					</Label>
+				) }
+				<div sx={ { display: 'flex' } }>
+					<ThemeInput
+						ref={ ref }
+						id={ forLabel }
+						required={ required }
+						aria-required={ required }
+						aria-describedby={ hasError ? `describe-${ forLabel }-validation` : undefined }
+						sx={ {
+							...inputStyles,
+							...sx,
+							...( hasError ? { borderColor: 'input.border.error' } : {} ),
+						} }
+						{ ...props }
+					/>
+					<div sx={ { ml: 2 } }>
+						<Button
+							sx={ { height: '40px' } }
+							aria-label={ `Copy ${ label }` }
+							onClick={ handleCopy }
+						>
+							<MdContentCopy />
+						</Button>
+					</div>
 				</div>
-			</div>
-			{ hasError && errorMessage && (
-				<Validation isValid={ false } describedId={ forLabel }>
-					{ errorMessage }
-				</Validation>
-			) }
-		</React.Fragment>
-	)
+				{ hasError && errorMessage && (
+					<Validation isValid={ false } describedId={ forLabel }>
+						{ errorMessage }
+					</Validation>
+				) }
+			</React.Fragment>
+		);
+	}
 );
 
 InputWithCopyButton.propTypes = {

--- a/src/system/Form/InputWithCopyButton.js
+++ b/src/system/Form/InputWithCopyButton.js
@@ -47,7 +47,7 @@ const InputWithCopyButton = React.forwardRef(
 
 		const handleCopy = e => {
 			e.preventDefault();
-			const clipboard = navigator.clipboard;
+			const clipboard = navigator.clipboard; // eslint-disable-line no-undef
 			clipboard.writeText( ref.current.value );
 			if ( copyHandler ) {
 				copyHandler( ref.current.value );

--- a/src/system/Form/InputWithCopyButton.stories.jsx
+++ b/src/system/Form/InputWithCopyButton.stories.jsx
@@ -4,17 +4,28 @@
  * Internal dependencies
  */
 import { Form } from '..';
+import { Notice } from '..';
+import { useState } from 'react';
 
 export default {
 	title: 'Form/InputWithCopyButton',
 };
 
-export const Default = () => (
-	<Form.Root>
-		<Form.InputWithCopyButton
-			placeholder="Your input here..."
-			label="Always add a label to inputs"
-			forLabel="input-simple"
-		/>
-	</Form.Root>
-);
+export const Default = () => {
+	const [ copiedText, setCopiedText ] = useState( '' );
+	return (
+		<Form.Root>
+			{ copiedText && (
+				<Notice variant="success" sx={ { mb: 4 } }>
+					Input successfully copied value! <strong>{ copiedText }</strong>
+				</Notice>
+			) }
+			<Form.InputWithCopyButton
+				placeholder="Your input here..."
+				label="Always add a label to inputs"
+				forLabel="input-simple"
+				copyHandler={ value => setCopiedText( value ) }
+			/>
+		</Form.Root>
+	);
+};

--- a/src/system/Form/InputWithCopyButton.stories.jsx
+++ b/src/system/Form/InputWithCopyButton.stories.jsx
@@ -1,0 +1,20 @@
+/** @jsxImportSource theme-ui */
+
+/**
+ * Internal dependencies
+ */
+import { Form } from '..';
+
+export default {
+	title: 'Form/InputWithCopyButton',
+};
+
+export const Default = () => (
+	<Form.Root>
+		<Form.InputWithCopyButton
+			placeholder="Your input here..."
+			label="Always add a label to inputs"
+			forLabel="input-simple"
+		/>
+	</Form.Root>
+);

--- a/src/system/Form/InputWithCopyButton.stories.jsx
+++ b/src/system/Form/InputWithCopyButton.stories.jsx
@@ -3,8 +3,7 @@
 /**
  * Internal dependencies
  */
-import { Form } from '..';
-import { Notice } from '..';
+import { Form, Notice } from '..';
 import { useState } from 'react';
 
 export default {

--- a/src/system/Form/index.js
+++ b/src/system/Form/index.js
@@ -2,6 +2,7 @@
  * Internal dependencies
  */
 import { Input } from './Input';
+import { InputWithCopyButton } from './InputWithCopyButton';
 import { Label } from './Label';
 import { Toggle } from './Toggle';
 import { Validation } from './Validation';
@@ -14,6 +15,7 @@ import { Checkbox } from './Checkbox';
 
 export {
 	Input,
+	InputWithCopyButton,
 	Label,
 	Radio,
 	RadioBoxGroup,

--- a/src/system/NewForm/index.js
+++ b/src/system/NewForm/index.js
@@ -7,6 +7,7 @@ import { FormAutocomplete } from './FormAutocomplete';
 import { FormAutocompleteMultiselect } from './FormAutocompleteMultiselect';
 import { Textarea } from '../Form/Textarea';
 import { Input } from '../Form/Input';
+import { InputWithCopyButton } from '../Form/InputWithCopyButton';
 import { Form } from './Form';
 import { Fieldset } from './Fieldset';
 import { Legend } from './Legend';
@@ -17,6 +18,17 @@ const Autocomplete = FormAutocomplete;
 const AutocompleteMulti = FormAutocompleteMultiselect;
 const Root = Form;
 
-export { Root, Select, Autocomplete, AutocompleteMulti, Textarea, Input, Label, Fieldset, Legend };
+export {
+	Root,
+	Select,
+	Autocomplete,
+	AutocompleteMulti,
+	Textarea,
+	Input,
+	InputWithCopyButton,
+	Label,
+	Fieldset,
+	Legend,
+};
 
 export default Root;


### PR DESCRIPTION
## Description

~Added option to add a component with `display: flex` beside the input box without affecting Label and Hint message.
This is to support adding a `copy` button beside input box.~

Created a new Input component with a Copy button > `InputWithCopyButton`

<img width="1713" alt="image" src="https://github.com/Automattic/vip-design-system/assets/2224344/77b9d8af-3115-4e11-85c1-b1f642fafe7b">

With notification callback
<img width="980" alt="image" src="https://github.com/Automattic/vip-design-system/assets/2224344/b8a55850-5df6-4750-8f16-20281b4c2172">

## Checklist

- [ ] This PR has good automated test coverage
- [x] The storybook for the component has been updated

## Steps to Test

1. Navigate to the [component](https://deploy-preview-206--vip-design-system-components.netlify.app/?path=/story/form-inputwithcopybutton--default).
2. Make sure the copy button is adjacent to the input box and label 
3. Make sure text is copied