### PR TITLE
Adjust link and menu

### DIFF
--- a/src/system/Nav/Nav.stories.tsx
+++ b/src/system/Nav/Nav.stories.tsx
@@ -163,7 +163,12 @@ export const Menu: Story = {
 					Domains & TLS
 				</NavItem.Menu>
 
-				<NavItem.MenuGroup active label="Logs" renderIcon={ size => <BiHistory size={ size } /> }>
+				<NavItem.MenuGroup
+					active
+					activeChildren
+					label="Logs"
+					renderIcon={ size => <BiHistory size={ size } /> }
+				>
 					<NavItem.Menu active as={ CustomLink } href="https://google.com/">
 						Audit
 					</NavItem.Menu>

--- a/src/system/Nav/NavItemGroup.test.tsx
+++ b/src/system/Nav/NavItemGroup.test.tsx
@@ -35,12 +35,12 @@ describe( '<NavItemGroup />', () => {
 	it( 'renders the NavItemGroup component a data-active-children', async () => {
 		const { container } = renderComponent();
 
-		// Should find the nav label
+		// Should find the button label
 		const button = screen.getByRole( 'button', { label: /Logs/ } );
 
 		expect( button ).toBeInTheDocument();
 
-		// Should find all links
+		// Expect to have another attribute
 		expect( button ).toHaveAttribute( 'data-active', 'true' );
 		expect( button ).toHaveAttribute( 'data-active-children', 'true' );
 

--- a/src/system/Nav/NavItemGroup.test.tsx
+++ b/src/system/Nav/NavItemGroup.test.tsx
@@ -1,0 +1,50 @@
+/** @jsxImportSource theme-ui */
+/* eslint-disable @typescript-eslint/ban-ts-comment */
+// @ts-nocheck
+
+import { render, screen } from '@testing-library/react';
+import { axe } from 'jest-axe';
+import { ThemeUIProvider } from 'theme-ui';
+
+import { Nav } from './Nav';
+import { NavItem } from './NavItem';
+import { theme } from '../';
+import { CustomLink } from '../utils/stories/CustomLink';
+
+const renderWithTheme = children =>
+	render( <ThemeUIProvider theme={ theme }>{ children }</ThemeUIProvider> );
+
+const renderComponent = () =>
+	renderWithTheme(
+		<Nav.Menu label="Nav Menu">
+			<NavItem.MenuGroup active activeChildren label="Logs">
+				<NavItem.Menu active as={ CustomLink } href="https://google.com/">
+					Audit
+				</NavItem.Menu>
+				<NavItem.Menu as={ CustomLink } href="https://wpvip.com/">
+					Runtime
+				</NavItem.Menu>
+				<NavItem.Menu as={ CustomLink } href="https://dashboard.wpvip.com/">
+					Slow Query
+				</NavItem.Menu>
+			</NavItem.MenuGroup>
+		</Nav.Menu>
+	);
+
+describe( '<NavItemGroup />', () => {
+	it( 'renders the NavItemGroup component a data-active-children', async () => {
+		const { container } = renderComponent();
+
+		// Should find the nav label
+		const button = screen.getByRole( 'button', { label: /Logs/ } );
+
+		expect( button ).toBeInTheDocument();
+
+		// Should find all links
+		expect( button ).toHaveAttribute( 'data-active', 'true' );
+		expect( button ).toHaveAttribute( 'data-active-children', 'true' );
+
+		// Check for accessibility issues
+		expect( await axe( container ) ).toHaveNoViolations();
+	} );
+} );

--- a/src/system/Nav/NavItemGroup.tsx
+++ b/src/system/Nav/NavItemGroup.tsx
@@ -17,6 +17,7 @@ import {
 
 export interface NavItemGroupProps extends NavItemBaseProps {
 	renderIcon?: NavItemRenderIconProp;
+	activeChildren?: boolean;
 	label: string;
 }
 
@@ -28,6 +29,7 @@ const NavItemGroupBase = forwardRef< HTMLLIElement, NavItemGroupProps >(
 			orientation,
 			className,
 			active,
+			activeChildren,
 			renderIcon,
 			children,
 			sx,
@@ -54,6 +56,7 @@ const NavItemGroupBase = forwardRef< HTMLLIElement, NavItemGroupProps >(
 							aria-haspopup={ true }
 							data-active={ active || undefined }
 							data-open={ isExpanded || undefined }
+							data-active-children={ activeChildren || undefined }
 							sx={ {
 								...navItemLinkVariantStyles( variant ),
 								...navItemGroupTriggerStyles,

--- a/src/system/Nav/styles/variants/menu.ts
+++ b/src/system/Nav/styles/variants/menu.ts
@@ -31,9 +31,9 @@ export const menuInverseItemStyles = (
 // Menu Item Link <a>
 
 const visitedLink = '&:visited';
-const activeAfter = '&[data-active]::before';
-const active = '&[data-active]';
-const focusNotActiveHoverNotActive = '&:focus:not(&[data-active]), &:hover:not(&[data-active])';
+const active = '&[data-active]:not(&[data-active-children="true"][data-state="open"])';
+const activeBefore = `${ active }::before`;
+const focusNotActiveHoverNotActive = `&:focus:not(${ active }), &:hover:not(${ active })`;
 const notHover = ':not(&:hover)';
 const svgIcon = 'svg';
 
@@ -63,7 +63,7 @@ export const menuItemLinkStyles: MixedStyleProp = {
 	[ visitedLink ]: {
 		color: 'text',
 	},
-	[ activeAfter ]: {
+	[ activeBefore ]: {
 		position: 'absolute',
 		content: "''",
 		overflow: 'hidden',

--- a/src/system/theme/index.js
+++ b/src/system/theme/index.js
@@ -414,8 +414,10 @@ export default {
 			'&:active': {
 				color: 'links.active',
 			},
+
 			textDecorationThickness: '0.125rem',
-			textUnderlineOffset: '0.125rem',
+			textUnderlineOffset: '0.250rem',
+
 			'&:hover, &:focus': {
 				color: 'links.hover',
 				textDecorationLine: 'underline',


### PR DESCRIPTION
## Description

- Link: Adjust the link `textUnderlineOffset` css style
- Menu: Add `activeChildren` to NavItem.MenuGroup so both can be active but with a different style

## Checklist

- N/A This PR has good automated test coverage
- [x] The storybook for the component has been updated

## Steps to Test

1. Open http://localhost:6006/?path=/story/navigation-nav--menu
2. Logs should be active (visually) when you close it
3. Logs should be inactive (visually) when you open and there's an active child

![chrome-capture-2024-4-29](https://github.com/Automattic/vip-design-system/assets/3402/6d479e33-6f7c-499e-8a19-15bc66a1dd19)
