### PR TITLE
Fix wrapping of items in toolbar util menu

### DIFF
--- a/src/system/Nav/styles/variants/toolbar.ts
+++ b/src/system/Nav/styles/variants/toolbar.ts
@@ -8,6 +8,7 @@ export const toolbarRootStyles: ThemeUIStyleObject = {
 	display: [ 'none', 'none', 'flex' ],
 	height: '100%',
 	ml: 0,
+	width: 'max-content',
 };
 
 // Toolbar Default Link Styles <a>

--- a/src/system/Toolbar/Toolbar.stories.tsx
+++ b/src/system/Toolbar/Toolbar.stories.tsx
@@ -57,7 +57,7 @@ export const Default: Story = {
 				</Nav.Toolbar>
 
 				<Toolbar.UtilNav>
-					<Text sx={ { color: 'toolbar.text.default', mb: 0 } }>Utility</Text>
+					<Text sx={ { color: 'toolbar.text.default', mb: 0 } }>Utility Item</Text>
 				</Toolbar.UtilNav>
 			</Toolbar.Primary>
 		</>


### PR DESCRIPTION
## Description

Since `1.6.5` we're extending the base nav styles in the toolbar nav which includes setting width to `100%`. This causes the util menu items (including the `VIP Features` toggle on the Dashboard) to wrap, even for large viewports. 

Before

<img width="850" alt="Screenshot 2024-03-01 at 15 02 22" src="https://github.com/Automattic/vip-design-system/assets/4177859/15fe48d8-d823-44a0-bbc4-17056d94bba4">

<img width="728" alt="Screenshot 2024-03-04 at 21 21 17" src="https://github.com/Automattic/vip-design-system/assets/4177859/bfaed6a5-7148-4576-9dcc-b0be2fb2934c">



After

<img width="848" alt="Screenshot 2024-03-01 at 15 02 32" src="https://github.com/Automattic/vip-design-system/assets/4177859/7f2315df-2a1e-4d90-8d20-a57975fae8c7">

<img width="714" alt="Screenshot 2024-03-04 at 21 22 01" src="https://github.com/Automattic/vip-design-system/assets/4177859/554a5630-f72c-4da9-8a96-71252cea3834">


## Checklist

- [ ] This PR has good automated test coverage
- [x] The storybook for the component has been updated

## Steps to Test

1. When the Netlify preview link is available, visit /?path=/story/navigation-toolbar--default
1. Verify the util menu item containing whitespace is not wrapped across two lines