### PR TITLE
[PIE-3778] Readjust the NoticeIcon

### DIFF
--- a/src/system/Notice/Notice.tsx
+++ b/src/system/Notice/Notice.tsx
@@ -30,7 +30,7 @@ export interface NoticeProps {
 type ColorVariants = 'warning' | 'error' | 'alert' | 'success' | 'info';
 
 const NoticeIcon = ( { color, variant }: NoticeIconProps ) => {
-	const sx = { color, flex: '0 0 auto', mt: 0 };
+	const sx = { color, flex: '0 0 auto' };
 	const size = 20;
 
 	switch ( variant ) {
@@ -97,9 +97,9 @@ export const Notice = React.forwardRef< HTMLDivElement, NoticeProps >(
 					<Flex
 						sx={ {
 							mr: 3,
-							mt: 0,
+							mt: title ? 2 : 0,
 							flexShrink: 0,
-							alignSelf: 'center',
+							alignSelf: title ? undefined : 'center',
 						} }
 					>
 						<NoticeIcon color={ `notice.icon.${ variant }` } variant={ variant } />


### PR DESCRIPTION
## Description

This PR is a followup to #253 (which changed the position of the NoticeIcon to be in the top) and to #277 (which fixed a bug in case the Notice component didn't have a title).

The #277 reverted the design changes, so this PR tries to address both requirements
* Having the notice icon between the title and the text, when the title is present
* Keeping the notice icon aligned to the content if we don't have the title.

There is still a use case left out, which is when the Notice width is small and/or the text of the content (without the title), splits into multiple lines.

In this case, with the changes, the icon will be centered vertical, which is not what we want (ideally we'd want the icon to be positioned as if we had a title), but I have yet to find a solution to this.

BEFORE
![CleanShot 2023-10-30 at 12 13 27@2x](https://github.com/Automattic/vip-design-system/assets/668251/f293e17f-d7e2-40d0-8fe9-71d72d2170c0)

AFTER
![CleanShot 2023-10-30 at 12 14 14@2x](https://github.com/Automattic/vip-design-system/assets/668251/349eccff-7b9c-4783-8b7b-8190846d2647)


## Checklist

- [ ] This PR has good automated test coverage
- [ ] The storybook for the component has been updated

## Steps to Test

Outline the steps to test and verify the PR here.

Example:

1. Pull down PR.
1. `npm run dev`.
1. Open Storybook Notice component
1. Check that the NoticeIcon is at the top when we have the title, and centered with the content when we don't have it.
