### PR TITLE
Adjust focus style for buttons

### DIFF
--- a/src/system/Button/Button.tsx
+++ b/src/system/Button/Button.tsx
@@ -54,6 +54,9 @@ const Button = forwardRef< HTMLButtonElement, ButtonProps >(
 						cursor: 'not-allowed',
 						pointerEvents: 'none',
 					},
+					'&:hover, &:focus': {
+						textDecoration: 'none',
+					},
 					flexGrow: Boolean( grow ) === true ? '1' : undefined,
 					width: Boolean( full ) === true ? '100%' : undefined,
 					...sx,

--- a/src/system/theme/index.js
+++ b/src/system/theme/index.js
@@ -283,9 +283,10 @@ export default {
 			fontWeight: 'medium',
 			boxShadow: 'none',
 			borderRadius: 1,
-			'&:hover, &:focus': {
+			'&:hover': {
 				backgroundColor: 'button.primary.background.hover',
 				color: 'button.primary.label.hover',
+				textDecoration: 'none',
 			},
 			verticalAlign: 'middle',
 			alignItems: 'center',
@@ -297,9 +298,6 @@ export default {
 					fill: 'inherit',
 				},
 			},
-			'&:hover': {
-				textDecoration: 'none',
-			},
 		},
 
 		secondary: {
@@ -307,7 +305,7 @@ export default {
 			color: 'button.secondary.label.default',
 			bg: 'button.secondary.background.default',
 
-			'&:hover, &:focus': {
+			'&:hover': {
 				backgroundColor: 'button.secondary.background.hover',
 				color: 'button.secondary.label.hover',
 			},
@@ -320,7 +318,7 @@ export default {
 			border: '1px solid',
 			borderColor: 'button.tertiary.border.default',
 
-			'&:hover, &:focus': {
+			'&:hover': {
 				backgroundColor: 'button.tertiary.background.hover',
 				color: 'button.tertiary.label.hover',
 				border: '1px solid',
@@ -335,7 +333,7 @@ export default {
 			border: '1px solid',
 			borderColor: 'transparent',
 
-			'&:hover, &:focus': {
+			'&:hover': {
 				backgroundColor: 'button.display.background.hover',
 				color: 'button.display.label.hover',
 				border: '1px solid',
@@ -350,7 +348,7 @@ export default {
 			border: '1px solid',
 			borderColor: 'transparent',
 
-			'&:hover, &:focus': {
+			'&:hover': {
 				backgroundColor: 'button.ghost.background.hover',
 				color: 'button.ghost.label.hover',
 				border: '1px solid',
@@ -365,7 +363,7 @@ export default {
 			border: '1px solid',
 			borderColor: 'transparent',
 
-			'&:hover, &:focus': {
+			'&:hover': {
 				backgroundColor: 'button.danger.primary.background.hover',
 				color: 'button.danger.primary.label.hover',
 				border: '1px solid',
@@ -396,7 +394,7 @@ export default {
 			color: 'text',
 			padding: 1,
 
-			'&:hover, &:focus': {
+			'&:hover': {
 				backgroundColor: 'borders.2',
 			},
 		},

--- a/src/system/theme/index.js
+++ b/src/system/theme/index.js
@@ -407,7 +407,9 @@ export default {
 				color: 'links.visited',
 			},
 			'&:hover': {
-				color: 'hover',
+				color: 'links.hover',
+				textDecorationLine: 'underline',
+				textDecorationThickness: '0.125rem',
 			},
 			'&:active': {
 				color: 'links.active',
@@ -415,12 +417,6 @@ export default {
 
 			textDecorationThickness: '0.125rem',
 			textUnderlineOffset: '0.250rem',
-
-			'&:hover, &:focus': {
-				color: 'links.hover',
-				textDecorationLine: 'underline',
-				textDecorationThickness: '0.125rem',
-			},
 		},
 		'button-primary': {
 			variant: 'buttons.primary',


### PR DESCRIPTION
## Description

Remove the focus state from buttons (not the outline). This was requested by @donaghokeeffe when QAing the Responsiveness work.

## Checklist

- [ ] This PR has good automated test coverage
- [ ] The storybook for the component has been updated

## Steps to Test

1. Pull down PR.
2. `npm run dev`.
3. Open http://localhost:6006/?path=/docs/button--docs
4. Check on button focus
5. Open MobileMenu example http://localhost:6006/?path=/story/navigation-mobilemenu--mobile-menu-example
6. Open and close, focus should stay as the active state + outline border
