### PR TITLE
LinkExternal: migrate from dashboard

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -21,6 +21,7 @@
         "accessible-autocomplete": "^2.0.4",
         "classnames": "^2.3.1",
         "framer-motion": "^3.9.1",
+        "i18n-calypso": "^7.0.0",
         "react-icons": "^4.7.0"
       },
       "devDependencies": {
@@ -125,6 +126,20 @@
       },
       "peerDependencies": {
         "eslint": ">=8"
+      }
+    },
+    "node_modules/@automattic/interpolate-components": {
+      "version": "1.2.1",
+      "resolved": "https://registry.npmjs.org/@automattic/interpolate-components/-/interpolate-components-1.2.1.tgz",
+      "integrity": "sha512-YNQtJsrs9KQ3lkBdtLyDheVRijoBA3y/PuHdgJ0eB4AX9JyjkDX7jd79Inh79+01CGNLbMQGrEJby2zvbJr17A==",
+      "peerDependencies": {
+        "@types/react": ">=16.14.23",
+        "react": ">=16.2.0"
+      },
+      "peerDependenciesMeta": {
+        "@types/react": {
+          "optional": true
+        }
       }
     },
     "node_modules/@aw-web-design/x-default-browser": {
@@ -8009,6 +8024,38 @@
       "integrity": "sha512-myfUej5naTBWnqOCc/MdVOLVjXUXtIA+NpDrDBKJtLLg2shUjBu3cZmB/85RyitKc55+lUUyl7oRfLOvkr2hsw==",
       "dev": true
     },
+    "node_modules/@tannin/compile": {
+      "version": "1.1.0",
+      "resolved": "https://registry.npmjs.org/@tannin/compile/-/compile-1.1.0.tgz",
+      "integrity": "sha512-n8m9eNDfoNZoxdvWiTfW/hSPhehzLJ3zW7f8E7oT6mCROoMNWCB4TYtv041+2FMAxweiE0j7i1jubQU4MEC/Gg==",
+      "dependencies": {
+        "@tannin/evaluate": "^1.2.0",
+        "@tannin/postfix": "^1.1.0"
+      }
+    },
+    "node_modules/@tannin/evaluate": {
+      "version": "1.2.0",
+      "resolved": "https://registry.npmjs.org/@tannin/evaluate/-/evaluate-1.2.0.tgz",
+      "integrity": "sha512-3ioXvNowbO/wSrxsDG5DKIMxC81P0QrQTYai8zFNY+umuoHWRPbQ/TuuDEOju9E+jQDXmj6yI5GyejNuh8I+eg=="
+    },
+    "node_modules/@tannin/plural-forms": {
+      "version": "1.1.0",
+      "resolved": "https://registry.npmjs.org/@tannin/plural-forms/-/plural-forms-1.1.0.tgz",
+      "integrity": "sha512-xl9R2mDZO/qiHam1AgMnAES6IKIg7OBhcXqy6eDsRCdXuxAFPcjrej9HMjyCLE0DJ/8cHf0i5OQTstuBRhpbHw==",
+      "dependencies": {
+        "@tannin/compile": "^1.1.0"
+      }
+    },
+    "node_modules/@tannin/postfix": {
+      "version": "1.1.0",
+      "resolved": "https://registry.npmjs.org/@tannin/postfix/-/postfix-1.1.0.tgz",
+      "integrity": "sha512-oocsqY7g0cR+Gur5jRQLSrX2OtpMLMse1I10JQBm8CdGMrDkh1Mg2gjsiquMHRtBs4Qwu5wgEp5GgIYHk4SNPw=="
+    },
+    "node_modules/@tannin/sprintf": {
+      "version": "1.2.0",
+      "resolved": "https://registry.npmjs.org/@tannin/sprintf/-/sprintf-1.2.0.tgz",
+      "integrity": "sha512-T0ORaQrH6kNFGzTg285RVPK+NCYZxOoA+r0QfKgHqK+yk5RuYPSKDa18XCLtycCNq+VWKpfyDpzGUGhYgCV+kw=="
+    },
     "node_modules/@testing-library/dom": {
       "version": "9.3.3",
       "resolved": "https://registry.npmjs.org/@testing-library/dom/-/dom-9.3.3.tgz",
@@ -8627,6 +8674,11 @@
       "integrity": "sha512-lfU4b34HOri+kAY5UheuFMWPDOI+OPceBSHZKp69gEyTL/mmJ4cnU6Y/rlme3UL3GyOn6Y42hyIEw0/q8sWx5w==",
       "dev": true
     },
