### PR TITLE
Add button variants to the Link component

### DIFF
--- a/src/system/Button/Button.stories.tsx
+++ b/src/system/Button/Button.stories.tsx
@@ -10,6 +10,7 @@ import { BiCalendarHeart } from 'react-icons/bi';
  * Internal dependencies
  */
 import { Button, ButtonVariant } from '..';
+import { Flex } from '../Flex/Flex';
 import ScreenReaderText from '../ScreenReaderText';
 
 export default {
@@ -66,7 +67,7 @@ This documentation is heavily inspired by the [U.S Web Design System (USWDS)](ht
 };
 
 const Template = args => (
-	<React.Fragment>
+	<Flex sx={ { gap: 2 } }>
 		<Button { ...args }>Primary</Button>
 
 		<Button variant="secondary" sx={ { ml: 2 } } { ...args }>
@@ -107,7 +108,7 @@ const Template = args => (
 				Button with constrained width
 			</Button>
 		</div>
-	</React.Fragment>
+	</Flex>
 );
 
 export const Default = Template.bind( {} );

--- a/src/system/Button/Button.tsx
+++ b/src/system/Button/Button.tsx
@@ -46,16 +46,6 @@ const Button = forwardRef< HTMLButtonElement, ButtonProps >(
 		return (
 			<ThemeButton
 				sx={ {
-					verticalAlign: 'middle',
-					display: 'inline-flex',
-					alignItems: 'center',
-					justifyContent: 'center',
-					minHeight: '36px',
-					py: 0,
-					textDecoration: 'none',
-					'&:hover': {
-						textDecoration: 'none',
-					},
 					'&:focus': 'none',
 					'&:focus-visible': ( theme: ButtonTheme ) => theme.outline,
 					'&[aria-disabled="true"]': {

--- a/src/system/Link/Link.stories.tsx
+++ b/src/system/Link/Link.stories.tsx
@@ -4,8 +4,8 @@
 import { Link } from '..';
 import { Flex } from '../Flex/Flex';
 
+import type { LinkProps } from './Link';
 import type { StoryObj } from '@storybook/react';
-import { LinkProps } from './Link';
 
 /**
  * Internal dependencies

--- a/src/system/Link/Link.stories.tsx
+++ b/src/system/Link/Link.stories.tsx
@@ -2,8 +2,10 @@
  * External dependencies
  */
 import { Link } from '..';
+import { Flex } from '../Flex/Flex';
 
 import type { StoryObj } from '@storybook/react';
+import { LinkProps } from './Link';
 
 /**
  * Internal dependencies
@@ -22,3 +24,22 @@ export const Default: Story = {
 		href: '#!',
 	},
 };
+
+const buttonTypes: LinkProps[ 'variant' ][] = [
+	'button-primary',
+	'button-secondary',
+	'button-tertiary',
+	'button-danger',
+	'button-display',
+	'button-ghost',
+];
+
+export const ButtonVariants = () => (
+	<Flex sx={ { gap: 2 } }>
+		{ buttonTypes.map( ( variant, index ) => (
+			<Link key={ index } href="#!" variant={ variant }>
+				Hello
+			</Link>
+		) ) }
+	</Flex>
+);

--- a/src/system/Link/Link.tsx
+++ b/src/system/Link/Link.tsx
@@ -15,33 +15,26 @@ interface LinkTheme extends Theme {
 }
 
 export interface LinkProps extends ThemeLinkProps {
-	active?: boolean;
+	variant?:
+		| 'primary'
+		| 'button-primary'
+		| 'button-secondary'
+		| 'button-tertiary'
+		| 'button-ghost'
+		| 'button-display'
+		| 'button-danger';
 }
 
 export const defaultLinkComponentStyle: ThemeUIStyleObject = {
-	color: 'link',
-	textDecorationThickness: '0.1em',
-	textUnderlineOffset: '0.1em',
-	'&:visited': {
-		color: 'links.visited',
-	},
-	'&:active': {
-		color: 'links.active',
-	},
-	'&:hover, &:focus': {
-		color: 'links.hover',
-		textDecorationLine: 'underline',
-		textDecorationThickness: '2px',
-	},
 	'&:focus-visible': ( theme: LinkTheme ) => theme.outline,
 };
 
 export const Link = forwardRef< HTMLAnchorElement, LinkProps >(
-	( { active = false, sx, ...props }: LinkProps, ref: Ref< HTMLAnchorElement > ) => (
+	( { variant = 'primary', sx, ...props }: LinkProps, ref: Ref< HTMLAnchorElement > ) => (
 		<ThemeLink
+			variant={ variant }
 			sx={ {
 				...defaultLinkComponentStyle,
-				color: active ? 'links.active' : 'link',
 				...sx,
 			} }
 			ref={ ref }

--- a/src/system/theme/index.js
+++ b/src/system/theme/index.js
@@ -271,11 +271,14 @@ export default {
 
 	buttons: {
 		primary: {
-			// you can reference other values defined in the theme
 			fontFamily: 'body',
 			color: 'button.primary.label.default',
 			bg: 'button.primary.background.default',
 			border: '1px solid transparent',
+			py: 0,
+			px: 5,
+			minHeight: '38px',
+			height: '100%',
 			cursor: 'pointer',
 			fontWeight: 'medium',
 			boxShadow: 'none',
@@ -283,6 +286,14 @@ export default {
 			'&:hover, &:focus': {
 				backgroundColor: 'button.primary.background.hover',
 				color: 'button.primary.label.hover',
+			},
+			verticalAlign: 'middle',
+			display: 'inline-flex',
+			alignItems: 'center',
+			justifyContent: 'center',
+			textDecoration: 'none',
+			'&:hover': {
+				textDecoration: 'none',
 			},
 		},
 
@@ -387,22 +398,42 @@ export default {
 	},
 
 	links: {
-		dark: {
-			color: 'modes.dark.muted',
-			'&:hover': { color: 'modes.dark.heading' },
-		},
-
-		hover: {
-			display: 'block',
-			color: 'inherit',
-			py: 1,
-			px: 2,
-			my: -1,
-			mx: -2,
-			borderRadius: 2,
-			'&:hover': {
-				backgroundColor: 'hover',
+		primary: {
+			color: 'link',
+			'&:visited': {
+				color: 'links.visited',
 			},
+			'&:hover': {
+				color: 'hover',
+			},
+			'&:active': {
+				color: 'links.active',
+			},
+			textDecorationThickness: '0.125rem',
+			textUnderlineOffset: '0.125rem',
+			'&:hover, &:focus': {
+				color: 'links.hover',
+				textDecorationLine: 'underline',
+				textDecorationThickness: '0.125rem',
+			},
+		},
+		'button-primary': {
+			variant: 'buttons.primary',
+		},
+		'button-danger': {
+			variant: 'buttons.danger',
+		},
+		'button-display': {
+			variant: 'buttons.display',
+		},
+		'button-ghost': {
+			variant: 'buttons.ghost',
+		},
+		'button-secondary': {
+			variant: 'buttons.secondary',
+		},
+		'button-tertiary': {
+			variant: 'buttons.tertiary',
 		},
 	},
 
@@ -492,7 +523,7 @@ export default {
 			fontFamily: 'body',
 			lineHeight: 'body',
 			fontWeight: 'body',
-			fontSize: 2,
+			fontSize: '16px',
 			color: 'text',
 			backgroundColor: 'backgrounds.primary',
 			fontSmoothing: 'antialiased',

--- a/src/system/theme/index.js
+++ b/src/system/theme/index.js
@@ -523,7 +523,6 @@ export default {
 			fontFamily: 'body',
 			lineHeight: 'body',
 			fontWeight: 'body',
-			fontSize: '16px',
 			color: 'text',
 			backgroundColor: 'backgrounds.primary',
 			fontSmoothing: 'antialiased',


### PR DESCRIPTION
## Description
<img width="1065" alt="image" src="https://github.com/Automattic/vip-design-system/assets/3402/223c7991-e541-49d9-8e91-068b3f9b7c70">

Sometimes, we want to display links as Buttons, and this is a way to reuse Button styles within the `Link` component.

## Checklist

- [x] This PR has good automated test coverage
- [x] The storybook for the component has been updated

## Steps to Test

1. Pull down PR.
2. `npm run dev`.
3. Open http://localhost:6006/?path=/docs/navigation-link--docs
4. There's a new section called: Button Variants
5. You should see a demo for each of the following new variants: 

```
button-primary
button-secondary
button-tertiary
button-danger
button-display
button-ghost
```
