### PR TITLE
Fix Notice behavior without title

### DIFF
--- a/src/system/Notice/Notice.stories.tsx
+++ b/src/system/Notice/Notice.stories.tsx
@@ -68,5 +68,16 @@ export const Default = () => (
 				</li>
 			</ul>
 		</Notice>
+
+		<Notice variant="alert" sx={ { mb: 4 } }>
+			Bucket names in Amazon S3 are globally unique, external link ↗. To ensure that shipped data is
+			delivered to the correct location, the Bucket Name and Bucket Region entered below must match
+			the details used to set up your S3 bucket, external link ↗.
+			<Link href="/?path=/story/avatar--default">A link to Avatar</Link>
+		</Notice>
+
+		<Notice variant="info" sx={ { mb: 4 } }>
+			Bucket names in Amazon S3 are globally unique.
+		</Notice>
 	</React.Fragment>
 );

--- a/src/system/Notice/Notice.tsx
+++ b/src/system/Notice/Notice.tsx
@@ -16,7 +16,6 @@ import { ThemeUIStyleObject } from 'theme-ui';
 interface NoticeIconProps {
 	color: string;
 	variant: ColorVariants;
-	hasTitle: boolean;
 }
 
 export interface NoticeProps {
@@ -103,11 +102,7 @@ export const Notice = React.forwardRef< HTMLDivElement, NoticeProps >(
 							alignSelf: 'center',
 						} }
 					>
-						<NoticeIcon
-							hasTitle={ !! title }
-							color={ `notice.icon.${ variant }` }
-							variant={ variant }
-						/>
+						<NoticeIcon color={ `notice.icon.${ variant }` } variant={ variant } />
 					</Flex>
 
 					<Box>

--- a/src/system/Notice/Notice.tsx
+++ b/src/system/Notice/Notice.tsx
@@ -16,6 +16,7 @@ import { ThemeUIStyleObject } from 'theme-ui';
 interface NoticeIconProps {
 	color: string;
 	variant: ColorVariants;
+	hasTitle: boolean;
 }
 
 export interface NoticeProps {
@@ -30,7 +31,7 @@ export interface NoticeProps {
 type ColorVariants = 'warning' | 'error' | 'alert' | 'success' | 'info';
 
 const NoticeIcon = ( { color, variant }: NoticeIconProps ) => {
-	const sx = { color, flex: '0 0 auto' };
+	const sx = { color, flex: '0 0 auto', mt: 0 };
 	const size = 20;
 
 	switch ( variant ) {
@@ -94,15 +95,20 @@ export const Notice = React.forwardRef< HTMLDivElement, NoticeProps >(
 						alignItems: 'start',
 					} }
 				>
-					<Box
+					<Flex
 						sx={ {
 							mr: 3,
-							mt: title ? 2 : 0,
+							mt: 0,
 							flexShrink: 0,
+							alignSelf: 'center',
 						} }
 					>
-						<NoticeIcon color={ `notice.icon.${ variant }` } variant={ variant } />
-					</Box>
+						<NoticeIcon
+							hasTitle={ !! title }
+							color={ `notice.icon.${ variant }` }
+							variant={ variant }
+						/>
+					</Flex>
 
 					<Box>
 						{ title && (


### PR DESCRIPTION
## Description

### Before

<img width="538" alt="image" src="https://github.com/Automattic/vip-design-system/assets/3402/dda87047-ab32-458b-b914-926bc21376e4">


### After

<img width="1267" alt="image" src="https://github.com/Automattic/vip-design-system/assets/3402/8afcebb4-a9da-46f9-b8d0-d5aa33ebc533">


## Checklist

- [ ] This PR has good automated test coverage
- [x] The storybook for the component has been updated

## Steps to Test

1. Pull down PR.
2. `npm run dev`.
3. http://localhost:6006/?path=/docs/notice--docs
4. Verify Notice with one line or multiple lines have the icon positioned as left-center