### PR TITLE
FORNO-1880: Fix alignment of inline label and select field

### DIFF
--- a/src/system/NewForm/FormSelect.js
+++ b/src/system/NewForm/FormSelect.js
@@ -16,6 +16,7 @@ import { baseControlStyle } from '../Form/Input.styles';
 import { Label } from '../Form/Label';
 
 const MAX_SUGGESTED_OPTIONS = 15;
+const ICON_SIZE = 24;
 const isDev = process.env.NODE_ENV !== 'production';
 
 const defaultStyles = {
@@ -26,6 +27,8 @@ const defaultStyles = {
 	appearance: 'none',
 	minHeight: '36px',
 	lineHeight: '36px',
+	fontFamily: 'inherit',
+	fontSize: '1em',
 };
 
 const renderOption = ( label, value ) => {
@@ -102,7 +105,7 @@ const FormSelect = React.forwardRef(
 		);
 
 		const SelectLabel = () => (
-			<Label required={ required } htmlFor={ forLabel }>
+			<Label sx={ { lineHeight: `${ ICON_SIZE }px` } } required={ required } htmlFor={ forLabel }>
 				{ label }
 			</Label>
 		);
@@ -131,7 +134,7 @@ const FormSelect = React.forwardRef(
 								: renderOption( optionLabel( option ), optionValue( option ) )
 						) }
 					</select>
-					<FormSelectArrow />
+					<FormSelectArrow iconSize={ ICON_SIZE } />
 				</FormSelectContent>
 
 				{ hasError && errorMessage && (

--- a/src/system/NewForm/FormSelectArrow.js
+++ b/src/system/NewForm/FormSelectArrow.js
@@ -11,11 +11,11 @@ import { MdExpandMore } from 'react-icons/md';
  */
 import { baseControlBorderStyle as borderStyle } from '../Form/Input.styles';
 
-export const FormSelectArrow = React.forwardRef( ( props, forwardRef ) => (
+export const FormSelectArrow = React.forwardRef( ( { iconSize = 24, ...props }, forwardRef ) => (
 	<MdExpandMore
 		ref={ forwardRef }
 		aria-hidden="true"
-		size={ 24 }
+		size={ iconSize }
 		sx={ {
 			position: 'absolute',
 			paddingLeft: 2,


### PR DESCRIPTION
## Description

Fixes an alignment issue with the inline select component. The extent of the current misalignment depends on the browser stylesheet since no font family or size is currently defined. The below "before" represents a minor example of the issue that has been reported.

Before

<img width="640" alt="Screenshot 2024-02-29 at 15 37 17" src="https://github.com/Automattic/vip-design-system/assets/4177859/931b7530-8fe4-4c65-a246-4d1eed099e8e">

After

<img width="624" alt="Screenshot 2024-02-29 at 15 38 11" src="https://github.com/Automattic/vip-design-system/assets/4177859/8d75acc2-9147-4ac6-98b6-7fc533759aea">

Also adjusts the height of the vertical bar between the label and select field to match the bar on the right of the select field.

## Checklist

- [ ] This PR has good automated test coverage
- [ ] The storybook for the component has been updated

## Steps to Test

1. Pull down PR.
1. `npm run dev`.
1. Visit http://localhost:6006/?path=/story/form-select--is-inline
1. Verify the label and select option text is vertically aligned