+    "node_modules/@types/mousetrap": {
+      "version": "1.6.15",
+      "resolved": "https://registry.npmjs.org/@types/mousetrap/-/mousetrap-1.6.15.tgz",
+      "integrity": "sha512-qL0hyIMNPow317QWW/63RvL1x5MVMV+Ru3NaY9f/CuEpCqrmb7WeuK2071ZY5hczOnm38qExWM2i2WtkXLSqFw=="
+    },
     "node_modules/@types/node": {
       "version": "20.4.5",
       "resolved": "https://registry.npmjs.org/@types/node/-/node-20.4.5.tgz",
@@ -8663,8 +8715,7 @@
     "node_modules/@types/prop-types": {
       "version": "15.7.11",
       "resolved": "https://registry.npmjs.org/@types/prop-types/-/prop-types-15.7.11.tgz",
-      "integrity": "sha512-ga8y9v9uyeiLdpKddhxYQkxNDrfvuPrlFb0N1qnZZByvcElJaXthF1UhvCh9TLWJBEHeNtdnbysW7Y6Uq8CVng==",
-      "devOptional": true
+      "integrity": "sha512-ga8y9v9uyeiLdpKddhxYQkxNDrfvuPrlFb0N1qnZZByvcElJaXthF1UhvCh9TLWJBEHeNtdnbysW7Y6Uq8CVng=="
     },
     "node_modules/@types/qs": {
       "version": "6.9.12",
@@ -8682,7 +8733,6 @@
       "version": "18.2.22",
       "resolved": "https://registry.npmjs.org/@types/react/-/react-18.2.22.tgz",
       "integrity": "sha512-60fLTOLqzarLED2O3UQImc/lsNRgG0jE/a1mPW9KjMemY0LMITWEsbS4VvZ4p6rorEHd5YKxxmMKSDK505GHpA==",
-      "devOptional": true,
       "dependencies": {
         "@types/prop-types": "*",
         "@types/scheduler": "*",
@@ -8693,7 +8743,6 @@
       "version": "18.2.7",
       "resolved": "https://registry.npmjs.org/@types/react-dom/-/react-dom-18.2.7.tgz",
       "integrity": "sha512-GRaAEriuT4zp9N4p1i8BDBYmEyfo+xQ3yHjJU4eiK5NDa1RmUZG+unZABUTK4/Ox/M+GaHwb6Ow8rUITrtjszA==",
-      "devOptional": true,
       "dependencies": {
         "@types/react": "*"
       }
@@ -8707,8 +8756,7 @@
     "node_modules/@types/scheduler": {
       "version": "0.16.3",
       "resolved": "https://registry.npmjs.org/@types/scheduler/-/scheduler-0.16.3.tgz",
-      "integrity": "sha512-5cJ8CB4yAx7BH1oMvdU0Jh9lrEXyPkar6F9G/ERswkCuvP4KQZfZkSjcMbAICCpQTN4OuZn8tz0HiKv9TGZgrQ==",
-      "devOptional": true
+      "integrity": "sha512-5cJ8CB4yAx7BH1oMvdU0Jh9lrEXyPkar6F9G/ERswkCuvP4KQZfZkSjcMbAICCpQTN4OuZn8tz0HiKv9TGZgrQ=="
     },
     "node_modules/@types/semver": {
       "version": "7.5.0",
@@ -9610,6 +9658,190 @@
       "dependencies": {
         "@webassemblyjs/ast": "1.11.6",
         "@xtuc/long": "4.2.2"
+      }
+    },
+    "node_modules/@wordpress/compose": {
+      "version": "6.34.0",
+      "resolved": "https://registry.npmjs.org/@wordpress/compose/-/compose-6.34.0.tgz",
+      "integrity": "sha512-Xud0mxrfDlzjURNLadrCwhSOZeIQ7tcKpZr4RvmD7Ab5bqZeCd8nOrolosHoSBr8V733NnI2M3VAyR4ASMVpJw==",
+      "dependencies": {
+        "@babel/runtime": "^7.16.0",
+        "@types/mousetrap": "^1.6.8",
+        "@wordpress/deprecated": "^3.57.0",
+        "@wordpress/dom": "^3.57.0",
+        "@wordpress/element": "^5.34.0",
+        "@wordpress/is-shallow-equal": "^4.57.0",
+        "@wordpress/keycodes": "^3.57.0",
+        "@wordpress/priority-queue": "^2.57.0",
+        "@wordpress/undo-manager": "^0.17.0",
+        "change-case": "^4.1.2",
+        "clipboard": "^2.0.11",
+        "mousetrap": "^1.6.5",
+        "use-memo-one": "^1.1.1"
+      },
+      "engines": {
+        "node": ">=12"
+      },
+      "peerDependencies": {
+        "react": "^18.0.0"
+      }
+    },
+    "node_modules/@wordpress/deprecated": {
+      "version": "3.57.0",
+      "resolved": "https://registry.npmjs.org/@wordpress/deprecated/-/deprecated-3.57.0.tgz",
+      "integrity": "sha512-rcyiGyd5qTeSaaYVU3gbWot6u0WpN0HPQZWyUq0I+HLmj6gLG7n1z8ZBEpg0iVxEtY46tIAxUWi/FKSlIKMAqg==",
+      "dependencies": {
+        "@babel/runtime": "^7.16.0",
+        "@wordpress/hooks": "^3.57.0"
+      },
+      "engines": {
+        "node": ">=12"
+      }
+    },
+    "node_modules/@wordpress/dom": {
+      "version": "3.57.0",
+      "resolved": "https://registry.npmjs.org/@wordpress/dom/-/dom-3.57.0.tgz",
+      "integrity": "sha512-3vJ1Z5Lzb7kfMoB8ni275vFGIRrljWFQ2XsVfO6oA/HeoIfHAGVcR58GmbjyxwEgClrizMGIkbs9ubrRpontLQ==",
+      "dependencies": {
+        "@babel/runtime": "^7.16.0",
+        "@wordpress/deprecated": "^3.57.0"
+      },
+      "engines": {
+        "node": ">=12"
+      }
+    },
+    "node_modules/@wordpress/element": {
+      "version": "5.34.0",
+      "resolved": "https://registry.npmjs.org/@wordpress/element/-/element-5.34.0.tgz",
+      "integrity": "sha512-/d/lWBDYYgzE2yeXYvPnjMSDG1EdQs5TSLdjM/drQVJMxWayFqAPaF/pVczLHCPYfjgyJN4Zc+bneAKj6dEiLw==",
+      "dependencies": {
+        "@babel/runtime": "^7.16.0",
+        "@types/react": "^18.0.21",
+        "@types/react-dom": "^18.0.6",
+        "@wordpress/escape-html": "^2.57.0",
+        "change-case": "^4.1.2",
+        "is-plain-object": "^5.0.0",
+        "react": "^18.3.0",
+        "react-dom": "^18.3.0"
+      },
+      "engines": {
+        "node": ">=12"
+      }
+    },
+    "node_modules/@wordpress/element/node_modules/react": {
+      "version": "18.3.1",
+      "resolved": "https://registry.npmjs.org/react/-/react-18.3.1.tgz",
+      "integrity": "sha512-wS+hAgJShR0KhEvPJArfuPVN1+Hz1t0Y6n5jLrGQbkb4urgPE/0Rve+1kMB1v/oWgHgm4WIcV+i7F2pTVj+2iQ==",
+      "dependencies": {
+        "loose-envify": "^1.1.0"
+      },
+      "engines": {
+        "node": ">=0.10.0"
+      }
+    },
+    "node_modules/@wordpress/element/node_modules/react-dom": {
+      "version": "18.3.1",
+      "resolved": "https://registry.npmjs.org/react-dom/-/react-dom-18.3.1.tgz",
+      "integrity": "sha512-5m4nQKp+rZRb09LNH59GM4BxTh9251/ylbKIbpe7TpGxfJ+9kv6BLkLBXIjjspbgbnIBNqlI23tRnTWT0snUIw==",
+      "dependencies": {
+        "loose-envify": "^1.1.0",
+        "scheduler": "^0.23.2"
+      },
+      "peerDependencies": {
+        "react": "^18.3.1"
+      }
+    },
+    "node_modules/@wordpress/escape-html": {
+      "version": "2.57.0",
+      "resolved": "https://registry.npmjs.org/@wordpress/escape-html/-/escape-html-2.57.0.tgz",
+      "integrity": "sha512-DkTDo1Qhvs9rfobBpg5vXAOKaev3Jox8R5ryvYIhql5chrkj/V5k2ZzwUChFXxYmivVkWacCwDGmDmwe2ex/ag==",
+      "dependencies": {
+        "@babel/runtime": "^7.16.0"
+      },
+      "engines": {
+        "node": ">=12"
+      }
+    },
+    "node_modules/@wordpress/hooks": {
+      "version": "3.57.0",
+      "resolved": "https://registry.npmjs.org/@wordpress/hooks/-/hooks-3.57.0.tgz",
+      "integrity": "sha512-+RaPsTj80QNUw3RfiMhxIzaAuYPAvMByrpy97jmodrvhPM5wR9utj40DYIlAiBfMhwACh8NM+kY+UB08CKcmCQ==",
+      "dependencies": {
+        "@babel/runtime": "^7.16.0"
+      },
+      "engines": {
+        "node": ">=12"
+      }
+    },
+    "node_modules/@wordpress/i18n": {
+      "version": "4.57.0",
+      "resolved": "https://registry.npmjs.org/@wordpress/i18n/-/i18n-4.57.0.tgz",
+      "integrity": "sha512-VYWYHE+7NxnZvE9Swhhe4leQcn0jHNkzRAEV36TkfAL/MvrQYCRh71KLTvKhsilG96HUQdBwjH0VPLmYEmR3sg==",
+      "dependencies": {
+        "@babel/runtime": "^7.16.0",
+        "@wordpress/hooks": "^3.57.0",
+        "gettext-parser": "^1.3.1",
+        "memize": "^2.1.0",
+        "sprintf-js": "^1.1.1",
+        "tannin": "^1.2.0"
+      },
+      "bin": {
+        "pot-to-php": "tools/pot-to-php.js"
+      },
+      "engines": {
+        "node": ">=12"
+      }
+    },
+    "node_modules/@wordpress/i18n/node_modules/sprintf-js": {
+      "version": "1.1.3",
+      "resolved": "https://registry.npmjs.org/sprintf-js/-/sprintf-js-1.1.3.tgz",
+      "integrity": "sha512-Oo+0REFV59/rz3gfJNKQiBlwfHaSESl1pcGyABQsnnIfWOFt6JNj5gCog2U6MLZ//IGYD+nA8nI+mTShREReaA=="
+    },
+    "node_modules/@wordpress/is-shallow-equal": {
+      "version": "4.57.0",
+      "resolved": "https://registry.npmjs.org/@wordpress/is-shallow-equal/-/is-shallow-equal-4.57.0.tgz",
+      "integrity": "sha512-qUMqZMLlunwY2J31HG6NZwD2kBIqcwvIDBmdQYvVuQ2aDGeB2Z6sVPXyHCqGfh2ynFfaIL8bDtjW5UtYGPUI4A==",
+      "dependencies": {
+        "@babel/runtime": "^7.16.0"
+      },
+      "engines": {
+        "node": ">=12"
+      }
+    },
+    "node_modules/@wordpress/keycodes": {
+      "version": "3.57.0",
+      "resolved": "https://registry.npmjs.org/@wordpress/keycodes/-/keycodes-3.57.0.tgz",
+      "integrity": "sha512-8u9MlHE5xPxJf7jROBO8IGYKN54IkjXQD3mfsxVE+dtONeNwRaPvvcZOuOfySerABcCat2OgWCh1s0cV5WNCuw==",
+      "dependencies": {
+        "@babel/runtime": "^7.16.0",
+        "@wordpress/i18n": "^4.57.0"
+      },
+      "engines": {
+        "node": ">=12"
+      }
+    },
+    "node_modules/@wordpress/priority-queue": {
+      "version": "2.57.0",
+      "resolved": "https://registry.npmjs.org/@wordpress/priority-queue/-/priority-queue-2.57.0.tgz",
+      "integrity": "sha512-g4Oka9aQFVPQUhXkKhHT6BoyTEdCG6S0TUvP4SP16PbkhbvIFwZ25GRQb2ERCVTdseCuDIM5YP0kwZd3NqTlGg==",
+      "dependencies": {
+        "@babel/runtime": "^7.16.0",
+        "requestidlecallback": "^0.3.0"
+      },
+      "engines": {
+        "node": ">=12"
+      }
+    },
+    "node_modules/@wordpress/undo-manager": {
+      "version": "0.17.0",
+      "resolved": "https://registry.npmjs.org/@wordpress/undo-manager/-/undo-manager-0.17.0.tgz",
+      "integrity": "sha512-K6wSKe93z3QDAn9eKLl6aQVYeafaB1R2FW6Uyqh6OFvQG9q0DXwdgECTT7Ce5tWPEtSjn2CjT5fqDW2Kn/fstg==",
+      "dependencies": {
+        "@babel/runtime": "^7.16.0",
+        "@wordpress/is-shallow-equal": "^4.57.0"
+      },
+      "engines": {
+        "node": ">=12"
       }
     },
     "node_modules/@xtuc/ieee754": {
@@ -10967,7 +11199,6 @@
       "version": "4.1.2",
       "resolved": "https://registry.npmjs.org/camel-case/-/camel-case-4.1.2.tgz",
       "integrity": "sha512-gxGWBrTT1JuMx6R+o5PTXMmUnhnVzLQ9SNutD4YqKtI6ap897t3tKECYla6gCWEkplXnlNybEkZg9GEGxKFCgw==",
-      "dev": true,
       "dependencies": {
         "pascal-case": "^3.1.2",
         "tslib": "^2.0.3"
@@ -11002,6 +11233,16 @@
         }
       ]
     },
+    "node_modules/capital-case": {
+      "version": "1.0.4",
+      "resolved": "https://registry.npmjs.org/capital-case/-/capital-case-1.0.4.tgz",
+      "integrity": "sha512-ds37W8CytHgwnhGGTi88pcPyR15qoNkOpYwmMMfnWqqWgESapLqvDx6huFjQ5vqWSn2Z06173XNA7LtMOeUh1A==",
+      "dependencies": {
+        "no-case": "^3.0.4",
+        "tslib": "^2.0.3",
+        "upper-case-first": "^2.0.2"
+      }
+    },
     "node_modules/case-sensitive-paths-webpack-plugin": {
       "version": "2.4.0",
       "resolved": "https://registry.npmjs.org/case-sensitive-paths-webpack-plugin/-/case-sensitive-paths-webpack-plugin-2.4.0.tgz",
@@ -11030,6 +11271,25 @@
       "integrity": "sha512-vbRorB5FUQWvla16U8R/qgaFIya2qGzwDrNmCZuYKrbdSUMG6I1ZCGQRefkRVhuOkIGVne7BQ35DSfo1qvJqFg==",
       "engines": {
         "node": ">=0.8.0"
+      }
+    },
+    "node_modules/change-case": {
+      "version": "4.1.2",
+      "resolved": "https://registry.npmjs.org/change-case/-/change-case-4.1.2.tgz",
+      "integrity": "sha512-bSxY2ws9OtviILG1EiY5K7NNxkqg/JnRnFxLtKQ96JaviiIxi7djMrSd0ECT9AC+lttClmYwKw53BWpOMblo7A==",
+      "dependencies": {
+        "camel-case": "^4.1.2",
+        "capital-case": "^1.0.4",
+        "constant-case": "^3.0.4",
+        "dot-case": "^3.0.4",
+        "header-case": "^2.0.4",
+        "no-case": "^3.0.4",
+        "param-case": "^3.0.4",
+        "pascal-case": "^3.1.2",
+        "path-case": "^3.0.4",
+        "sentence-case": "^3.0.4",
+        "snake-case": "^3.0.4",
+        "tslib": "^2.0.3"
       }
     },
     "node_modules/char-regex": {
@@ -11185,6 +11445,16 @@
       },
       "optionalDependencies": {
         "@colors/colors": "1.5.0"
+      }
+    },
+    "node_modules/clipboard": {
+      "version": "2.0.11",
+      "resolved": "https://registry.npmjs.org/clipboard/-/clipboard-2.0.11.tgz",
+      "integrity": "sha512-C+0bbOqkezLIsmWSvlsXS0Q0bmkugu7jcfMIACB+RDEntIzQIkdr148we28AfSloQLRdZlYL/QYyrq05j/3Faw==",
+      "dependencies": {
+        "good-listener": "^1.2.2",
+        "select": "^1.1.2",
+        "tiny-emitter": "^2.0.0"
       }
     },
     "node_modules/cliui": {
@@ -11442,6 +11712,16 @@
       "dev": true,
       "engines": {
         "node": "^14.18.0 || >=16.10.0"
+      }
+    },
+    "node_modules/constant-case": {
+      "version": "3.0.4",
+      "resolved": "https://registry.npmjs.org/constant-case/-/constant-case-3.0.4.tgz",
+      "integrity": "sha512-I2hSBi7Vvs7BEuJDr5dDHfzb/Ruj3FyvFyh7KLilAjNQw3Be+xgqUBA2W6scVEcL0hL1dwPRtIqEPVUCKkSsyQ==",
+      "dependencies": {
+        "no-case": "^3.0.4",
+        "tslib": "^2.0.3",
+        "upper-case": "^2.0.2"
       }
     },
     "node_modules/constants-browserify": {
@@ -11851,7 +12131,6 @@
       "version": "4.3.4",
       "resolved": "https://registry.npmjs.org/debug/-/debug-4.3.4.tgz",
       "integrity": "sha512-PRWFHuSU3eDtQJPvnNY7Jcket1j0t5OuOsFzPPzsekD52Zl8qUfFIPEiswXqIvHWGVHOgX+7G/vCNNhehwxfkQ==",
-      "dev": true,
       "dependencies": {
         "ms": "2.1.2"
       },
@@ -12035,6 +12314,11 @@
       "engines": {
         "node": ">=0.4.0"
       }
+    },
+    "node_modules/delegate": {
+      "version": "3.2.0",
+      "resolved": "https://registry.npmjs.org/delegate/-/delegate-3.2.0.tgz",
+      "integrity": "sha512-IofjkYBZaZivn0V8nnsMJGBr4jVLxHDheKSW88PyxS5QC4Vo9ZbZVvhzlSxY87fVq3STR6r+4cGepyHkcWOQSw=="
     },
     "node_modules/depd": {
       "version": "2.0.0",
@@ -12241,7 +12525,6 @@
       "version": "3.0.4",
       "resolved": "https://registry.npmjs.org/dot-case/-/dot-case-3.0.4.tgz",
       "integrity": "sha512-Kv5nKlh6yRrdrGvxeJ2e5y2eRUpkUosIW4A2AS38zwSz27zu7ufDwQPi5Jhs3XAlGNetl3bmnGhQsMtkKJnj3w==",
-      "dev": true,
       "dependencies": {
         "no-case": "^3.0.4",
         "tslib": "^2.0.3"
@@ -12383,6 +12666,25 @@
       "dev": true,
       "engines": {
         "node": ">= 0.8"
+      }
+    },
+    "node_modules/encoding": {
+      "version": "0.1.13",
+      "resolved": "https://registry.npmjs.org/encoding/-/encoding-0.1.13.tgz",
+      "integrity": "sha512-ETBauow1T35Y/WZMkio9jiM0Z5xjHHmJ4XmjZOq1l/dXz3lr2sRn87nJy20RupqSh1F2m3HHPSp8ShIPQJrJ3A==",
+      "dependencies": {
+        "iconv-lite": "^0.6.2"
+      }
+    },
+    "node_modules/encoding/node_modules/iconv-lite": {
+      "version": "0.6.3",
+      "resolved": "https://registry.npmjs.org/iconv-lite/-/iconv-lite-0.6.3.tgz",
+      "integrity": "sha512-4fCk79wshMdzMp2rH06qWrJE4iolqLhCUH+OiuIgU++RB0+94NlDL81atO7GX55uUKueo0txHNtvEyI6D7WdMw==",
+      "dependencies": {
+        "safer-buffer": ">= 2.1.2 < 3.0.0"
+      },
+      "engines": {
+        "node": ">=0.10.0"
       }
     },
     "node_modules/end-of-stream": {
@@ -13481,7 +13783,6 @@
       "version": "3.3.0",
       "resolved": "https://registry.npmjs.org/events/-/events-3.3.0.tgz",
       "integrity": "sha512-mQw+2fkQbALzQ7V0MY0IqdnXNOeTtP4r0lN9z7AAawCXgqea7bDii20AYrIBrFd/Hx0M2Ocz6S111CaFkUcb0Q==",
-      "dev": true,
       "engines": {
         "node": ">=0.8.x"
       }
@@ -14440,6 +14741,15 @@
         "url": "https://github.com/privatenumber/get-tsconfig?sponsor=1"
       }
     },
+    "node_modules/gettext-parser": {
+      "version": "1.4.0",
+      "resolved": "https://registry.npmjs.org/gettext-parser/-/gettext-parser-1.4.0.tgz",
+      "integrity": "sha512-sedZYLHlHeBop/gZ1jdg59hlUEcpcZJofLq2JFwJT1zTqAU3l2wFv6IsuwFHGqbiT9DWzMUW4/em2+hspnmMMA==",
+      "dependencies": {
+        "encoding": "^0.1.12",
+        "safe-buffer": "^5.1.1"
+      }
+    },
     "node_modules/giget": {
       "version": "1.2.1",
       "resolved": "https://registry.npmjs.org/giget/-/giget-1.2.1.tgz",
@@ -14572,6 +14882,14 @@
       "dev": true,
       "engines": {
         "node": ">=8"
+      }
+    },
+    "node_modules/good-listener": {
+      "version": "1.2.2",
+      "resolved": "https://registry.npmjs.org/good-listener/-/good-listener-1.2.2.tgz",
+      "integrity": "sha512-goW1b+d9q/HIwbVYZzZ6SsTr4IgE+WA44A0GmPIQstuOrgsFcT7VEJ48nmr9GaRtNu0XTKacFLGnBPAM6Afouw==",
+      "dependencies": {
+        "delegate": "^3.1.2"
       }
     },
     "node_modules/gopd": {
@@ -14725,6 +15043,15 @@
         "url": "https://github.com/sponsors/ljharb"
       }
     },
