### PR TITLE
Adjust/checkbox radio styles

### DIFF
--- a/src/system/Form/Checkbox/Checkbox.stories.tsx
+++ b/src/system/Form/Checkbox/Checkbox.stories.tsx
@@ -73,12 +73,7 @@ export const Default = () => {
 							aria-labelledby={ `label-check1-${ variant }` }
 							onCheckedChange={ setChecked }
 						/>
-						<Label
-							clickable
-							sx={ { m: 0, ml: 2 } }
-							htmlFor={ `check1-${ variant }` }
-							id={ `label-check1-${ variant }` }
-						>
+						<Label clickable htmlFor={ `check1-${ variant }` } id={ `label-check1-${ variant }` }>
 							This option
 						</Label>
 					</Flex>
@@ -91,12 +86,7 @@ export const Default = () => {
 							aria-labelledby={ `label-check2-${ variant }` }
 							onCheckedChange={ setChecked2 }
 						/>
-						<Label
-							clickable
-							sx={ { m: 0, ml: 2 } }
-							htmlFor={ `check2-${ variant }` }
-							id={ `label-check2-${ variant }` }
-						>
+						<Label clickable htmlFor={ `check2-${ variant }` } id={ `label-check2-${ variant }` }>
 							This option too
 						</Label>
 					</Flex>
@@ -115,12 +105,7 @@ export const Default = () => {
 						aria-labelledby={ `label-check1-disabled` }
 						onCheckedChange={ setChecked }
 					/>
-					<Label
-						clickable
-						sx={ { m: 0, ml: 2 } }
-						htmlFor={ `check1-disabled` }
-						id={ `label-check1-disabled` }
-					>
+					<Label clickable htmlFor={ `check1-disabled` } id={ `label-check1-disabled` }>
 						This option
 					</Label>
 				</Flex>
@@ -133,12 +118,7 @@ export const Default = () => {
 						aria-labelledby={ `label-check2-disabled` }
 						onCheckedChange={ setChecked2 }
 					/>
-					<Label
-						clickable
-						sx={ { m: 0, ml: 2 } }
-						htmlFor={ `check2-disabled` }
-						id={ `label-check2-disabled` }
-					>
+					<Label clickable htmlFor={ `check2-disabled` } id={ `label-check2-disabled` }>
 						This option too
 					</Label>
 				</Flex>
@@ -171,11 +151,7 @@ export const Indeterminate = () => {
 							checked={ 'indeterminate' }
 						/>
 
-						<Label
-							sx={ { m: 0, ml: 2, color: 'text', fontWeight: 'regular' } }
-							htmlFor={ `check1-${ variant }` }
-							id={ `label-check1-${ variant }` }
-						>
+						<Label htmlFor={ `check1-${ variant }` } id={ `label-check1-${ variant }` }>
 							This option
 						</Label>
 					</Flex>
@@ -192,11 +168,7 @@ export const Indeterminate = () => {
 						aria-labelledby={ `label-check1-disabled` }
 						checked={ 'indeterminate' }
 					/>
-					<Label
-						sx={ { m: 0, ml: 2 } }
-						htmlFor={ `check1-disabled` }
-						id={ `label-check1-disabled` }
-					>
+					<Label htmlFor={ `check1-disabled` } id={ `label-check1-disabled` }>
 						This option
 					</Label>
 				</Flex>

--- a/src/system/Form/Checkbox/Checkbox.stories.tsx
+++ b/src/system/Form/Checkbox/Checkbox.stories.tsx
@@ -61,9 +61,7 @@ export const Default = () => {
 
 	return (
 		<Form.Root>
-			{ (
-				[ 'primary', 'success', 'error', 'warning', 'info' ] as CheckboxProps[ 'variant' ][]
-			 ).map( variant => (
+			{ ( [ 'primary', 'success', 'brand' ] as CheckboxProps[ 'variant' ][] ).map( variant => (
 				<Form.Fieldset key={ variant }>
 					<Form.Legend>Tell me your { variant } prefereces</Form.Legend>
 
@@ -161,9 +159,7 @@ export const Indeterminate = () => {
 
 	return (
 		<Form.Root>
-			{ (
-				[ 'primary', 'success', 'error', 'warning', 'info' ] as CheckboxProps[ 'variant' ][]
-			 ).map( variant => (
+			{ ( [ 'primary', 'success', 'brand' ] as CheckboxProps[ 'variant' ][] ).map( variant => (
 				<Form.Fieldset key={ variant }>
 					<Form.Legend>Indeterminate state { variant }</Form.Legend>
 
@@ -174,8 +170,9 @@ export const Indeterminate = () => {
 							aria-labelledby={ `label-check1-${ variant }` }
 							checked={ 'indeterminate' }
 						/>
+
 						<Label
-							sx={ { m: 0, ml: 2 } }
+							sx={ { m: 0, ml: 2, color: 'text', fontWeight: 'regular' } }
 							htmlFor={ `check1-${ variant }` }
 							id={ `label-check1-${ variant }` }
 						>

--- a/src/system/Form/Checkbox/Checkbox.tsx
+++ b/src/system/Form/Checkbox/Checkbox.tsx
@@ -7,7 +7,7 @@ import { RadioOptionProps } from '../Radio/RadioOption';
 
 export interface CheckboxProps extends CheckboxPrimitive.CheckboxProps {
 	disabled?: boolean;
-	variant?: 'primary' | 'success' | 'error' | 'warning' | 'info' | 'disabled';
+	variant?: 'primary' | 'success' | 'brand' | 'disabled';
 }
 
 const StyledCheckbox = ( { variant = 'primary', ...rest }: CheckboxProps ) => (

--- a/src/system/Form/Checkbox/styles.ts
+++ b/src/system/Form/Checkbox/styles.ts
@@ -4,6 +4,7 @@ import {
 	baseControlBorderStyle,
 	baseControlFocusStyle,
 	inputBaseBackground,
+	inputBaseText,
 } from '../Input.styles';
 
 // The output willl be 16px because of the 1px border.
@@ -29,6 +30,10 @@ export const checkboxStyle = ( variant: string ): ThemeUIStyleObject => ( {
 		backgroundColor: variant,
 		color: variant,
 		borderColor: variant,
+	},
+	'& ~ label': {
+		fontWeight: 'regular',
+		color: inputBaseText,
 	},
 	svg: {
 		position: 'absolute',

--- a/src/system/Form/Checkbox/styles.ts
+++ b/src/system/Form/Checkbox/styles.ts
@@ -34,6 +34,8 @@ export const checkboxStyle = ( variant: string ): ThemeUIStyleObject => ( {
 	'& ~ label': {
 		fontWeight: 'regular',
 		color: inputBaseText,
+		m: 0,
+		ml: 2,
 	},
 	svg: {
 		position: 'absolute',

--- a/src/system/Form/Radio/Radio.stories.tsx
+++ b/src/system/Form/Radio/Radio.stories.tsx
@@ -62,39 +62,35 @@ export const Default = () => {
 
 	return (
 		<>
-			{ ( [ 'primary', 'success', 'error', 'warning', 'info' ] as RadioProps[ 'variant' ][] ).map(
-				variant => (
-					<Box key={ variant }>
-						<Heading as="h2" sx={ { textTransform: 'capitalize' } }>
-							{ variant }
-						</Heading>
+			{ ( [ 'primary', 'success', 'brand' ] as RadioProps[ 'variant' ][] ).map( variant => (
+				<Box key={ variant }>
+					<Heading as="h2" sx={ { textTransform: 'capitalize' } }>
+						{ variant }
+					</Heading>
 
-						<Radio
-							variant={ variant }
-							onChange={ ( _, option ) =>
-								toggleChecked( `the_option_${ variant }`, option?.value )
-							}
-							name={ `the_option_${ variant }` }
-							defaultValue={ checked?.[ `the_option_${ variant }` ] || `${ variant }-option-a` }
-							options={ [
-								{
-									id: `${ variant }-option-a`,
-									value: `${ variant }-option-a`,
-									label: `I am the ${ variant } option A`,
-								},
-								{
-									id: `${ variant }-option-b`,
-									value: `${ variant }-option-b`,
-									label: `I am the ${ variant } option B`,
-								},
-							] }
-						/>
-					</Box>
-				)
-			) }
+					<Radio
+						variant={ variant }
+						onChange={ ( _, option ) => toggleChecked( `the_option_${ variant }`, option?.value ) }
+						name={ `the_option_${ variant }` }
+						defaultValue={ checked?.[ `the_option_${ variant }` ] || `${ variant }-option-a` }
+						options={ [
+							{
+								id: `${ variant }-option-a`,
+								value: `${ variant }-option-a`,
+								label: `I am the ${ variant } option A`,
+							},
+							{
+								id: `${ variant }-option-b`,
+								value: `${ variant }-option-b`,
+								label: `I am the ${ variant } option B`,
+							},
+						] }
+					/>
+				</Box>
+			) ) }
 			<Box>
 				<Heading as="h2" sx={ { textTransform: 'capitalize' } }>
-					Disabled
+					disabled
 				</Heading>
 
 				<Radio
@@ -197,7 +193,7 @@ export const AcessibleExamples = () => {
 
 			<Form.Fieldset>
 				<Form.Legend sx={ { mb: 0, fontSize: 2, fontWeight: 'bold' } }>
-					All Disabled options
+					All disabled options
 				</Form.Legend>
 
 				<Flex sx={ { alignItems: 'center' } }>

--- a/src/system/Form/Radio/Radio.tsx
+++ b/src/system/Form/Radio/Radio.tsx
@@ -8,7 +8,7 @@ import { RadioOption, RadioOptionOptionProps } from './RadioOption';
 export const VIP_RADIO = 'vip-radio-component';
 
 export type RadioProps = {
-	variant?: 'primary' | 'success' | 'error' | 'warning' | 'info' | 'disabled';
+	variant?: 'primary' | 'success' | 'brand' | 'disabled';
 	disabled?: boolean | undefined;
 	defaultValue?: string | number;
 	onChange?: ( e: React.ChangeEvent< HTMLInputElement >, option?: RadioOptionOptionProps ) => void;

--- a/src/system/Form/Radio/styles.ts
+++ b/src/system/Form/Radio/styles.ts
@@ -1,13 +1,16 @@
 import { ThemeUIStyleObject } from 'theme-ui';
 
-import { screenReaderTextClass } from '../../ScreenReaderText/ScreenReaderText';
 import { baseControlBorderStyle, inputBaseText } from '../Input.styles';
 
 // The output willl be 18px because of the 1px border.
 const RADIO_SIZE = 16;
 
 export const inputStyle = ( variant: string ): ThemeUIStyleObject => ( {
-	...screenReaderTextClass,
+	position: 'absolute',
+	top: 0,
+	left: 0,
+	clip: 'rect(1px, 1px, 1px, 1px)',
+	clipPath: 'inset(50%)',
 	width: RADIO_SIZE,
 	height: RADIO_SIZE,
 	'&:focus ~ label:before': {
@@ -15,7 +18,7 @@ export const inputStyle = ( variant: string ): ThemeUIStyleObject => ( {
 		content: '""',
 		border: '1px solid',
 		borderColor: baseControlBorderStyle.borderColor,
-		left: -5,
+		left: 0,
 	},
 	'&:checked ~ label::after': {
 		borderColor: variant,
@@ -28,18 +31,16 @@ export const inputStyle = ( variant: string ): ThemeUIStyleObject => ( {
 } );
 
 export const labelStyle = ( variant: string ): ThemeUIStyleObject => ( {
+	display: 'flex',
 	cursor: 'pointer',
 	position: 'relative',
-	marginLeft: 5,
 	marginBottom: 0,
 	userSelect: 'none',
 	color: inputBaseText,
-	lineHeight: 'body',
+	fontWeight: 'regular',
+	lineHeight: 'normal',
 	'&:before, &:after': {
 		borderRadius: '100%',
-		position: 'absolute',
-		top: 1,
-		left: -5,
 		transition: 'all .3s ease-out',
 		width: RADIO_SIZE,
 		height: RADIO_SIZE,
@@ -48,8 +49,12 @@ export const labelStyle = ( variant: string ): ThemeUIStyleObject => ( {
 		content: '""',
 		border: '1px solid',
 		borderColor: baseControlBorderStyle.borderColor,
+		marginRight: 2,
 	},
 	'&::after': {
+		position: 'absolute',
+		top: 0,
+		left: 0,
 		content: '""',
 		backgroundColor: variant,
 		backgroundSize: '100%',
@@ -65,4 +70,5 @@ export const itemStyle: ThemeUIStyleObject = {
 	display: 'flex',
 	alignItems: 'center',
 	my: 2,
+	position: 'relative',
 };

--- a/src/system/Form/RadioBoxGroup.js
+++ b/src/system/Form/RadioBoxGroup.js
@@ -38,6 +38,7 @@ const RadioOption = ( {
 				backgroundColor: 'input.radio-box.background.default',
 				cursor: 'pointer',
 				borderRadius: 2,
+				minWidth: 220,
 				textAlign: 'left',
 				border: '1px solid',
 				borderColor: 'input.radio-box.border.default',

--- a/src/system/theme/colors.js
+++ b/src/system/theme/colors.js
@@ -6,6 +6,5 @@
 
 export default theme => ( {
 	...theme.color,
-	brand: theme.color.gold,
 	grey: theme.color.gray,
 } );


### PR DESCRIPTION
## Description

- [x] Update Radio label styles
- [x] Update Radio and Checkbox sizing and spaces
<img width="405" alt="image" src="https://github.com/Automattic/vip-design-system/assets/3402/3dd2f8c5-29be-4336-beab-47ad03e8c2ae">
- [x] Make the `brand` color customizable from the theme

## Checklist

- [ ] This PR has good automated test coverage
- [x] The storybook for the component has been updated

## Steps to Test

1. Pull down PR.
2. `npm run dev`.
3. Open http://localhost:6006/?path=/story/form-radio--default
4. Radio updates: No bold font, 8px gap between radio and label, and only primary/success/brand/disabled states.
5. Open http://localhost:6006/?path=/docs/form-checkbox--docs
6. Checkbox updates: No bold font, 8px gap between radio and label, and only primary/success/brand/disabled states.
