### PR TITLE
Adjust tabs selected styling and the responsiveness behavior

### DIFF
--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@automattic/vip-design-system",
-  "version": "2.4.1-dev.0",
+  "version": "2.4.1-dev.1",
   "main": "build/system/index.js",
   "scripts": {
     "build-storybook": "storybook build",

--- a/src/system/Nav/Nav.stories.tsx
+++ b/src/system/Nav/Nav.stories.tsx
@@ -115,16 +115,25 @@ export const Tab: Story = {
 				<strong>Variant: Tab</strong>
 			</p>
 			<Nav.Tab sx={ { mb: 4 } } label="Nav Tab">
-				<NavItem.Tab active as={ CustomLink } href="https://random-website.com/">
+				<NavItem.Tab as={ CustomLink } href="#!">
 					PHP
 				</NavItem.Tab>
-				<NavItem.Tab as={ CustomLink } href="https://wordpress.com">
+				<NavItem.Tab as={ CustomLink } href="#2!">
 					WordPress
 				</NavItem.Tab>
-				<NavItem.Tab as={ CustomLink } href="https://newrelic.com/">
+				<NavItem.Tab active as={ CustomLink } href="#3!">
 					New Relic
 				</NavItem.Tab>
-				<NavItem.Tab disabled as={ CustomLink } href="https://google.com/">
+				<NavItem.Tab as={ CustomLink } href="#4!">
+					Datadog
+				</NavItem.Tab>
+				<NavItem.Tab as={ CustomLink } href="#4!">
+					OnePlus
+				</NavItem.Tab>
+				<NavItem.Tab as={ CustomLink } href="#5!">
+					Rollbar
+				</NavItem.Tab>
+				<NavItem.Tab disabled as={ CustomLink } href="#6!">
 					Not accessible
 				</NavItem.Tab>
 			</Nav.Tab>

--- a/src/system/Nav/Nav.tsx
+++ b/src/system/Nav/Nav.tsx
@@ -24,7 +24,7 @@ const NavBase = forwardRef< HTMLElement, NavProps >(
 			aria-label={ label }
 			ref={ ref }
 			className={ classNames( VIP_NAV, className ) }
-			sx={ navStyles( variant ) }
+			sx={ navStyles( variant, orientation ) }
 			orientation={ orientation }
 		>
 			<NavigationMenu.List

--- a/src/system/Nav/styles.ts
+++ b/src/system/Nav/styles.ts
@@ -86,22 +86,6 @@ export const navItemStyles = (
 	}
 };
 
-export const navRootStyles = ( variant: NavVariant ): ThemeUIStyleObject => {
-	switch ( variant ) {
-		case 'tabs': {
-			return tabRootStyles;
-		}
-
-		case 'toolbar': {
-			return toolbarRootStyles;
-		}
-
-		default: {
-			return defaultNavRootStyles;
-		}
-	}
-};
-
 export const navStyles = (
 	variant: NavVariant,
 	orientation: NavProps[ 'orientation' ]

--- a/src/system/Nav/styles.ts
+++ b/src/system/Nav/styles.ts
@@ -8,6 +8,7 @@ import {
 	menuInverseItemStyles,
 	menuItemLinkStyles,
 	menuItemStyles,
+	tabItemStyles,
 } from './styles/variants/menu';
 import {
 	defaultNavItemStyles,
@@ -68,6 +69,9 @@ export const navItemStyles = (
 		case 'menu': {
 			return menuItemStyles( orientation );
 		}
+		case 'tabs': {
+			return tabItemStyles( orientation );
+		}
 		case 'menu-inverse': {
 			return menuInverseItemStyles( orientation );
 		}
@@ -98,13 +102,16 @@ export const navRootStyles = ( variant: NavVariant ): ThemeUIStyleObject => {
 	}
 };
 
-export const navStyles = ( variant: NavVariant ): ThemeUIStyleObject => {
+export const navStyles = (
+	variant: NavVariant,
+	orientation: NavProps[ 'orientation' ]
+): ThemeUIStyleObject => {
 	let navStyle: ThemeUIStyleObject = {};
 
 	switch ( variant ) {
 		case 'tabs':
 			{
-				navStyle = tabRootStyles;
+				navStyle = tabRootStyles( orientation );
 			}
 
 			break;

--- a/src/system/Nav/styles/variants/menu.ts
+++ b/src/system/Nav/styles/variants/menu.ts
@@ -17,6 +17,12 @@ export const menuItemStyles = ( orientation: NavProps[ 'orientation' ] ): ThemeU
 	justifyContent: 'space-between',
 } );
 
+// Tab Item Style <li>
+export const tabItemStyles = ( orientation: NavProps[ 'orientation' ] ): ThemeUIStyleObject => ( {
+	...defaultNavItemStyles( orientation ),
+	mr: 0,
+} );
+
 // Menu Inverse Item Style <li>
 export const menuInverseItemStyles = (
 	orientation: NavProps[ 'orientation' ]

--- a/src/system/Nav/styles/variants/tabs.ts
+++ b/src/system/Nav/styles/variants/tabs.ts
@@ -1,27 +1,64 @@
 import { ThemeUIStyleObject } from 'theme-ui';
 
 import { defaultItemLinkStyles } from './primary';
+import { NavProps } from '../../Nav';
 
 // Tab Root Styles <nav>
+const getTabPropsByOrientation = ( orientation: NavProps[ 'orientation' ] ): ThemeUIStyleObject => {
+	if ( orientation === 'vertical' ) {
+		return {
+			'> div:first-of-type': {
+				height: '100%',
+				overflowY: 'auto',
+			},
+			ul: {
+				minHeight: 'max-content',
+			},
+		};
+	}
+	return {
+		'> div:first-of-type': {
+			width: '100%',
+			overflowX: 'auto',
+		},
+		ul: {
+			minWidth: 'max-content',
+		},
+	};
+};
 
-export const tabRootStyles: ThemeUIStyleObject = {
+export const tabRootStyles = ( orientation: NavProps[ 'orientation' ] ): ThemeUIStyleObject => ( {
 	width: '100%',
 	borderColor: 'borders.2',
-};
+	gap: 2,
+
+	// Responsive in case the content is bigger than the viewport
+	...getTabPropsByOrientation( orientation ),
+} );
 
 // Tab Link <a>
 export const tabItemLinkStyles: ThemeUIStyleObject = {
 	...defaultItemLinkStyles,
-	px: 0,
-	mr: 2,
+	px: 2,
+	height: '100%',
+	backgroundColor: 'red',
 	color: 'heading',
 	'&[data-active]': {
 		color: 'link',
 		fontWeight: 'normal',
-		boxShadow: 'inset 0 -1px 0 0, 0 1px 0 0',
+		position: 'relative',
+		'&::after': {
+			position: 'absolute',
+			bottom: 0,
+			display: 'block',
+			width: '100%',
+			content: '""',
+			height: '0.125rem',
+			backgroundColor: 'link',
+		},
 	},
 	'&[aria-disabled="true"]': {
 		color: 'muted',
 	},
-	':hover': { fontWeight: 'regular', color: 'heading' },
+	':hover': { fontWeight: 'regular', color: 'link' },
 };

--- a/src/system/Tabs/Tabs.stories.jsx
+++ b/src/system/Tabs/Tabs.stories.jsx
@@ -38,6 +38,7 @@ export const Default = () => (
 		</TabsContent>
 	</Tabs>
 );
+
 export const SetActiveTab = () => {
 	const [ activeTab, setActiveTab ] = React.useState( 'all' );
 

--- a/src/system/Tabs/TabsTrigger.js
+++ b/src/system/Tabs/TabsTrigger.js
@@ -24,7 +24,16 @@ const styles = {
 	'&[data-state="active"]': {
 		color: 'link',
 		fontWeight: 'regular',
-		boxShadow: 'inset 0 -1px 0 0, 0 1px 0 0',
+		position: 'relative',
+		'&::after': {
+			position: 'absolute',
+			bottom: 0,
+			display: 'block',
+			width: '100%',
+			content: '""',
+			height: '0.125rem',
+			backgroundColor: 'link',
+		},
 	},
 	'&:disabled': {
 		color: 'muted',

--- a/src/system/theme/index.js
+++ b/src/system/theme/index.js
@@ -536,7 +536,8 @@ export default {
 			a: {
 				'&:hover': {
 					textDecorationLine: 'underline',
-					textDecorationThickness: '2px',
+					textDecorationThickness: '0.125rem',
+					textUnderlineOffset: '0.250rem',
 				},
 			},
 			svg: {


### PR DESCRIPTION
## Description

- [x] Add responsiveness behavior for Nav.Tab
- [x] Adjust selected item styles for smaller screens (box-shadow) by adding extra borders

## Checklist

- [ ] This PR has good automated test coverage
- [ ] The storybook for the component has been updated

## Steps to Test — Responsiveness Behavior

![chrome-capture-2024-5-1 (1)](https://github.com/Automattic/vip-design-system/assets/3402/8c325ade-91be-41a7-9635-f4652706b812)

1. Pull down PR.
2. `npm run dev.`
3. Open http://localhost:6006/?path=/story/navigation-nav--tab
4. Reduce the viewport smaller than the tab items size
5. Expect to have a horizontal scrollbar

## Steps to Test — Box shadow bug
1. Pull down PR.
2. `npm run dev.`
3. Open http://localhost:6006/?path=/story/navigation-nav--tab
4. By using the device toolbar in Chrome, put on a iPhone XR size with 50% of zoom

<img width="499" alt="image" src="https://github.com/Automattic/vip-design-system/assets/3402/b73a0d29-b6d4-4c69-a4df-46fda43a2b8c">

5. Expect to have the selected item with a bottom border and not left/right borders (see screenshot above)

| Before | After |
|--------|--------|
| 
<img width="210" alt="image" src="https://github.com/Automattic/vip-design-system/assets/3402/ef33d3a1-cff0-44c1-aa16-1fb7556ff310">
 | 
<img width="210" alt="image" src="https://github.com/Automattic/vip-design-system/assets/3402/64ed7ef2-fecc-428e-9760-a27fb23d69ea">
 |