+    "node_modules/hash.js": {
+      "version": "1.1.7",
+      "resolved": "https://registry.npmjs.org/hash.js/-/hash.js-1.1.7.tgz",
+      "integrity": "sha512-taOaskGt4z4SOANNseOviYDvjEJinIkRgmp7LbKP2YTTmVxWBl87s/uzK9r+44BclBSp2X7K1hqeNfz9JbBeXA==",
+      "dependencies": {
+        "inherits": "^2.0.3",
+        "minimalistic-assert": "^1.0.1"
+      }
+    },
     "node_modules/hasown": {
       "version": "2.0.0",
       "resolved": "https://registry.npmjs.org/hasown/-/hasown-2.0.0.tgz",
@@ -14743,6 +15070,15 @@
       "dev": true,
       "bin": {
         "he": "bin/he"
+      }
+    },
+    "node_modules/header-case": {
+      "version": "2.0.4",
+      "resolved": "https://registry.npmjs.org/header-case/-/header-case-2.0.4.tgz",
+      "integrity": "sha512-H/vuk5TEEVZwrR0lp2zed9OCo1uAILMlx0JEMgC26rzyJJ3N1v6XkwHHXJQdR2doSjcGPM6OKPYoJgf0plJ11Q==",
+      "dependencies": {
+        "capital-case": "^1.0.4",
+        "tslib": "^2.0.3"
       }
     },
     "node_modules/hey-listen": {
@@ -14943,6 +15279,38 @@
         "node": ">=10.17.0"
       }
     },
