### PR TITLE
Add the jsxImportSource pragma in tsx files using classic HTML tags

### DIFF
--- a/src/system/ScreenReaderText/ScreenReaderText.tsx
+++ b/src/system/ScreenReaderText/ScreenReaderText.tsx
@@ -1,3 +1,6 @@
+/** @jsxImportSource theme-ui */
+// we'll need jsxImportSource for the sx prop when used with html elements
+
 /**
  * External dependencies
  */

--- a/src/system/Table/Table.stories.tsx
+++ b/src/system/Table/Table.stories.tsx
@@ -1,3 +1,6 @@
+/** @jsxImportSource theme-ui */
+// we'll need jsxImportSource for the sx prop when used with html elements
+
 /**
  * External dependencies
  */

--- a/src/system/Table/Table.tsx
+++ b/src/system/Table/Table.tsx
@@ -1,3 +1,6 @@
+/** @jsxImportSource theme-ui */
+// we'll need jsxImportSource for the sx prop when used with html elements
+
 /**
  * External dependencies
  */

--- a/src/system/Table/TableCell.tsx
+++ b/src/system/Table/TableCell.tsx
@@ -1,3 +1,6 @@
+/** @jsxImportSource theme-ui */
+// we'll need jsxImportSource for the sx prop when used with html elements
+
 /**
  * External dependencies
  */

--- a/src/system/Table/TableRow.tsx
+++ b/src/system/Table/TableRow.tsx
@@ -1,3 +1,6 @@
+/** @jsxImportSource theme-ui */
+// we'll need jsxImportSource for the sx prop when used with html elements
+
 /**
  * External dependencies
  */

--- a/src/system/Text/Text.stories.tsx
+++ b/src/system/Text/Text.stories.tsx
@@ -1,3 +1,6 @@
+/** @jsxImportSource theme-ui */
+// we'll need jsxImportSource for the sx prop when used with html elements
+
 /**
  * Internal dependencies
  */


### PR DESCRIPTION
## Description

With the switch to TS, the components using classic HTML tags are not leveraging the jsxImportSource in the tsconfig file.

While we figure this out, we're adding the pragma back in the top of the file to fix it.
![CleanShot 2023-10-11 at 15 49 14@2x](https://github.com/Automattic/vip-design-system/assets/668251/e2bb1ab7-2a8d-4166-a581-da5bdc975fd6)


## Checklist

- [ ] This PR has good automated test coverage
- [ ] The storybook for the component has been updated

## Steps to Test

1. Pull down PR.
1. `npm run dev`.
1. Open Storybook at the wizard page http://localhost:6006/?path=/docs/wizard--docs to ensure the `ScreenReaderText` is hidden .
