### PR TITLE
[PIE-3694] Apply the debounce to the source function

### DIFF
--- a/src/system/NewForm/FormAutocomplete.js
+++ b/src/system/NewForm/FormAutocomplete.js
@@ -131,6 +131,7 @@ const FormAutocomplete = React.forwardRef(
 		const [ selectedValue, setSelectedValue ] = useState( value || '' );
 		const [ inputQuery, setInputQuery ] = useState( value );
 		let debounceTimeout;
+		let sourceDebounceTimeout;
 		if ( ! forwardRef ) {
 			forwardRef = React.createRef();
 		}
@@ -242,9 +243,19 @@ const FormAutocomplete = React.forwardRef(
 			setInputQuery( query );
 			// user function to fetch the results has the precedence
 			if ( source ) {
-				return source( query, populateResults );
+				if ( ! debounce ) {
+					source( query, populateResults );
+					return;
+				}
+				clearTimeout( sourceDebounceTimeout );
+
+				if ( ! query.length || query.length >= minLength ) {
+					sourceDebounceTimeout = setTimeout( () => {
+						source( query, populateResults );
+					}, debounce );
+				}
 			}
-			return suggest( query, populateResults );
+			suggest( query, populateResults );
 		};
 		useEffect( () => {
 			global.document

--- a/src/system/NewForm/FormAutocomplete.js
+++ b/src/system/NewForm/FormAutocomplete.js
@@ -127,11 +127,10 @@ const FormAutocomplete = React.forwardRef(
 		forwardRef
 	) => {
 		const [ isDirty, setIsDirty ] = useState( false );
-
+		const [ sourceDebounceTimeout, setSourceDebounceTimeout ] = useState( null );
 		const [ selectedValue, setSelectedValue ] = useState( value || '' );
 		const [ inputQuery, setInputQuery ] = useState( value );
 		let debounceTimeout;
-		let sourceDebounceTimeout;
 		if ( ! forwardRef ) {
 			forwardRef = React.createRef();
 		}
@@ -247,12 +246,17 @@ const FormAutocomplete = React.forwardRef(
 					source( query, populateResults );
 					return;
 				}
-				clearTimeout( sourceDebounceTimeout );
+				if ( sourceDebounceTimeout ) {
+					clearTimeout( sourceDebounceTimeout );
+					setSourceDebounceTimeout( null );
+				}
 
 				if ( ! query.length || query.length >= minLength ) {
-					sourceDebounceTimeout = setTimeout( () => {
-						source( query, populateResults );
-					}, debounce );
+					setSourceDebounceTimeout(
+						setTimeout( () => {
+							source( query, populateResults );
+						}, debounce )
+					);
 				}
 			}
 			suggest( query, populateResults );

--- a/src/system/NewForm/FormAutocomplete.js
+++ b/src/system/NewForm/FormAutocomplete.js
@@ -255,11 +255,13 @@ const FormAutocomplete = React.forwardRef(
 					setSourceDebounceTimeout(
 						setTimeout( () => {
 							source( query, populateResults );
+							setSourceDebounceTimeout( null );
 						}, debounce )
 					);
 				}
+			} else {
+				suggest( query, populateResults );
 			}
-			suggest( query, populateResults );
 		};
 		useEffect( () => {
 			global.document

--- a/src/system/NewForm/FormAutocomplete.stories.jsx
+++ b/src/system/NewForm/FormAutocomplete.stories.jsx
@@ -13,6 +13,10 @@ export default {
 			type: { name: 'string', required: false },
 			control: { type: 'text' },
 		},
+		debounce: {
+			type: { name: 'number', required: false },
+			control: { type: 'number' },
+		},
 		label: {
 			type: { name: 'string', required: false },
 			control: { type: 'text' },

--- a/src/system/NewForm/FormAutocomplete.stories.jsx
+++ b/src/system/NewForm/FormAutocomplete.stories.jsx
@@ -103,13 +103,14 @@ export const WithDebounce = () => {
 		</>
 	);
 };
-export const WithSlowSearch = DefaultComponent.bind( {} );
-WithSlowSearch.args = {
+export const WithSlowSearchAndDebounce = DefaultComponent.bind( {} );
+WithSlowSearchAndDebounce.args = {
 	...Default.args,
 	label: 'Label',
 	autoFilter: false,
 	minLength: 3,
 	required: true,
+	debounce: 500,
 	source: async ( query, populateResults ) => {
 		if ( ! query || query.length >= 3 ) {
 			setTimeout( () => {


### PR DESCRIPTION
## Description
Jira: https://vipjira.atlassian.net/browse/PIE-3694

When we use the debounce parameter, we were only debouncing the `handleInputChange` which is called only if we use the filtering on a predefined list through the `suggest` function.

The `handleInputChange` function is not called in case we use a `source` function to populate the autocomplete from an external set of data. 

This PR adds the debounce support to the source function so it can handle the debounce correctly when used.
## Checklist

- [ ] This PR has good automated test coverage
- [X] The storybook for the component has been updated

## Steps to Test

1. Pull down PR.
1. `npm run dev`.
1. Open Storybook http://localhost:6006/?path=/story/form-autocomplete--with-slow-search-and-debounce
1. try to type `Choco`, the debounce is set to 500  and the function is set to have a 1s delay.
1. If you lower the debounce in the controls section to something like 10, and you try playing again with the text (writing `vanil` and right after that `straw`) you should see the source function being called multiple times and changing the contents because the debounce is not high enough
