### PR TITLE
[Toolbar] Set the 64px height only for 1047px breakpoint and above

### DIFF
--- a/src/system/Toolbar/Toolbar.tsx
+++ b/src/system/Toolbar/Toolbar.tsx
@@ -22,7 +22,7 @@ const Toolbar = forwardRef< HTMLElement, ToolbarProps >(
 			role="banner"
 			sx={ {
 				display: 'flex',
-				height: [ 64, 56 ],
+				height: [ 56, null, null, 64 ],
 				backgroundColor: 'toolbar.background',
 				flexDirection: 'row',
 				alignItems: 'center',


### PR DESCRIPTION
## Description

A few sentences describing the overall goals of the pull request. Any special considerations and decisions.

Also include any references to relevant discussions and documentation.

## Checklist

- N/A This PR has good automated test coverage
- N/A The storybook for the component has been updated

## Steps to Test

1. Pull down PR.
2. `npm run dev`.
3. Open http://localhost:6006/iframe.html?id=navigation-toolbar--vip-dashboard-like&viewMode=story
4. If the screen size bigger than 1047px the height of the Toolbar should be 64px, otherwise: 56px.
