### PR TITLE
propagate className to the NewDialog when present

### DIFF
--- a/src/system/NewConfirmationDialog/NewConfirmationDialog.stories.jsx
+++ b/src/system/NewConfirmationDialog/NewConfirmationDialog.stories.jsx
@@ -17,6 +17,7 @@ export const Default = () => {
 		<Box>
 			<p>Confirm that your name is John doe?</p>
 			<NewConfirmationDialog
+				className="storybook-confirmation-dialog"
 				title={ 'Are you John Doe?' }
 				buttonVariant="danger"
 				description={ 'Please confirm that your name is John Doe.' }

--- a/src/system/NewConfirmationDialog/NewConfirmationDialog.test.js
+++ b/src/system/NewConfirmationDialog/NewConfirmationDialog.test.js
@@ -10,6 +10,7 @@ import { axe } from 'jest-axe';
 import { NewConfirmationDialog } from './NewConfirmationDialog';
 
 const defaultProps = {
+	className: 'my-custom-class',
 	needsConfirm: true,
 	title: 'My Custom Title',
 	body: 'My Custom Text',
@@ -17,6 +18,7 @@ const defaultProps = {
 	trigger: <button>Trigger</button>,
 };
 
+const getDialog = () => screen.getByRole( 'dialog' );
 const getButton = () => screen.getByText( 'Trigger' );
 const getConfirmButton = () => screen.getByText( defaultProps.label );
 const getTitle = () => screen.getByRole( 'heading', { level: 2 } );
@@ -28,6 +30,11 @@ describe( '<NewConfirmationDialog />', () => {
 		expect( getButton() ).toBeInTheDocument();
 
 		fireEvent.click( getButton() );
+
+		const dialog = getDialog();
+		expect( dialog ).toBeInTheDocument();
+		expect( dialog ).toHaveClass( 'vip-dialog-component' );
+		expect( dialog ).toHaveClass( defaultProps.className );
 
 		expect( getTitle() ).toHaveTextContent( defaultProps.title );
 

--- a/src/system/NewDialog/NewDialog.js
+++ b/src/system/NewDialog/NewDialog.js
@@ -5,7 +5,9 @@
  */
 import React from 'react';
 import PropTypes from 'prop-types';
+import classNames from 'classnames';
 import * as DialogPrimitive from '@radix-ui/react-dialog';
+
 /**
  * Internal dependencies
  */
@@ -25,6 +27,7 @@ export const NewDialog = ( {
 	style: extraStyles,
 	contentProps = {},
 	portalProps = {},
+	className = null,
 	...props
 } ) => {
 	const closeRef = React.useRef( null );
@@ -48,7 +51,7 @@ export const NewDialog = ( {
 				<DialogOverlay />
 
 				<DialogPrimitive.Content
-					className="vip-dialog-component"
+					className={ classNames( 'vip-dialog-component', className ) }
 					sx={ { ...contentStyles, ...extraStyles } }
 					{ ...contentProps }
 				>
@@ -71,6 +74,7 @@ NewDialog.propTypes = {
 	showHeading: PropTypes.bool,
 	disabled: PropTypes.bool,
 	style: PropTypes.oneOfType( [ PropTypes.object, PropTypes.func ] ),
+	className: PropTypes.any,
 
 	// Content props in: https://www.radix-ui.com/docs/primitives/components/dialog#content
 	contentProps: PropTypes.any,


### PR DESCRIPTION
## Description

Passing `className` to the `NewConfirmationDialog` component does not currently result in it being added to the rendered container.

This change addresses that by pulling it out of the props passed through to `NewDialog` and adds test coverage that the dialog has the expected CSS Class names.

## Checklist

- [x] This PR has good automated test coverage
- [x] The storybook for the component has been updated

## Steps to Test

Outline the steps to test and verify the PR here.

Example:

1. Pull down PR.
1. `npm run dev`.
1. Open Storybook.
1. Browse to the `NewConfirmationDialog` component
1. Click the button
1. Inspect the modal container
1. Verify the presence of the `storybook-confirmation-dialog` CSS class