### PR TITLE
PIE-3778 Make the Notice icon alignment adjust with the Notice content

### DIFF
--- a/src/system/Notice/Notice.stories.tsx
+++ b/src/system/Notice/Notice.stories.tsx
@@ -1,3 +1,4 @@
+/** @jsxImportSource theme-ui */
 /**
  * External dependencies
  */
@@ -52,11 +53,11 @@ export const Default = () => (
 
 		<Notice
 			variant="alert"
-			sx={ { mb: 4 } }
+			sx={ { mb: 2 } }
 			title="There are errors in your form"
 			headingVariant="h2"
 		>
-			<ul sx={ { mb: 0 } }>
+			<ul sx={ { m: 0, pl: 3 } }>
 				<li>
 					<Link href="#name">Please enter your name.</Link>
 				</li>
@@ -69,13 +70,13 @@ export const Default = () => (
 			</ul>
 		</Notice>
 
-		<Notice variant="alert" sx={ { mb: 4 } }>
+		<Notice variant="alert" sx={ { mb: 2 } }>
 			<>
 				<Heading variant={ 'h4' } sx={ { fontSize: 2 } }>
 					Alternative way of printing errors
 				</Heading>
 
-				<ul sx={ { mb: 0 } }>
+				<ul sx={ { m: 0, pl: 3 } }>
 					<li>
 						<Link href="#name">Please enter your name.</Link>
 					</li>

--- a/src/system/Notice/Notice.stories.tsx
+++ b/src/system/Notice/Notice.stories.tsx
@@ -6,7 +6,7 @@
  * Internal dependencies
  */
 import React from 'react';
-import { Notice, Link } from '..';
+import { Notice, Link, Heading } from '..';
 
 export default {
 	title: 'Notice',
@@ -67,6 +67,23 @@ export const Default = () => (
 					<Link href="#terms">Please agree to the terms.</Link>
 				</li>
 			</ul>
+		</Notice>
+
+		<Notice variant="alert" sx={ { mb: 4 } }>
+			<>
+				<Heading variant={ 'h4' } sx={ { fontSize: 2 } }>
+					Alternative way of printing errors
+				</Heading>
+
+				<ul sx={ { mb: 0 } }>
+					<li>
+						<Link href="#name">Please enter your name.</Link>
+					</li>
+					<li>
+						<Link href="#email">Please enter your email address.</Link>
+					</li>
+				</ul>
+			</>
 		</Notice>
 
 		<Notice variant="alert" sx={ { mb: 4 } }>

--- a/src/system/Notice/Notice.tsx
+++ b/src/system/Notice/Notice.tsx
@@ -91,20 +91,23 @@ export const Notice = React.forwardRef< HTMLDivElement, NoticeProps >(
 			>
 				<Flex
 					sx={ {
-						alignItems: 'start',
+						height: '100%',
 					} }
 				>
-					<Flex
-						sx={ {
-							mr: 3,
-							mt: title ? 2 : 0,
-							flexShrink: 0,
-							alignSelf: title ? undefined : 'center',
-						} }
-					>
-						<NoticeIcon color={ `notice.icon.${ variant }` } variant={ variant } />
-					</Flex>
-
+					<Box sx={ { minWidth: '32px', mr: 3 } }>
+						<Flex
+							sx={ {
+								flexDirection: 'column',
+								minHeight: '20px',
+								maxHeight: '28px',
+								alignItems: 'flex-end',
+								height: '100%',
+							} }
+						>
+							<Box sx={ { flex: '1 100%' } }></Box>
+							<NoticeIcon color={ `notice.icon.${ variant }` } variant={ variant } />
+						</Flex>
+					</Box>
 					<Box>
 						{ title && (
 							<Heading

--- a/src/system/Notice/Notice.tsx
+++ b/src/system/Notice/Notice.tsx
@@ -91,20 +91,24 @@ export const Notice = React.forwardRef< HTMLDivElement, NoticeProps >(
 			>
 				<Flex
 					sx={ {
-						height: '100%',
+						height: '100%', // required for the dynamic height of the icon box to work
 					} }
 				>
 					<Box sx={ { minWidth: '32px', mr: 3 } }>
 						<Flex
 							sx={ {
-								flexDirection: 'column',
+								flexDirection: 'column', // the trick here is to have a flex column with the icon at the bottom and an empty div that fills the space
 								minHeight: '20px',
-								maxHeight: '28px',
-								alignItems: 'flex-end',
-								height: '100%',
+								maxHeight: '28px', // we're forcing the max height so that the icon is, at max, aligned between the first and the second line of text
+								alignItems: 'flex-end', // we want the icon to be aligned to the bottom
+								height: '100%', // specifying the height will allow the box to match the height of the content.
 							} }
 						>
-							<Box sx={ { flex: '1 100%' } }></Box>
+							<Box
+								sx={ {
+									flex: '1 100%', // we need this empty div to make the icon align to the bottom
+								} }
+							></Box>
 							<NoticeIcon color={ `notice.icon.${ variant }` } variant={ variant } />
 						</Flex>
 					</Box>

--- a/src/system/Notice/Notice.tsx
+++ b/src/system/Notice/Notice.tsx
@@ -94,12 +94,12 @@ export const Notice = React.forwardRef< HTMLDivElement, NoticeProps >(
 						height: '100%', // required for the dynamic height of the icon box to work
 					} }
 				>
-					<Box sx={ { minWidth: '32px', mr: 3 } }>
+					<Box sx={ { minWidth: '32px', mr: 3, mt: 0 } }>
 						<Flex
 							sx={ {
 								flexDirection: 'column', // the trick here is to have a flex column with the icon at the bottom and an empty div that fills the space
 								minHeight: '20px',
-								maxHeight: '28px', // we're forcing the max height so that the icon is, at max, aligned between the first and the second line of text
+								maxHeight: '32px', // we're forcing the max height so that the icon is, at max, aligned between the first and the second line of text
 								alignItems: 'flex-end', // we want the icon to be aligned to the bottom
 								height: '100%', // specifying the height will allow the box to match the height of the content.
 							} }


### PR DESCRIPTION
## Description

This PR is the third iteration on improving how we align the NoticeIcon in the Notice. 
Our goal is to have the notice align between the first and second line of the content and, if the content is short, be vertically centered.

Context:
In #277 we settled for having two options
1. If we don't have a notice title, we'll vertical align it in the middle.
2. If we have the title, we'll align between the first and second line of text.

Sadly, one might want to add a specific title in the content of the notice and this would show the icon in the middle.

Example: 
![CleanShot 2023-11-06 at 13 06 31@2x](https://github.com/Automattic/vip-design-system/assets/668251/33578af3-661e-485d-ae81-d5828e34325a)

As such, I decided to see if Flex could help us build a way to have the vertical alignment adjust properly.

Long story short: I was able to 100% match our goals by using an empty div that will stretch if the height is enough (aligning the icon between the first and the second line) and disappear with short content.

Thanks to that, now the icon should properly align.

Result:
![CleanShot 2023-11-06 at 17 38 16@2x](https://github.com/Automattic/vip-design-system/assets/668251/e9a92937-147c-4e56-9861-e14d9edadc05)


## Checklist

- [ ] This PR has good automated test coverage
- [ ] The storybook for the component has been updated

## Steps to Test

Outline the steps to test and verify the PR here.

Example:

1. Pull down PR.
1. `npm run dev`.
1. Check that the notice icon properly aligns