### PR TITLE
Breadcrumbs and link style update

### DIFF
--- a/src/system/Breadcrumbs/Breadcrumbs.stories.tsx
+++ b/src/system/Breadcrumbs/Breadcrumbs.stories.tsx
@@ -1,11 +1,12 @@
+/** @jsxImportSource theme-ui */
+
 import React from 'react';
 
 import { Breadcrumbs as Breadcrumbs } from './Breadcrumbs';
+import { Box } from '../Box';
+import { CustomLink, CustomLinkComponentized } from '../utils/stories/CustomLink';
 
 import type { StoryObj } from '@storybook/react';
-
-// eslint-disable-next-line jsx-a11y/anchor-has-content
-const CustomLink = props => <a { ...props } />;
 
 export default {
 	title: 'Navigation/Breadcrumbs',
@@ -76,5 +77,33 @@ export const Default: Story = {
 				{ href: 'https://google.com/', label: 'Not accessible' },
 			] }
 		/>
+	),
+};
+
+export const Collapsible: Story = {
+	render: () => (
+		<Box sx={ { display: 'flex', flexDirection: 'column', gap: 4 } }>
+			<p>
+				When entering Mobile views, the first and the last link will appear. A button with a … will
+				also be visible. Once pressed, the rest of the links become available, and the focus is
+				moved to the next link.
+			</p>
+
+			<hr sx={ { width: '100%', my: 4 } } />
+
+			<Breadcrumbs
+				wrapMode="collapsible"
+				LinkComponent={ CustomLinkComponentized }
+				label="Nav Breadcrumbs"
+				links={ [
+					{ href: '/', label: 'Home' },
+					{ href: 'https://datadog.com/', label: 'Data dog' },
+					{ href: 'https://newrelic.com/', label: 'New Relic' },
+					{ href: 'https://rollbar.com/', label: 'Rollbar' },
+					{ href: 'https://areallylong.com/', label: 'A really long name' },
+					{ href: 'https://google.com/', label: 'I am the last item' },
+				] }
+			/>
+		</Box>
 	),
 };

--- a/src/system/Breadcrumbs/Breadcrumbs.test.tsx
+++ b/src/system/Breadcrumbs/Breadcrumbs.test.tsx
@@ -2,11 +2,16 @@
 /* eslint-disable @typescript-eslint/ban-ts-comment */
 // @ts-nocheck
 import { render, screen } from '@testing-library/react';
+import userEvent from '@testing-library/user-event';
+import * as matchMedia from '@theme-ui/match-media';
 import { axe } from 'jest-axe';
 import { ThemeUIProvider } from 'theme-ui';
 
 import { Breadcrumbs } from './Breadcrumbs';
 import { theme } from '../';
+
+jest.mock( '@theme-ui/match-media' );
+const mockBreakpointIndex = matchMedia.useBreakpointIndex;
 
 // eslint-disable-next-line jsx-a11y/anchor-has-content
 const CustomLink = props => <a { ...props } />;
@@ -39,6 +44,7 @@ describe( '<Breadcrumbs />', () => {
 			} ),
 		} );
 	} );
+
 	it( 'renders the Breadcrumbs component', async () => {
 		const { container } = renderComponent();
 
@@ -52,5 +58,59 @@ describe( '<Breadcrumbs />', () => {
 
 		// Check for accessibility issues
 		expect( await axe( container ) ).toHaveNoViolations();
+	} );
+
+	describe( 'wrapMode tests', () => {
+		beforeEach( () => {
+			mockBreakpointIndex.mockReset();
+		} );
+
+		it( 'expands the breadcrumb items when clicking in the collapsible link', async () => {
+			mockBreakpointIndex.mockReturnValue( 0 );
+
+			const links = [
+				{ label: 'Home', href: '/' },
+				{ label: 'Applications', href: '/apps' },
+				{ label: 'Applications 3', href: '/apps/3' },
+				{ label: 'Applications 4', href: '/apps/4' },
+				{ label: 'The last' },
+			];
+
+			const user = userEvent.setup();
+
+			const { container } = renderWithTheme(
+				<Breadcrumbs
+					wrapMode="collapsible"
+					label="Main Collapsible Breadcrumb"
+					LinkComponent={ CustomLink }
+					links={ links }
+				/>
+			);
+
+			// Should find the nav label
+			const navEl = screen.getByLabelText( 'Main Collapsible Breadcrumb' );
+
+			expect( navEl ).toBeInTheDocument();
+
+			// Contract should have
+			expect( navEl.querySelectorAll( 'li' ) ).toHaveLength( 3 );
+
+			const pressToShowButton = screen.getByRole( 'button', {
+				name: 'Press to show more breadcrumbs',
+			} );
+
+			// Should find all links
+			expect( screen.getByText( 'Home' ) ).toBeInTheDocument();
+			expect( pressToShowButton ).toBeInTheDocument();
+			expect( screen.getByText( 'The last' ) ).toHaveAttribute( 'aria-current', 'page' );
+
+			// Click to expand the breadcrumbs
+			await user.click( pressToShowButton );
+
+			expect( navEl.querySelectorAll( 'li' ) ).toHaveLength( 5 );
+
+			// Check for accessibility issues
+			expect( await axe( container ) ).toHaveNoViolations();
+		} );
 	} );
 } );