+    "node_modules/i18n-calypso": {
+      "version": "7.0.0",
+      "resolved": "https://registry.npmjs.org/i18n-calypso/-/i18n-calypso-7.0.0.tgz",
+      "integrity": "sha512-GQesQzd/VYXiJOrjMixJNFOqNOcp43kKGKZTimYu70RabvcObpjfAOqtrQganszXqXWxZ7fAXOnhCTd8NVtf/Q==",
+      "dependencies": {
+        "@automattic/interpolate-components": "^1.2.1",
+        "@babel/runtime": "^7.23.6",
+        "@tannin/sprintf": "^1.1.0",
+        "@wordpress/compose": "^6.25.0",
+        "debug": "^4.3.3",
+        "events": "^3.0.0",
+        "hash.js": "^1.1.5",
+        "lodash": "^4.17.21",
+        "lru": "^3.1.0",
+        "tannin": "^1.1.1",
+        "use-subscription": "1.6.0"
+      },
+      "peerDependencies": {
+        "react": "^18.2.0"
+      }
+    },
+    "node_modules/i18n-calypso/node_modules/@babel/runtime": {
+      "version": "7.24.5",
+      "resolved": "https://registry.npmjs.org/@babel/runtime/-/runtime-7.24.5.tgz",
+      "integrity": "sha512-Nms86NXrsaeU9vbBJKni6gXiEXZ4CVpYVzEjDH9Sb8vmZ3UljyA1GSOJl/6LGPO8EHLuSF9H+IxNXHPX8QHJ4g==",
+      "dependencies": {
+        "regenerator-runtime": "^0.14.0"
+      },
+      "engines": {
+        "node": ">=6.9.0"
+      }
+    },
     "node_modules/iconv-lite": {
       "version": "0.4.24",
       "resolved": "https://registry.npmjs.org/iconv-lite/-/iconv-lite-0.4.24.tgz",
@@ -15133,8 +15501,7 @@
     "node_modules/inherits": {
       "version": "2.0.4",
       "resolved": "https://registry.npmjs.org/inherits/-/inherits-2.0.4.tgz",
-      "integrity": "sha512-k/vGaX4/Yla3WzyMCvTQOXYeIHvqOKtnqBduzTHpzpQZzAskKMhZ2K+EnBiSM9zGSoIFeMpXKxa4dYeZIQqewQ==",
-      "dev": true
+      "integrity": "sha512-k/vGaX4/Yla3WzyMCvTQOXYeIHvqOKtnqBduzTHpzpQZzAskKMhZ2K+EnBiSM9zGSoIFeMpXKxa4dYeZIQqewQ=="
     },
     "node_modules/internal-slot": {
       "version": "1.0.5",
@@ -15513,7 +15880,6 @@
       "version": "5.0.0",
       "resolved": "https://registry.npmjs.org/is-plain-object/-/is-plain-object-5.0.0.tgz",
       "integrity": "sha512-VRSzKkbMm5jMDoKLbltAkFQ5Qr7VDiTFGXxYFXXowVj387GeGNOCsOH6Msy00SGZ3Fp84b1Naa1psqgcCIEP5Q==",
-      "dev": true,
       "engines": {
         "node": ">=0.10.0"
       }
@@ -18164,8 +18530,7 @@
     "node_modules/lodash": {
       "version": "4.17.21",
       "resolved": "https://registry.npmjs.org/lodash/-/lodash-4.17.21.tgz",
-      "integrity": "sha512-v2kDEe57lecTulaDIuNTPy3Ry4gLGJ6Z1O3vE1krgXZNrsQ+LFTGHVxVjcXPs17LhbZVGedAJv8XZ1tvj5FvSg==",
-      "dev": true
+      "integrity": "sha512-v2kDEe57lecTulaDIuNTPy3Ry4gLGJ6Z1O3vE1krgXZNrsQ+LFTGHVxVjcXPs17LhbZVGedAJv8XZ1tvj5FvSg=="
     },
     "node_modules/lodash.debounce": {
       "version": "4.0.8",
@@ -18262,9 +18627,19 @@
       "version": "2.0.2",
       "resolved": "https://registry.npmjs.org/lower-case/-/lower-case-2.0.2.tgz",
       "integrity": "sha512-7fm3l3NAF9WfN6W3JOmf5drwpVqX78JtoGJ3A6W0a6ZnldM41w2fV5D490psKFTpMds8TJse/eHLFFsNHHjHgg==",
-      "dev": true,
       "dependencies": {
         "tslib": "^2.0.3"
+      }
+    },
+    "node_modules/lru": {
+      "version": "3.1.0",
+      "resolved": "https://registry.npmjs.org/lru/-/lru-3.1.0.tgz",
+      "integrity": "sha512-5OUtoiVIGU4VXBOshidmtOsvBIvcQR6FD/RzWSvaeHyxCGB+PCUCu+52lqMfdc0h/2CLvHhZS4TwUmMQrrMbBQ==",
+      "dependencies": {
+        "inherits": "^2.0.1"
+      },
+      "engines": {
+        "node": ">= 0.4.0"
       }
     },
     "node_modules/lru-cache": {
@@ -18390,6 +18765,11 @@
         "node": ">= 4.0.0"
       }
     },
+    "node_modules/memize": {
+      "version": "2.1.0",
+      "resolved": "https://registry.npmjs.org/memize/-/memize-2.1.0.tgz",
+      "integrity": "sha512-yywVJy8ctVlN5lNPxsep5urnZ6TTclwPEyigM9M3Bi8vseJBOfqNrGWN/r8NzuIt3PovM323W04blJfGQfQSVg=="
+    },
     "node_modules/memoizerific": {
       "version": "1.11.3",
       "resolved": "https://registry.npmjs.org/memoizerific/-/memoizerific-1.11.3.tgz",
@@ -18493,6 +18873,11 @@
         "node": ">=4"
       }
     },
