### PR TITLE
Update MenuMobileInverse styling

### DIFF
--- a/src/system/MobileMenu/MobileMenu.stories.tsx
+++ b/src/system/MobileMenu/MobileMenu.stories.tsx
@@ -14,7 +14,7 @@ import {
 import { MdOutlinePhotoLibrary } from 'react-icons/md';
 
 import { MobileMenu, MobileMenuTrigger, MobileMenuWrapper } from './MobileMenu';
-import { Nav, NavItem } from '..';
+import { Flex, Nav, NavItem } from '..';
 import { CustomLink } from '../utils/stories/CustomLink';
 
 import type { StoryObj } from '@storybook/react';
@@ -73,91 +73,100 @@ export const MobileMenuExample = () => (
 				</>
 			}
 		>
-			<Nav.Menu sx={ { mb: 4 } } label="Nav Menu">
-				<NavItem.Menu
-					href="https://wordpress.com"
-					renderIcon={ size => <BiGridAlt size={ size } /> }
-					as={ CustomLink }
-				>
-					Overview
-				</NavItem.Menu>
-				<NavItem.Menu
-					as={ CustomLink }
-					href="https://random-website.com/"
-					renderIcon={ size => <BiWindows size={ size } /> }
-				>
-					Network Sites
-				</NavItem.Menu>
-				<NavItem.Menu
-					as={ CustomLink }
-					href="https://random-website.com/"
-					renderIcon={ size => <AiOutlineLock size={ size } /> }
-				>
-					Domains & TLS
-				</NavItem.Menu>
+			<Flex
+				sx={ {
+					gap: 3,
+					px: 5,
+					py: 0,
+					flexDirection: 'column',
+				} }
+			>
+				<Nav.Menu sx={ { mb: 4 } } label="Nav Menu">
+					<NavItem.Menu
+						href="https://wordpress.com"
+						renderIcon={ size => <BiGridAlt size={ size } /> }
+						as={ CustomLink }
+					>
+						Overview
+					</NavItem.Menu>
+					<NavItem.Menu
+						as={ CustomLink }
+						href="https://random-website.com/"
+						renderIcon={ size => <BiWindows size={ size } /> }
+					>
+						Network Sites
+					</NavItem.Menu>
+					<NavItem.Menu
+						as={ CustomLink }
+						href="https://random-website.com/"
+						renderIcon={ size => <AiOutlineLock size={ size } /> }
+					>
+						Domains & TLS
+					</NavItem.Menu>
 
-				<NavItem.MenuGroup active label="Logs" renderIcon={ size => <BiHistory size={ size } /> }>
-					<NavItem.Menu as={ CustomLink } href="https://google.com/">
-						Audit
-					</NavItem.Menu>
-					<NavItem.Menu active as={ CustomLink } href="https://wpvip.com/">
-						Runtime
-					</NavItem.Menu>
-					<NavItem.Menu as={ CustomLink } href="https://dashboard.wpvip.com/">
-						Slow Query
-					</NavItem.Menu>
-				</NavItem.MenuGroup>
+					<NavItem.MenuGroup active label="Logs" renderIcon={ size => <BiHistory size={ size } /> }>
+						<NavItem.Menu as={ CustomLink } href="https://google.com/">
+							Audit
+						</NavItem.Menu>
+						<NavItem.Menu active as={ CustomLink } href="https://wpvip.com/">
+							Runtime
+						</NavItem.Menu>
+						<NavItem.Menu as={ CustomLink } href="https://dashboard.wpvip.com/">
+							Slow Query
+						</NavItem.Menu>
+					</NavItem.MenuGroup>
 
-				<NavItem.MenuGroup
-					label="Performance"
-					renderIcon={ size => <BiTachometer size={ size } /> }
-				>
-					<NavItem.Menu as={ CustomLink } href="https://random-website.com/">
-						Metrics
+					<NavItem.MenuGroup
+						label="Performance"
+						renderIcon={ size => <BiTachometer size={ size } /> }
+					>
+						<NavItem.Menu as={ CustomLink } href="https://random-website.com/">
+							Metrics
+						</NavItem.Menu>
+						<NavItem.Menu as={ CustomLink } href="https://random-website.com/">
+							Monitor
+						</NavItem.Menu>
+						<NavItem.Menu as={ CustomLink } href="https://random-website.com/">
+							Cache
+						</NavItem.Menu>
+					</NavItem.MenuGroup>
+					<NavItem.Menu
+						as={ CustomLink }
+						href="https://random-website.com/"
+						renderIcon={ size => <BiCodeAlt size={ size } /> }
+					>
+						Code [v]
 					</NavItem.Menu>
-					<NavItem.Menu as={ CustomLink } href="https://random-website.com/">
-						Monitor
+					<NavItem.Menu
+						as={ CustomLink }
+						href="https://random-website.com/"
+						renderIcon={ size => <BiData size={ size } /> }
+					>
+						Database [v]
 					</NavItem.Menu>
-					<NavItem.Menu as={ CustomLink } href="https://random-website.com/">
-						Cache
+					<NavItem.Menu
+						as={ CustomLink }
+						href="https://random-website.com/"
+						renderIcon={ size => <MdOutlinePhotoLibrary size={ size } /> }
+					>
+						Media [v]
 					</NavItem.Menu>
-				</NavItem.MenuGroup>
-				<NavItem.Menu
-					as={ CustomLink }
-					href="https://random-website.com/"
-					renderIcon={ size => <BiCodeAlt size={ size } /> }
-				>
-					Code [v]
-				</NavItem.Menu>
-				<NavItem.Menu
-					as={ CustomLink }
-					href="https://random-website.com/"
-					renderIcon={ size => <BiData size={ size } /> }
-				>
-					Database [v]
-				</NavItem.Menu>
-				<NavItem.Menu
-					as={ CustomLink }
-					href="https://random-website.com/"
-					renderIcon={ size => <MdOutlinePhotoLibrary size={ size } /> }
-				>
-					Media [v]
-				</NavItem.Menu>
-				<NavItem.Menu
-					as={ CustomLink }
-					href="https://random-website.com/"
-					renderIcon={ size => <BiBell size={ size } /> }
-				>
-					Notifications
-				</NavItem.Menu>
-				<NavItem.Menu
-					as={ CustomLink }
-					href="https://random-website.com/"
-					renderIcon={ size => <BiBulb size={ size } /> }
-				>
-					Features
-				</NavItem.Menu>
-			</Nav.Menu>
+					<NavItem.Menu
+						as={ CustomLink }
+						href="https://random-website.com/"
+						renderIcon={ size => <BiBell size={ size } /> }
+					>
+						Notifications
+					</NavItem.Menu>
+					<NavItem.Menu
+						as={ CustomLink }
+						href="https://random-website.com/"
+						renderIcon={ size => <BiBulb size={ size } /> }
+					>
+						Features
+					</NavItem.Menu>
+				</Nav.Menu>
+			</Flex>
 		</MobileMenu>
 	</MobileMenuWrapper>
 );