--- a/src/system/Breadcrumbs/Breadcrumbs.tsx
+++ b/src/system/Breadcrumbs/Breadcrumbs.tsx
@@ -67,7 +67,7 @@ const breadcrumbLinks = (
 				  ]
 				: otherLinksRaw;
 		} else if ( wrapMode === 'collapsible' ) {
-			separatorLink = isSmallestScreen && ! showAllItems;
+			separatorLink = isSmallestScreen && ! showAllItems && totalLinks > 2;
 			otherLinks = isSmallestScreen && ! showAllItems ? [ links?.[ 0 ] ] : otherLinksRaw;
 		}
 	}

--- a/src/system/Breadcrumbs/styles.ts
+++ b/src/system/Breadcrumbs/styles.ts
@@ -1,3 +1,8 @@
+import { ThemeUIStyleObject } from 'theme-ui';
+
+import { linkUnderlineProperties } from '../Link/Link';
+import { breadcrumbsLinkStyles } from '../Nav/styles/variants/breadcrumbs';
+
 export const smallestScreenItemStyles = {
 	'&::before': {
 		display: 'inline-block',
@@ -9,4 +14,10 @@ export const smallestScreenItemStyles = {
 		height: '0.8em',
 		content: "'←'",
 	},
+};
+
+export const collapsibleSeparatorStyles: ThemeUIStyleObject = {
+	all: 'unset',
+	...breadcrumbsLinkStyles,
+	...linkUnderlineProperties,
 };

--- a/src/system/Link/Link.stories.tsx
+++ b/src/system/Link/Link.stories.tsx
@@ -1,7 +1,7 @@
 /**
  * External dependencies
  */
-import { Link } from '..';
+import { Link, LinkVariant } from './Link';
 import { Flex } from '../Flex/Flex';
 
 import type { LinkProps } from './Link';
@@ -14,6 +14,47 @@ import type { StoryObj } from '@storybook/react';
 export default {
 	title: 'Navigation/Link',
 	component: Link,
+	argTypes: {
+		variant: {
+			type: 'select',
+			options: Object.values( LinkVariant ),
+		},
+	},
+	parameters: {
+		docs: {
+			description: {
+				component: `
+
+Links are navigational elements that direct visitors to other locations, either on the same page or to a different page or site. They can be inline or separate from the text flow. Since every link is a potential user interaction, too many links can be overwhelming.
+
+## Guidance
+
+### When to use the link component
+
+- When you want to direct users to another page or site.
+- When you want to direct users to another section of the same page (anchors).
+
+### When to consider something else
+
+- When you want to trigger an action (use a button instead).
+- When you want to display a message (use a notification instead).
+
+### Accessibility
+
+- Don’t rely on only color to distinguish links
+- Don’t block external links with disruptive notifications
+- Icons can be helpful. Consider adding an icon to signal specific actions (Download, Open in a new window, etc).
+- Don’t use the same link text for different URLs on the same page. This can confuse users and make it difficult for them to understand where the link will take them.
+
+-------
+
+This documentation is heavily inspired by the [U.S Web Design System (USWDS)](https://designsystem.digital.gov/components/link/). We use USWDS as trusted source of truth for accessibility and usability best practices.
+
+## Component Properties
+`,
+			},
+		},
+	},
 };
 
 type Story = StoryObj< typeof Link >;

--- a/src/system/Link/Link.tsx
+++ b/src/system/Link/Link.tsx
@@ -25,6 +25,12 @@ export interface LinkProps extends ThemeLinkProps {
 		| 'button-danger';
 }
 
+export const linkUnderlineProperties: ThemeUIStyleObject = {
+	textDecorationLine: 'underline',
+	textDecorationThickness: '0.1rem',
+	textUnderlineOffset: '0.250rem',
+};
+
 export const defaultLinkComponentStyle: ThemeUIStyleObject = {
 	'&:focus-visible': ( theme: LinkTheme ) => theme.outline,
 };

--- a/src/system/Link/Link.tsx
+++ b/src/system/Link/Link.tsx
@@ -14,20 +14,23 @@ interface LinkTheme extends Theme {
 	outline?: Record< string, string >;
 }
 
+export enum LinkVariant {
+	'primary',
+	'button-primary',
+	'button-secondary',
+	'button-tertiary',
+	'button-ghost',
+	'button-display',
+	'button-danger',
+}
+
 export interface LinkProps extends ThemeLinkProps {
-	variant?:
-		| 'primary'
-		| 'button-primary'
-		| 'button-secondary'
-		| 'button-tertiary'
-		| 'button-ghost'
-		| 'button-display'
-		| 'button-danger';
+	variant?: keyof typeof LinkVariant;
 }
 
 export const linkUnderlineProperties: ThemeUIStyleObject = {
 	textDecorationLine: 'underline',
-	textDecorationThickness: '0.1rem',
+	textDecorationThickness: '0.07rem',
 	textUnderlineOffset: '0.250rem',
 };
 

--- a/src/system/Nav/styles.ts
+++ b/src/system/Nav/styles.ts
@@ -141,5 +141,6 @@ export const navMenuListStyles = ( orientation: NavProps[ 'orientation' ] ): The
 		gap: 1,
 		px: 0,
 		flexDirection: orientation === 'horizontal' ? 'row' : 'column',
+		flexWrap: orientation === 'horizontal' ? 'wrap' : undefined,
 	};
 };

