### PR TITLE
Adjust checkbox/radio with indeterminate rules and less examples

### DIFF
--- a/src/system/Form/Checkbox/Checkbox.stories.tsx
+++ b/src/system/Form/Checkbox/Checkbox.stories.tsx
@@ -61,7 +61,7 @@ export const Default = () => {
 
 	return (
 		<Form.Root>
-			{ ( [ 'primary', 'success', 'brand' ] as CheckboxProps[ 'variant' ][] ).map( variant => (
+			{ ( [ 'primary', 'brand' ] as CheckboxProps[ 'variant' ][] ).map( variant => (
 				<Form.Fieldset key={ variant }>
 					<Form.Legend>Tell me your { variant } prefereces</Form.Legend>
 
@@ -139,7 +139,7 @@ export const Indeterminate = () => {
 
 	return (
 		<Form.Root>
-			{ ( [ 'primary', 'success', 'brand' ] as CheckboxProps[ 'variant' ][] ).map( variant => (
+			{ ( [ 'primary', 'brand' ] as CheckboxProps[ 'variant' ][] ).map( variant => (
 				<Form.Fieldset key={ variant }>
 					<Form.Legend>Indeterminate state { variant }</Form.Legend>
 

--- a/src/system/Form/Checkbox/Checkbox.tsx
+++ b/src/system/Form/Checkbox/Checkbox.tsx
@@ -34,9 +34,6 @@ const Checkbox = ( {
 
 	return (
 		<StyledCheckbox
-			sx={ {
-				opacity: disabled ? 0.4 : 1,
-			} }
 			onCheckedChange={ disabled ? undefined : onCheckedChange }
 			aria-disabled={ disabled }
 			variant={ variant }

--- a/src/system/Form/Checkbox/styles.ts
+++ b/src/system/Form/Checkbox/styles.ts
@@ -10,51 +10,62 @@ import {
 // The output willl be 16px because of the 1px border.
 const CHECKBOX_SIZE = 14;
 
-export const checkboxStyle = ( variant: string ): ThemeUIStyleObject => ( {
-	all: 'unset',
-	position: 'relative',
-	backgroundColor: inputBaseBackground,
-	...baseControlBorderStyle,
-	...baseControlFocusStyle,
-	width: CHECKBOX_SIZE,
-	height: CHECKBOX_SIZE,
-	borderRadius: 1,
-	display: 'flex',
-	justifyContent: 'center',
-	'&[aria-disabled="true"]': {
-		opacity: 0.7,
-		cursor: 'not-allowed',
-		pointerEvents: 'none',
-	},
-	'&[data-state=checked]': {
-		backgroundColor: variant,
-		color: variant,
-		borderColor: variant,
-	},
-	'& ~ label': {
-		fontWeight: 'regular',
-		color: inputBaseText,
-		m: 0,
-		ml: 2,
-	},
-	svg: {
-		position: 'absolute',
-		top: 0,
-		left: 0,
-	},
-} );
+export const checkboxStyle = ( variant: string ): ThemeUIStyleObject => {
+	const variantColor = variant === 'disabled' ? 'input.background.disabled' : variant;
 
-export const checkboxIndicatorStyle = ( variant: string ): ThemeUIStyleObject => ( {
-	width: 14,
-	height: 14,
-	backgroundImage: `url("data:image/svg+xml,%3Csvg xmlns='http://www.w3.org/2000/svg' width='14' height='14' viewBox='1 1 14 14' fill='none'%3E%3Cpath fill-rule='evenodd' clip-rule='evenodd' d='M13.9259 4.9995L6.15142 12.4008L2.92603 9.33023L4.2591 7.92994L6.15142 9.73143L12.5928 3.59921L13.9259 4.9995Z' fill='white'/%3E%3C/svg%3E")`,
+	return {
+		all: 'unset',
+		position: 'relative',
+		backgroundColor: inputBaseBackground,
+		...baseControlBorderStyle,
+		...baseControlFocusStyle,
+		width: CHECKBOX_SIZE,
+		height: CHECKBOX_SIZE,
+		borderRadius: 0,
+		display: 'flex',
+		justifyContent: 'center',
+		'&[aria-disabled="true"]': {
+			opacity: 0.7,
+			cursor: 'not-allowed',
+			pointerEvents: 'none',
+		},
+		'&[data-state=checked], &[data-state=indeterminate]': {
+			backgroundColor: variantColor,
+			color: variantColor,
+			borderColor: variantColor,
+		},
+		'& ~ label': {
+			fontWeight: 'regular',
+			color: inputBaseText,
+			m: 0,
+			ml: 2,
+		},
+		svg: {
+			position: 'absolute',
+			fill: 'currentColor',
+			top: 0,
+			left: 0,
+		},
+	};
+};
 
-	'&[data-state=indeterminate]': {
-		marginTop: '6px',
-		backgroundImage: 'none',
-		backgroundColor: variant,
-		position: 'absolute',
-		width: 10,
-		height: 2,
-	},
-} );
+export const checkboxIndicatorStyle = ( variant: string ): ThemeUIStyleObject => {
+	const backgroundColor = variant === 'disabled' ? 'icon.inverse-disabled' : 'icon.inverse';
+
+	return {
+		width: 14,
+		height: 14,
+		backgroundColor,
+		maskImage: `url("data:image/svg+xml,%3Csvg xmlns='http://www.w3.org/2000/svg' width='14' height='14' viewBox='1 1 14 14' fill='none'%3E%3Cpath fill-rule='evenodd' clip-rule='evenodd' d='M13.9259 4.9995L6.15142 12.4008L2.92603 9.33023L4.2591 7.92994L6.15142 9.73143L12.5928 3.59921L13.9259 4.9995Z' fill='currentcolor'/%3E%3C/svg%3E")`,
+
+		'&[data-state=indeterminate]': {
+			maskImage: 'none',
+			backgroundColor,
+			position: 'absolute',
+			top: '50%',
+			width: 8,
+			height: 2,
+			marginTop: '-1px',
+		},
+	};
+};

--- a/src/system/Form/Radio/Radio.stories.tsx
+++ b/src/system/Form/Radio/Radio.stories.tsx
@@ -62,7 +62,7 @@ export const Default = () => {
 
 	return (
 		<>
-			{ ( [ 'primary', 'success', 'brand' ] as RadioProps[ 'variant' ][] ).map( variant => (
+			{ ( [ 'primary', 'brand' ] as RadioProps[ 'variant' ][] ).map( variant => (
 				<Box key={ variant }>
 					<Heading as="h2" sx={ { textTransform: 'capitalize' } }>
 						{ variant }


### PR DESCRIPTION
## Description

<img width="389" alt="image" src="https://github.com/Automattic/vip-design-system/assets/3402/c925fe63-5717-4b8d-a66b-f35f1b5c7d4f">
<img width="348" alt="image" src="https://github.com/Automattic/vip-design-system/assets/3402/8d51be7e-d078-405c-b608-7fc9bebe4164">
<img width="320" alt="image" src="https://github.com/Automattic/vip-design-system/assets/3402/d1455a35-cd0f-471c-9e08-429f36479f5d">


As agreed, we will:

- [x] Remove the extra variants from examples (success)
- [x] Update the checkbox with the indeterminate state
- [x] Match color and styles

## Checklist

- [x] This PR has good automated test coverage
- [x] The storybook for the component has been updated

## Steps to Test

1. Pull down PR.
2. `npm run dev`.
3. Open http://localhost:6006/?path=/story/form-radio--default
4. No more `success` state
5. Open http://localhost:6006/?path=/story/form-checkbox--indeterminate
6. Indeterminate state is implemented as Figma shows
7. No more success `variants`. Keep primary and brand in all controles for now.

<img width="1019" alt="image" src="https://github.com/Automattic/vip-design-system/assets/3402/c367b5cc-5c20-4719-a869-6b569c0734bd">
