### PR TITLE
Update Form.Input readonly color from latest token

### DIFF
--- a/src/system/Form/Input.stories.tsx
+++ b/src/system/Form/Input.stories.tsx
@@ -34,6 +34,6 @@ export const Default = () => (
 
 		<Form.Label htmlFor="input-with-custom-label">Custom Label outside the Input</Form.Label>
 		<Form.Input forLabel="input-with-custom-label" required />
-		<Form.Input forLabel="input-readonly" readOnly={ true } value="This is a readonly input" />
+		<Form.Input forLabel="input-readonly" readOnly value="This is a readonly input" />
 	</Form.Root>
 );

--- a/src/system/Form/Input.stories.tsx
+++ b/src/system/Form/Input.stories.tsx
@@ -34,5 +34,6 @@ export const Default = () => (
 
 		<Form.Label htmlFor="input-with-custom-label">Custom Label outside the Input</Form.Label>
 		<Form.Input forLabel="input-with-custom-label" required />
+		<Form.Input forLabel="input-readonly" readOnly={ true } value="This is a readonly input" />
 	</Form.Root>
 );

--- a/src/system/Form/Input.styles.ts
+++ b/src/system/Form/Input.styles.ts
@@ -30,7 +30,10 @@ export const baseControlStyle = {
 	'&:disabled': {
 		borderColor: 'input.border.disabled',
 	},
-
+	'&:read-only': {
+		borderColor: 'input.border.disabled',
+		backgroundColor: 'input.background.read-only',
+	},
 	'&::placeholder': {
 		color: 'input.text.placeholder',
 		opacity: 1,

--- a/src/system/Form/InputWithCopyButton.stories.jsx
+++ b/src/system/Form/InputWithCopyButton.stories.jsx
@@ -25,6 +25,13 @@ export const Default = () => {
 				forLabel="input-simple"
 				copyHandler={ value => setCopiedText( value ) }
 			/>
+			<Form.InputWithCopyButton
+				value="Copy me!"
+				label="This is a readonly input"
+				forLabel="input-simple"
+				readOnly
+				copyHandler={ value => setCopiedText( value ) }
+			/>
 		</Form.Root>
 	);
 };


### PR DESCRIPTION
## Description

Updated background color of Form.Input > readOnly
![image](https://github.com/Automattic/vip-design-system/assets/2224344/821c0761-77ff-4b43-95d3-b42d7cd105a5)

Slack [convo](https://a8c.slack.com/archives/C03A93G9BBP/p1696328026290569)

## Checklist

- [ ] This PR has good automated test coverage
- [x] The storybook for the component has been updated

## Steps to Test

[Input readony](https://deploy-preview-270--vip-design-system-components.netlify.app/?path=/docs/form-input--docs)