--- a/src/system/theme/index.js
+++ b/src/system/theme/index.js
@@ -403,20 +403,19 @@ export default {
 
 	links: {
 		primary: {
+			...linkUnderlineProperties,
+
 			color: 'link',
 			'&:visited': {
 				color: 'links.visited',
 			},
 			'&:hover': {
 				color: 'links.hover',
-				textDecorationLine: 'underline',
-				...linkUnderlineProperties,
+				textDecorationThickness: '0.15rem',
 			},
 			'&:active': {
 				color: 'links.active',
 			},
-
-			...linkUnderlineProperties,
 		},
 		'button-primary': {
 			variant: 'buttons.primary',

--- a/src/system/theme/index.js
+++ b/src/system/theme/index.js
@@ -1,12 +1,12 @@
 /**
  * Internal dependencies
  */
-import { linkUnderlineProperties } from '../Link/Link';
 import { generateBreakpoints } from './breakpoints';
 import ColorBuilder from './colors';
 import ValetDark from './generated/valet-theme-dark.json';
 import Valet from './generated/valet-theme-light.json';
 import ThemeBuilder from './getPropValue';
+import { linkUnderlineProperties } from '../Link/Link';
 
 // Light
 const { getPropValue, getVariants, ValetTheme, getHeadingStyles } = ThemeBuilder( Valet );

--- a/src/system/theme/index.js
+++ b/src/system/theme/index.js
@@ -1,6 +1,7 @@
 /**
  * Internal dependencies
  */
+import { linkUnderlineProperties } from '../Link/Link';
 import { generateBreakpoints } from './breakpoints';
 import ColorBuilder from './colors';
 import ValetDark from './generated/valet-theme-dark.json';
@@ -409,14 +410,13 @@ export default {
 			'&:hover': {
 				color: 'links.hover',
 				textDecorationLine: 'underline',
-				textDecorationThickness: '0.125rem',
+				...linkUnderlineProperties,
 			},
 			'&:active': {
 				color: 'links.active',
 			},
 
-			textDecorationThickness: '0.125rem',
-			textUnderlineOffset: '0.250rem',
+			...linkUnderlineProperties,
 		},
 		'button-primary': {
 			variant: 'buttons.primary',
@@ -531,7 +531,7 @@ export default {
 			a: {
 				'&:hover': {
 					textDecorationLine: 'underline',
-					textDecorationThickness: '0.125rem',
+					textDecorationThickness: '0.1rem',
 					textUnderlineOffset: '0.250rem',
 				},
 			},

--- a/src/system/utils/stories/CustomLink.tsx
+++ b/src/system/utils/stories/CustomLink.tsx
@@ -1,6 +1,12 @@
 import React, { Ref, forwardRef } from 'react';
 
+import { Link } from '../../Link/Link';
+
 export const CustomLink = forwardRef< HTMLAnchorElement >(
 	// eslint-disable-next-line jsx-a11y/anchor-has-content
 	( props, ref: Ref< HTMLAnchorElement > ) => <a { ...props } ref={ ref } />
+);
+
+export const CustomLinkComponentized = forwardRef< HTMLAnchorElement >(
+	( props, ref: Ref< HTMLAnchorElement > ) => <Link { ...props } ref={ ref } />
 );


### PR DESCRIPTION
## Description

- Updating Breadcrumbs with a new variant (collapsible). You can define by using `wrapMode` property.
- Updating link styles

## Checklist

- [x] This PR has good automated test coverage
- [x] The storybook for the component has been updated

## Steps to Test — Breadcrumbs

**USING THE KEYBOARD**

1. Pull down PR.
2. `npm run dev`.
3. Open http://localhost:6006/?path=/story/navigation-breadcrumbs--collapsible
4. Reduce screen size to make the breadcrumb wraps
4. Verify the three dots button is available. Press the button, the focus should be on the following link

## Steps to Test — Link
1. Pull down PR.
2. `npm run dev`.
3. Open http://localhost:6006/?path=/story/navigation-link
4. Notice that the underline is smaller
5. The hover underline is stronger