--- a/src/system/MobileMenu/MobileMenu.tsx
+++ b/src/system/MobileMenu/MobileMenu.tsx
@@ -53,9 +53,9 @@ export const MobileMenu = forwardRef< HTMLDivElement, MobileMenuProps >(
 				>
 					<Flex sx={ { width: '100%', flexDirection: 'column' } }>
 						{ toolbarItems && (
-							<Nav.Primary label="Main Links" orientation="vertical">
+							<Nav.PrimaryInverse label="Main Links" orientation="vertical">
 								{ toolbarItems }
-							</Nav.Primary>
+							</Nav.PrimaryInverse>
 						) }
 
 						<Box

--- a/src/system/Nav/Nav.tsx
+++ b/src/system/Nav/Nav.tsx
@@ -6,7 +6,14 @@ import { Ref, forwardRef } from 'react';
 import { navMenuListStyles, navStyles } from './styles';
 
 export const VIP_NAV = 'vip-nav-component';
-export type NavVariant = 'primary' | 'tabs' | 'toolbar' | 'menu' | 'menu-inverse' | 'breadcrumbs';
+export type NavVariant =
+	| 'primary'
+	| 'tabs'
+	| 'toolbar'
+	| 'menu'
+	| 'menu-inverse'
+	| 'breadcrumbs'
+	| 'primary-inverse';
 
 export interface NavProps extends NavigationMenu.NavigationMenuProps {
 	className?: string;
@@ -43,6 +50,12 @@ const NavPrimary = forwardRef< HTMLElement, NavProps >(
 	)
 );
 
+const NavPrimaryInverse = forwardRef< HTMLElement, NavProps >(
+	( props: NavProps, ref: Ref< HTMLElement > ) => (
+		<NavBase { ...props } variant="primary-inverse" ref={ ref } />
+	)
+);
+
 const NavTab = forwardRef< HTMLElement, NavProps >(
 	( props: NavProps, ref: Ref< HTMLElement > ) => (
 		<NavBase { ...props } variant="tabs" ref={ ref } />
@@ -65,6 +78,7 @@ export type NavItemRenderIconProp = ( size: number ) => JSX.Element | null;
 
 export const Nav = {
 	Primary: NavPrimary,
+	PrimaryInverse: NavPrimaryInverse,
 	Tab: NavTab,
 	Toolbar: NavToolbar,
 	Menu: NavMenu,

--- a/src/system/Nav/styles.ts
+++ b/src/system/Nav/styles.ts
@@ -105,6 +105,17 @@ export const navStyles = (
 			}
 
 			break;
+		case 'primary-inverse':
+			{
+				navStyle = {
+					...defaultNavRootStyles,
+					px: 5,
+					pt: 2,
+					pb: 4,
+				};
+			}
+
+			break;
 		default: {
 			navStyle = defaultNavRootStyles;
 		}

--- a/src/system/Nav/styles/variants/menu.ts
+++ b/src/system/Nav/styles/variants/menu.ts
@@ -30,7 +30,7 @@ export const menuInverseItemStyles = (
 	...menuItemStyles( orientation ),
 	width: '100%',
 	mr: 0,
-	height: 45,
+	height: 38,
 	color: 'toolbar.text.default',
 } );
 


### PR DESCRIPTION
## Description

A few styling updates for the MobileMenu

| Before | After |
|--------|--------|
| <img width="353" alt="image" src="https://github.com/Automattic/vip-design-system/assets/3402/8d0270db-261d-4a70-834e-2e7dad47fd5f"> | <img width="354" alt="image" src="https://github.com/Automattic/vip-design-system/assets/3402/a3110a32-2ee1-4645-b769-0d0dbcd06f13"> |

## Checklist

- [ ] This PR has good automated test coverage
- [x] The storybook for the component has been updated

## Steps to Test

1. Pull down PR.
2. `npm run dev`.
3. Open http://localhost:6006/?path=/story/navigation-mobilemenu--mobile-menu-example
4. Items are aligned according to the screenshots above
