### PR TITLE
Fix wizard component style

### DIFF
--- a/src/system/Box/Box.tsx
+++ b/src/system/Box/Box.tsx
@@ -8,9 +8,9 @@ import { Box as ThemeBox, BoxProps as ThemeBoxProps } from 'theme-ui';
 export const Box = forwardRef< HTMLElement, ThemeBoxProps >(
 	( props: ThemeBoxProps, ref: Ref< HTMLElement > ) => (
 		<ThemeBox
-			{ ...props }
 			className={ classNames( 'vip-box-component', props.className ) }
 			ref={ ref }
+			{ ...props }
 		/>
 	)
 );

--- a/src/system/Card/Card.tsx
+++ b/src/system/Card/Card.tsx
@@ -3,7 +3,6 @@
 /**
  * External dependencies
  */
-import classNames, { Argument } from 'classnames';
 import { forwardRef, Ref } from 'react';
 import { BoxProps } from 'theme-ui';
 

--- a/src/system/Card/Card.tsx
+++ b/src/system/Card/Card.tsx
@@ -21,8 +21,6 @@ export enum CardVariant {
 
 export interface CardProps {
 	variant?: keyof typeof CardVariant;
-	sx?: BoxProps[ 'sx' ];
-	className?: Argument;
 	title?: string;
 	children?: React.ReactNode;
 	renderHeader?: ( title?: string ) => React.ReactNode;
@@ -32,7 +30,7 @@ type CardBoxProps = CardProps & BoxProps;
 
 export const Card = forwardRef< HTMLElement, CardBoxProps >(
 	(
-		{ variant = 'primary', title, renderHeader, sx = {}, className, children, ...props }: CardProps,
+		{ variant = 'primary', title, renderHeader, children, ...rest }: CardProps,
 		ref: Ref< HTMLElement >
 	) => {
 		return (
@@ -41,13 +39,13 @@ export const Card = forwardRef< HTMLElement, CardBoxProps >(
 				sx={ {
 					variant: `cards.${ variant }`,
 				} }
-				className={ classNames( 'vip-card-component', className ) }
-				{ ...props }
+				className="vip-card-component"
+				{ ...rest }
 			>
 				{ renderHeader ? renderHeader( title ) : '' }
 				{ title && ! renderHeader && (
 					<Box
-						className={ classNames( 'vip-card-header-component', className ) }
+						className="vip-card-header-component"
 						sx={ {
 							variant: `cards.${ variant }.header`,
 						} }
@@ -57,10 +55,9 @@ export const Card = forwardRef< HTMLElement, CardBoxProps >(
 				) }
 
 				<Box
-					className={ classNames( 'vip-card-body-component', className ) }
+					className="vip-card-body-component"
 					sx={ {
 						variant: `cards.${ variant }.children`,
-						...sx,
 					} }
 				>
 					{ children }

--- a/src/system/Wizard/WizardStep.tsx
+++ b/src/system/Wizard/WizardStep.tsx
@@ -101,6 +101,7 @@ export const WizardStep = React.forwardRef< HTMLDivElement, WizardStepProps >(
 				} }
 				data-step={ order }
 				data-active={ active || undefined }
+				className={ `wizard-step-${ status }` }
 				ref={ forwardRef }
 			>
 				<Flex sx={ { alignItems: 'flex-end', mb: 2 } }>


### PR DESCRIPTION
## Description

![image](https://github.com/Automattic/vip-design-system/assets/3402/bb575516-86ba-4a9f-8595-619303ebd0be)

Wizard was getting double styles caused by a bug in the classNames package.

## Checklist

- [ ] This PR has good automated test coverage
- [x] The storybook for the component has been updated

## Steps to Test

1. Pull down PR.
2. `npm run dev`.
3. Open http://localhost:6006/?path=/story/navigation-wizard--default
4. Verify Wizard styles are correct, similar to the left screenshot above
