### PR TITLE
Make Nav full-width by default

### DIFF
--- a/src/system/Nav/Nav.stories.tsx
+++ b/src/system/Nav/Nav.stories.tsx
@@ -138,8 +138,8 @@ export const Menu: Story = {
 	render: () => (
 		<>
 			<p>
-				<strong>Variant: Menu</strong>. This menu takes full-width by default. You can customize by
-				passing a custom <code>sx</code> prop.
+				<strong>Variant: Menu</strong>. This menu takes full width by default. You can put it in a
+				container with constrained width..
 			</p>
 
 			<Nav.Menu sx={ { mb: 4 } } label="Nav Menu">

--- a/src/system/Nav/Nav.stories.tsx
+++ b/src/system/Nav/Nav.stories.tsx
@@ -138,10 +138,11 @@ export const Menu: Story = {
 	render: () => (
 		<>
 			<p>
-				<strong>Variant: Menu</strong>.
+				<strong>Variant: Menu</strong>. This menu takes full-width by default. You can customize by
+				passing a custom <code>sx</code> prop.
 			</p>
 
-			<Nav.Menu sx={ { mb: 4, width: 250 } } label="Nav Menu">
+			<Nav.Menu sx={ { mb: 4 } } label="Nav Menu">
 				<NavItem.Menu
 					href="https://wordpress.com"
 					renderIcon={ size => <BiGridAlt size={ size } /> }

--- a/src/system/Nav/Nav.stories.tsx
+++ b/src/system/Nav/Nav.stories.tsx
@@ -152,7 +152,6 @@ export const Menu: Story = {
 				</NavItem.Menu>
 				<NavItem.Menu
 					as={ CustomLink }
-					active
 					href="https://random-website.com/"
 					renderIcon={ size => <BiWindows size={ size } /> }
 				>

--- a/src/system/Nav/styles.ts
+++ b/src/system/Nav/styles.ts
@@ -303,7 +303,7 @@ export const navItemLinkStyles = ( variant: NavVariant ): ThemeUIStyleObject => 
 
 export const navItemLinkVariantStyles = ( variant: NavVariant ): ThemeUIStyleObject => {
 	const defaultStyles = {
-		width: 'max-content',
+		width: '100%',
 		borderColor: 'transparent',
 	};
 


### PR DESCRIPTION
## Description

Make the Nav component full-width by default.

<img width="923" alt="image" src="https://github.com/Automattic/vip-design-system/assets/3402/d52022d5-f961-4dee-b119-23b8a5e3d57b">


## Checklist

- [ ] This PR has good automated test coverage
- [ ] The storybook for the component has been updated

## Steps to Test

Outline the steps to test and verify the PR here.

Example:

1. Pull down PR.
2. `npm run dev`.
3. Open http://localhost:6006/?path=/docs/navigation-nav--docs
4. Menu example takes full-width