+    "node_modules/minimalistic-assert": {
+      "version": "1.0.1",
+      "resolved": "https://registry.npmjs.org/minimalistic-assert/-/minimalistic-assert-1.0.1.tgz",
+      "integrity": "sha512-UtJcAD4yEaGtjPezWuO9wC4nwUnVH/8/Im3yEHQP4b67cXlD/Qr9hdITCU1xDbSEXg2XKNaP8jsReV7vQd00/A=="
+    },
     "node_modules/minimatch": {
       "version": "3.1.2",
       "resolved": "https://registry.npmjs.org/minimatch/-/minimatch-3.1.2.tgz",
@@ -18572,11 +18957,15 @@
       "integrity": "sha512-gKLcREMhtuZRwRAfqP3RFW+TK4JqApVBtOIftVgjuABpAtpxhPGaDcfvbhNvD0B8iD1oUr/txX35NjcaY6Ns/A==",
       "dev": true
     },
+    "node_modules/mousetrap": {
+      "version": "1.6.5",
+      "resolved": "https://registry.npmjs.org/mousetrap/-/mousetrap-1.6.5.tgz",
+      "integrity": "sha512-QNo4kEepaIBwiT8CDhP98umTetp+JNfQYBWvC1pc6/OAibuXtRcxZ58Qz8skvEHYvURne/7R8T5VoOI7rDsEUA=="
+    },
     "node_modules/ms": {
       "version": "2.1.2",
       "resolved": "https://registry.npmjs.org/ms/-/ms-2.1.2.tgz",
-      "integrity": "sha512-sGkPx+VjMtmA6MX27oA4FBFELFCZZ4S4XqeGOXCv68tT+jb3vk/RyaKWP0PTKyWtmLSM0b+adUTEvbs1PEaH2w==",
-      "dev": true
+      "integrity": "sha512-sGkPx+VjMtmA6MX27oA4FBFELFCZZ4S4XqeGOXCv68tT+jb3vk/RyaKWP0PTKyWtmLSM0b+adUTEvbs1PEaH2w=="
     },
     "node_modules/nanoid": {
       "version": "3.3.7",
@@ -18621,7 +19010,6 @@
       "version": "3.0.4",
       "resolved": "https://registry.npmjs.org/no-case/-/no-case-3.0.4.tgz",
       "integrity": "sha512-fgAN3jGAh+RoxUGZHTSOLJIqUc2wmoBwGR4tbpNAKmmovFoWq0OdRkb0VkldReO2a2iBT/OEulG9XSUc10r3zg==",
-      "dev": true,
       "dependencies": {
         "lower-case": "^2.0.2",
         "tslib": "^2.0.3"
@@ -19260,7 +19648,6 @@
       "version": "3.0.4",
       "resolved": "https://registry.npmjs.org/param-case/-/param-case-3.0.4.tgz",
       "integrity": "sha512-RXlj7zCYokReqWpOPH9oYivUzLYZ5vAPIfEmCTNViosC78F8F0H9y7T7gG2M39ymgutxF5gcFEsyZQSph9Bp3A==",
-      "dev": true,
       "dependencies": {
         "dot-case": "^3.0.4",
         "tslib": "^2.0.3"
@@ -19331,7 +19718,6 @@
       "version": "3.1.2",
       "resolved": "https://registry.npmjs.org/pascal-case/-/pascal-case-3.1.2.tgz",
       "integrity": "sha512-uWlGT3YSnK9x3BQJaOdcZwrnV6hPpd8jFH1/ucpiLRPh/2zCVJKS19E4GvYHvaCcACn3foXZ0cLB9Wrx1KGe5g==",
-      "dev": true,
       "dependencies": {
         "no-case": "^3.0.4",
         "tslib": "^2.0.3"
@@ -19342,6 +19728,15 @@
       "resolved": "https://registry.npmjs.org/path-browserify/-/path-browserify-1.0.1.tgz",
       "integrity": "sha512-b7uo2UCUOYZcnF/3ID0lulOJi/bafxa1xPe7ZPsammBSpjSWQkjNxlt635YGS2MiR9GjvuXCtz2emr3jbsz98g==",
       "dev": true
+    },
+    "node_modules/path-case": {
+      "version": "3.0.4",
+      "resolved": "https://registry.npmjs.org/path-case/-/path-case-3.0.4.tgz",
+      "integrity": "sha512-qO4qCFjXqVTrcbPt/hQfhTQ+VhFsqNKOPtytgNKkKxSoEp3XPUQ8ObFuePylOIok5gjn69ry8XiULxCwot3Wfg==",
+      "dependencies": {
+        "dot-case": "^3.0.4",
+        "tslib": "^2.0.3"
+      }
     },
     "node_modules/path-exists": {
       "version": "4.0.0",
@@ -20535,8 +20930,7 @@
     "node_modules/requestidlecallback": {
       "version": "0.3.0",
       "resolved": "https://registry.npmjs.org/requestidlecallback/-/requestidlecallback-0.3.0.tgz",
-      "integrity": "sha512-TWHFkT7S9p7IxLC5A1hYmAYQx2Eb9w1skrXmQ+dS1URyvR8tenMLl4lHbqEOUnpEYxNKpkVMXUgknVpBZWXXfQ==",
-      "dev": true
+      "integrity": "sha512-TWHFkT7S9p7IxLC5A1hYmAYQx2Eb9w1skrXmQ+dS1URyvR8tenMLl4lHbqEOUnpEYxNKpkVMXUgknVpBZWXXfQ=="
     },
     "node_modules/require-directory": {
       "version": "2.1.1",
@@ -20709,7 +21103,6 @@
       "version": "5.2.1",
       "resolved": "https://registry.npmjs.org/safe-buffer/-/safe-buffer-5.2.1.tgz",
       "integrity": "sha512-rp3So07KcdmmKbGvgaNxQSJr7bGVSVk5S9Eq1F+ppbRo70+YeaDxkw5Dd8NPN+GD6bjnYm2VuPuCXmpuYvmCXQ==",
-      "dev": true,
       "funding": [
         {
           "type": "github",
@@ -20751,8 +21144,7 @@
     "node_modules/safer-buffer": {
       "version": "2.1.2",
       "resolved": "https://registry.npmjs.org/safer-buffer/-/safer-buffer-2.1.2.tgz",
-      "integrity": "sha512-YZo3K82SD7Riyi0E1EQPojLz7kpepnSQI9IyPbHHg1XXXevb5dJI7tpyN2ADxGcQbHG7vcyRHk0cbwqcQriUtg==",
-      "dev": true
+      "integrity": "sha512-YZo3K82SD7Riyi0E1EQPojLz7kpepnSQI9IyPbHHg1XXXevb5dJI7tpyN2ADxGcQbHG7vcyRHk0cbwqcQriUtg=="
     },
     "node_modules/saxes": {
       "version": "6.0.0",
@@ -20767,9 +21159,9 @@
       }
     },
     "node_modules/scheduler": {
-      "version": "0.23.0",
-      "resolved": "https://registry.npmjs.org/scheduler/-/scheduler-0.23.0.tgz",
-      "integrity": "sha512-CtuThmgHNg7zIZWAXi3AsyIzA3n4xx7aNyjwC2VJldO2LMVDhFK+63xGqq6CsJH4rTAt6/M+N4GhZiDYPx9eUw==",
+      "version": "0.23.2",
+      "resolved": "https://registry.npmjs.org/scheduler/-/scheduler-0.23.2.tgz",
+      "integrity": "sha512-UOShsPwz7NrMUqhR6t0hWjFduvOzbtv7toDH1/hIrfRNIDBnnBWd0CwJTGvTpngVlmwGCdP9/Zl/tVrDqcuYzQ==",
       "dependencies": {
         "loose-envify": "^1.1.0"
       }
@@ -20791,6 +21183,11 @@
         "type": "opencollective",
         "url": "https://opencollective.com/webpack"
       }
+    },
+    "node_modules/select": {
+      "version": "1.1.2",
+      "resolved": "https://registry.npmjs.org/select/-/select-1.1.2.tgz",
+      "integrity": "sha512-OwpTSOfy6xSs1+pwcNrv0RBMOzI39Lp3qQKUTPVVPRjCdNa5JH/oPRiqsesIskK8TVgmRiHwO4KXlV2Li9dANA=="
     },
     "node_modules/semver": {
       "version": "6.3.1",
@@ -20845,6 +21242,16 @@
       "resolved": "https://registry.npmjs.org/ms/-/ms-2.1.3.tgz",
       "integrity": "sha512-6FlzubTLZG3J2a/NVCAleEhjzq5oxgHyaCU9yYXvcLsvoVaHJq/s5xXI6/XXP6tz7R9xAOtHnSO/tXtF3WRTlA==",
       "dev": true
+    },
+    "node_modules/sentence-case": {
+      "version": "3.0.4",
+      "resolved": "https://registry.npmjs.org/sentence-case/-/sentence-case-3.0.4.tgz",
+      "integrity": "sha512-8LS0JInaQMCRoQ7YUytAo/xUu5W2XnQxV2HI/6uM6U7CITS1RqPElr30V6uIqyMKM9lJGRVFy5/4CuzcixNYSg==",
+      "dependencies": {
+        "no-case": "^3.0.4",
+        "tslib": "^2.0.3",
+        "upper-case-first": "^2.0.2"
+      }
     },
     "node_modules/serialize-javascript": {
       "version": "6.0.2",
@@ -20977,6 +21384,15 @@
       "dev": true,
       "engines": {
         "node": ">=6"
+      }
+    },
+    "node_modules/snake-case": {
+      "version": "3.0.4",
+      "resolved": "https://registry.npmjs.org/snake-case/-/snake-case-3.0.4.tgz",
+      "integrity": "sha512-LAOh4z89bGQvl9pFfNF8V146i7o7/CqFPbqzYgP+yYzDIDeS9HaNFtXABamRW+AQzEVODcvE79ljJ+8a9YSdMg==",
+      "dependencies": {
+        "dot-case": "^3.0.4",
+        "tslib": "^2.0.3"
       }
     },
     "node_modules/source-map": {
@@ -21438,6 +21854,14 @@
       "integrity": "sha512-AsS729u2RHUfEra9xJrE39peJcc2stq2+poBXX8bcM08Y6g9j/i/PUzwNQqkaJde7Ntg1TO7bSREbR5sdosQ+g==",
       "dev": true
     },
+    "node_modules/tannin": {
+      "version": "1.2.0",
+      "resolved": "https://registry.npmjs.org/tannin/-/tannin-1.2.0.tgz",
+      "integrity": "sha512-U7GgX/RcSeUETbV7gYgoz8PD7Ni4y95pgIP/Z6ayI3CfhSujwKEBlGFTCRN+Aqnuyf4AN2yHL+L8x+TCGjb9uA==",
+      "dependencies": {
+        "@tannin/plural-forms": "^1.1.0"
+      }
+    },
     "node_modules/tapable": {
       "version": "2.2.1",
       "resolved": "https://registry.npmjs.org/tapable/-/tapable-2.2.1.tgz",
@@ -21799,6 +22223,11 @@
       "dependencies": {
         "safe-buffer": "~5.1.0"
       }
+    },
+    "node_modules/tiny-emitter": {
+      "version": "2.1.0",
+      "resolved": "https://registry.npmjs.org/tiny-emitter/-/tiny-emitter-2.1.0.tgz",
+      "integrity": "sha512-NB6Dk1A9xgQPMoGqC5CVXn123gWyte215ONT5Pp5a0yt4nlEoO1ZWeCwpncaekPHXO60i47ihFnZPiRPjRMq4Q=="
     },
     "node_modules/tiny-invariant": {
       "version": "1.3.3",
@@ -22320,6 +22749,22 @@
         "browserslist": ">= 4.21.0"
       }
     },
+    "node_modules/upper-case": {
+      "version": "2.0.2",
+      "resolved": "https://registry.npmjs.org/upper-case/-/upper-case-2.0.2.tgz",
+      "integrity": "sha512-KgdgDGJt2TpuwBUIjgG6lzw2GWFRCW9Qkfkiv0DxqHHLYJHmtmdUIKcZd8rHgFSjopVTlw6ggzCm1b8MFQwikg==",
+      "dependencies": {
+        "tslib": "^2.0.3"
+      }
+    },
+    "node_modules/upper-case-first": {
+      "version": "2.0.2",
+      "resolved": "https://registry.npmjs.org/upper-case-first/-/upper-case-first-2.0.2.tgz",
+      "integrity": "sha512-514ppYHBaKwfJRK/pNC6c/OxfGa0obSnAl106u97Ed0I625Nin96KAjttZF6ZL3e1XLtphxnqrOi9iWgm+u+bg==",
+      "dependencies": {
+        "tslib": "^2.0.3"
+      }
+    },
     "node_modules/uri-js": {
       "version": "4.4.1",
       "resolved": "https://registry.npmjs.org/uri-js/-/uri-js-4.4.1.tgz",
@@ -22388,6 +22833,14 @@
         }
       }
     },
+    "node_modules/use-memo-one": {
+      "version": "1.1.3",
+      "resolved": "https://registry.npmjs.org/use-memo-one/-/use-memo-one-1.1.3.tgz",
+      "integrity": "sha512-g66/K7ZQGYrI6dy8GLpVcMsBp4s17xNkYJVSMvTEevGy3nDxHOfE6z8BVE22+5G5x7t3+bhzrlTDB7ObrEE0cQ==",
+      "peerDependencies": {
+        "react": "^16.8.0 || ^17.0.0 || ^18.0.0"
+      }
+    },
     "node_modules/use-resize-observer": {
       "version": "9.1.0",
       "resolved": "https://registry.npmjs.org/use-resize-observer/-/use-resize-observer-9.1.0.tgz",
@@ -22420,6 +22873,14 @@
         "@types/react": {
           "optional": true
         }
+      }
+    },
+    "node_modules/use-subscription": {
+      "version": "1.6.0",
+      "resolved": "https://registry.npmjs.org/use-subscription/-/use-subscription-1.6.0.tgz",
+      "integrity": "sha512-0Y/cTLlZfw547tJhJMoRA16OUbVqRm6DmvGpiGbmLST6BIA5KU5cKlvlz8DVMrACnWpyEjCkgmhLatthP4jUbA==",
+      "peerDependencies": {
+        "react": "^18.0.0"
       }
     },
     "node_modules/util": {

--- a/package.json
+++ b/package.json
@@ -43,6 +43,7 @@
     "accessible-autocomplete": "^2.0.4",
     "classnames": "^2.3.1",
     "framer-motion": "^3.9.1",
+    "i18n-calypso": "^7.0.0",
     "react-icons": "^4.7.0"
   },
   "peerDependencies": {

--- a/src/system/LinkExternal/LinkExternal.stories.tsx
+++ b/src/system/LinkExternal/LinkExternal.stories.tsx
@@ -1,0 +1,17 @@
+import LinkExternal from './LinkExternal';
+
+import type { StoryObj } from '@storybook/react';
+
+export default {
+	title: 'Navigation/LinkExternal',
+	component: LinkExternal,
+};
+
+type Story = StoryObj< typeof LinkExternal >;
+
+export const Default: Story = {
+	args: {
+		children: 'View on GitHub',
+		href: 'https://github.com/Automattic/vip-design-system',
+	},
+};

--- a/src/system/LinkExternal/LinkExternal.test.tsx
+++ b/src/system/LinkExternal/LinkExternal.test.tsx
@@ -1,0 +1,23 @@
+/**
+ * External dependencies
+ */
+import { render } from '@testing-library/react';
+import React from 'react';
+
+import '@testing-library/jest-dom';
+
+/**
+ * Internal dependencies
+ */
+import LinkExternal from './LinkExternal';
+
+describe( '<LinkExternal />', () => {
+	it( 'should render correctly', () => {
+		const { container } = render(
+			<LinkExternal href="https://google.com/">View on Github</LinkExternal>
+		);
+
+		// Make sure <ScreenReaderText> was loaded
+		expect( container.querySelector( '.screen-reader-text' ) ).toBeInTheDocument();
+	} );
+} );

--- a/src/system/LinkExternal/LinkExternal.test.tsx
+++ b/src/system/LinkExternal/LinkExternal.test.tsx
@@ -1,23 +1,47 @@
-/**
- * External dependencies
- */
-import { render } from '@testing-library/react';
-import React from 'react';
-
 import '@testing-library/jest-dom';
+import { render, screen } from '@testing-library/react';
 
 /**
  * Internal dependencies
  */
 import LinkExternal from './LinkExternal';
 
+const props = {
+	children: 'View on Github',
+	href: 'https://github.com/Automattic/vip-design-system',
+};
+
 describe( '<LinkExternal />', () => {
 	it( 'should render correctly', () => {
-		const { container } = render(
-			<LinkExternal href="https://google.com/">View on Github</LinkExternal>
-		);
+		render( <LinkExternal { ...props }>View on Github</LinkExternal> );
 
-		// Make sure <ScreenReaderText> was loaded
-		expect( container.querySelector( '.screen-reader-text' ) ).toBeInTheDocument();
+		const link = screen.getByRole( 'link' );
+
+		expect( link ).toHaveTextContent( /view on github/i );
+		expect( link ).toHaveTextContent( /external link/i );
+		expect( link ).toHaveAttribute( 'target', '_self' );
+		expect( link ).toHaveAttribute( 'rel', '' );
+	} );
+
+	it( 'should open in new tab when newTab is true', () => {
+		render( <LinkExternal { ...props } newTab /> );
+
+		const link = screen.getByRole( 'link' );
+
+		expect( link ).toHaveTextContent( /opens in a new tab/i );
+		expect( link ).toHaveAttribute( 'target', '_blank' );
+		expect( link ).toHaveAttribute( 'rel', 'noopener noreferrer' );
+	} );
+
+	it( 'should contain additional screenreader text when added', () => {
+		render( <LinkExternal { ...props } screenReaderText="VIP Design System" /> );
+
+		expect( screen.getByRole( 'link', { name: /vip design system/i } ) ).toBeInTheDocument();
+	} );
+
+	it( 'should hide icon when showExternalIcon is false', () => {
+		render( <LinkExternal { ...props } showExternalIcon={ false } /> );
+
+		expect( screen.queryByText( '↗' ) ).not.toBeInTheDocument();
 	} );
 } );

--- a/src/system/LinkExternal/LinkExternal.tsx
+++ b/src/system/LinkExternal/LinkExternal.tsx
@@ -1,13 +1,7 @@
 /**
- * External dependencies
- */
-
-import React from 'react';
-
-import { Link } from '../Link';
-/**
  * Internal dependencies
  */
+import { Link } from '../Link';
 import ScreenReaderText from '../ScreenReaderText';
 
 // Screen reader announcements
@@ -16,12 +10,11 @@ const NEW_TAB_TEXT = ', opens in a new tab'; // reads as: link, <link text>, ext
 
 type Props = {
 	children?: React.ReactNode;
-	screenReaderText?: string | number | ReactChild;
+	screenReaderText?: string | number;
 	href: string;
 	showExternalIcon?: boolean;
 	defaultScreenReaderText?: boolean;
 	newTab?: boolean;
-	[ rest: string ]: any;
 };
 
 export const LinkExternal: React.FC< Props > = ( {

--- a/src/system/LinkExternal/LinkExternal.tsx
+++ b/src/system/LinkExternal/LinkExternal.tsx
@@ -2,6 +2,7 @@
  * External dependencies
  */
 import { translate } from 'i18n-calypso';
+
 /**
  * Internal dependencies
  */

--- a/src/system/LinkExternal/LinkExternal.tsx
+++ b/src/system/LinkExternal/LinkExternal.tsx
@@ -1,12 +1,16 @@
 /**
+ * External dependencies
+ */
+import { translate } from 'i18n-calypso';
+/**
  * Internal dependencies
  */
 import { Link } from '../Link';
 import ScreenReaderText from '../ScreenReaderText';
 
 // Screen reader announcements
-const DEFAULT_EXTERNAL_LINK_TEXT = ', external link'; // reads as: link, <link text>, external link
-const NEW_TAB_TEXT = ', opens in a new tab'; // reads as: link, <link text>, external link, opens in a new tab
+const DEFAULT_EXTERNAL_LINK_TEXT = translate( ', external link' ); // reads as: link, <link text>, external link
+const NEW_TAB_TEXT = translate( ', opens in a new tab' ); // reads as: link, <link text>, external link, opens in a new tab
 
 type Props = {
 	children?: React.ReactNode;

--- a/src/system/LinkExternal/LinkExternal.tsx
+++ b/src/system/LinkExternal/LinkExternal.tsx
@@ -1,0 +1,52 @@
+/**
+ * External dependencies
+ */
+
+import React from 'react';
+
+import { Link } from '../Link';
+/**
+ * Internal dependencies
+ */
+import ScreenReaderText from '../ScreenReaderText';
+
+// Screen reader announcements
+const DEFAULT_EXTERNAL_LINK_TEXT = ', external link'; // reads as: link, <link text>, external link
+const NEW_TAB_TEXT = ', opens in a new tab'; // reads as: link, <link text>, external link, opens in a new tab
+
+type Props = {
+	children?: React.ReactNode;
+	screenReaderText?: string | number | ReactChild;
+	href: string;
+	showExternalIcon?: boolean;
+	defaultScreenReaderText?: boolean;
+	newTab?: boolean;
+	[ rest: string ]: any;
+};
+
+export const LinkExternal: React.FC< Props > = ( {
+	children = null,
+	screenReaderText = '',
+	href,
+	showExternalIcon = true,
+	newTab = false,
+	...rest
+} ) => (
+	<Link
+		as="a"
+		target={ newTab ? '_blank' : '_self' }
+		rel={ newTab ? 'noopener noreferrer' : '' }
+		href={ href }
+		{ ...rest }
+	>
+		{ children }
+		<ScreenReaderText>
+			{ screenReaderText }
+			{ DEFAULT_EXTERNAL_LINK_TEXT }
+			{ newTab ? NEW_TAB_TEXT : '' }
+		</ScreenReaderText>
+		{ showExternalIcon && <span aria-hidden="true">&nbsp;↗</span> }
+	</Link>
+);
+
+export default LinkExternal;

--- a/src/system/LinkExternal/index.ts
+++ b/src/system/LinkExternal/index.ts
@@ -1,4 +1,0 @@
-/**
- * Internal dependencies
- */
-export { LinkExternal } from './LinkExternal';

--- a/src/system/LinkExternal/index.ts
+++ b/src/system/LinkExternal/index.ts
@@ -1,0 +1,4 @@
+/**
+ * Internal dependencies
+ */
+export { LinkExternal } from './LinkExternal';

--- a/src/system/index.js
+++ b/src/system/index.js
@@ -36,7 +36,7 @@ import {
 import { Grid } from './Grid';
 import { Heading } from './Heading';
 import { Link } from './Link';
-import { LinkExternal } from './LinkExternal';
+import LinkExternal from './LinkExternal/LinkExternal';
 import { MobileMenuWrapper, MobileMenuTrigger, MobileMenu } from './MobileMenu/MobileMenu';
 import { Nav } from './Nav/Nav';
 import { NavItem } from './Nav/NavItem';

--- a/src/system/index.js
+++ b/src/system/index.js
@@ -36,6 +36,7 @@ import {
 import { Grid } from './Grid';
 import { Heading } from './Heading';
 import { Link } from './Link';
+import { LinkExternal } from './LinkExternal';
 import { MobileMenuWrapper, MobileMenuTrigger, MobileMenu } from './MobileMenu/MobileMenu';
 import { Nav } from './Nav/Nav';
 import { NavItem } from './Nav/NavItem';
@@ -95,6 +96,7 @@ export {
 	TableCell,
 	Tooltip,
 	Link,
+	LinkExternal,
 	Radio,
 	RadioBoxGroup,
 	Textarea,


### PR DESCRIPTION
## Summary

We're planning to migrate the footer from the dashboard (#373), which contains the  `LinkExternal` component. To make that migration easier, I figured I'd start here. 

## Details

In the first commit https://github.com/Automattic/vip-design-system/commit/0ecdce962fda7504bb8ed9e6c97394a48b26cd0a, it's 1:1 with the dashboard, just for ease of comparing the following changes in subsequent commits. But mostly, I've kept the component the same. I checked in with @djalmaaraujo to see if we wanted to use this as an opportunity to change anything about the component or if we want to keep it the same for a smoother migration. I initially thought we might want an `isExternal` prop on the existing `<Link/>` component, but I want to ensure I follow the standards set here. 🙂 

## Checklist

- [x] This PR has good automated test coverage
- [x] The storybook for the component has been updated

## Steps to Test

1. Pull down PR.
2. `npm run dev`.
3. Open Storybook.
4. Navigate to `LinkExternal` component
5. Verify component works the same as the dashboard component