### PR TITLE
Fix Radio buttons zIndex issue

### DIFF
--- a/src/system/Form/Radio.js
+++ b/src/system/Form/Radio.js
@@ -31,7 +31,6 @@ const inputStyle = {
 		content: '""',
 		border: '1px solid',
 		borderColor: baseControlBorderStyle.borderColor,
-		zIndex: 3,
 		left: `${ -1 * radioPosition }px`,
 	} ),
 	'&:checked ~ label::after': {
@@ -54,7 +53,6 @@ const labelStyle = {
 		top: 1,
 		left: `${ -1 * radioPosition }px`,
 		transition: 'all .3s ease-out',
-		zIndex: 2,
 		width: '16px',
 		height: '16px',
 	},


### PR DESCRIPTION
## Description

Removes the non-needed zIndex properties from this component. 

### Before
<img width="1456" alt="image" src="https://github.com/Automattic/vip-design-system/assets/3402/5ee05f86-d725-4b9b-8c72-bac0e155bd7e">

### After
<img width="848" alt="image" src="https://github.com/Automattic/vip-design-system/assets/3402/e5985ae7-7379-46df-988f-6cdfa77f7304">


## Checklist

- N/A This PR has good automated test coverage
- N/A The storybook for the component has been updated

## Steps to Test

To test if this is working in the dashboard, you need to do the following:

1. Open your local `vip-dashboard` repo.
2. Change the line: `"@automattic/vip-design-system":` to: `"@automattic/vip-design-system": "github:Automattic/vip-design-system#2ac019ba8368ebd68efc8efc14d7c2da586f4126",`
3. `npm i`.
4. `npm run dev`
5. Open /apps/APP_ID/production/access-routing/hsts (Private link)
6. Try to enable the HSTS
7. When the modal opens, the Radio buttons are not in front of the modal content
