### PR TITLE
Restore vendor prefixed font smoothing properties

### DIFF
--- a/src/system/theme/index.js
+++ b/src/system/theme/index.js
@@ -532,7 +532,8 @@ export default {
 			fontWeight: 'body',
 			color: 'text',
 			backgroundColor: 'backgrounds.primary',
-			fontSmoothing: 'antialiased',
+			'-webkit-font-smoothing': 'antialiased',
+			'-moz-osx-font-smoothing': 'grayscale',
 			a: {
 				'&:hover': {
 					textDecorationLine: 'underline',


### PR DESCRIPTION
## Description

In https://github.com/Automattic/vip-design-system/pull/371/files we switched to using an unprefixed `font-smoothing` property. AFAIK this property still requires the vendor prefixes. 

## Checklist

- [ ] This PR has good automated test coverage
- [ ] The storybook for the component has been updated

## Steps to Test

1. Pull down PR.
1. `npm run dev`.
1. Open http://localhost:6006/?path=/docs/text--docs
1. Verify the computed styles for any element includes the `-webkit-font-smoothing: antialiased` (or `-moz-osx-font-smoothing: 'grayscale'` if using Firefox).
