### PR TITLE
Reduce common card padding

### DIFF
--- a/src/system/Card/Card.stories.tsx
+++ b/src/system/Card/Card.stories.tsx
@@ -37,3 +37,8 @@ export const WithHeaderSecondary = () => (
 );
 
 export const DefaultIndent = () => <Card variant="indent">Hello</Card>;
+export const StyledBody = () => (
+	<Card variant="indent" title="Hello world" bodyStyles={ { p: 6, backgroundColor: 'layer.2' } }>
+		Hello styled body.
+	</Card>
+);

--- a/src/system/Card/Card.tsx
+++ b/src/system/Card/Card.tsx
@@ -4,7 +4,7 @@
  * External dependencies
  */
 import { forwardRef, Ref } from 'react';
-import { BoxProps, Theme, ThemeUIStyleObject } from 'theme-ui';
+import { BoxProps, ThemeUIStyleObject } from 'theme-ui';
 
 /**
  * Internal dependencies

--- a/src/system/Card/Card.tsx
+++ b/src/system/Card/Card.tsx
@@ -4,7 +4,7 @@
  * External dependencies
  */
 import { forwardRef, Ref } from 'react';
-import { BoxProps } from 'theme-ui';
+import { BoxProps, Theme, ThemeUIStyleObject } from 'theme-ui';
 
 /**
  * Internal dependencies
@@ -23,13 +23,23 @@ export interface CardProps {
 	title?: string;
 	children?: React.ReactNode;
 	renderHeader?: ( title?: string ) => React.ReactNode;
+	bodyStyles?: ThemeUIStyleObject;
+	headerStyles?: ThemeUIStyleObject;
 }
 
 type CardBoxProps = CardProps & BoxProps;
 
 export const Card = forwardRef< HTMLElement, CardBoxProps >(
 	(
-		{ variant = 'primary', title, renderHeader, children, ...rest }: CardProps,
+		{
+			variant = 'primary',
+			title,
+			renderHeader,
+			bodyStyles,
+			headerStyles,
+			children,
+			...rest
+		}: CardProps,
 		ref: Ref< HTMLElement >
 	) => {
 		return (
@@ -47,6 +57,7 @@ export const Card = forwardRef< HTMLElement, CardBoxProps >(
 						className="vip-card-header-component"
 						sx={ {
 							variant: `cards.${ variant }.header`,
+							...headerStyles,
 						} }
 					>
 						{ title }
@@ -57,6 +68,7 @@ export const Card = forwardRef< HTMLElement, CardBoxProps >(
 					className="vip-card-body-component"
 					sx={ {
 						variant: `cards.${ variant }.children`,
+						...bodyStyles,
 					} }
 				>
 					{ children }

--- a/src/system/theme/index.js
+++ b/src/system/theme/index.js
@@ -258,7 +258,7 @@ export default {
 				borderTopLeftRadius: 2,
 				borderTopRightRadius: 2,
 				py: 3,
-				px: 5,
+				px: 4,
 				gap: 2,
 				fontWeight: 'bold',
 				display: 'flex',

--- a/src/system/theme/index.js
+++ b/src/system/theme/index.js
@@ -265,8 +265,8 @@ export default {
 				minHeight: 46,
 			},
 			children: {
-				padding: 5,
-				gap: 6,
+				padding: 4,
+				gap: 3,
 			},
 		},
 		secondary: {


### PR DESCRIPTION
## Description

Reduce Card default padding to 

## Checklist

- [ ] This PR has good automated test coverage
- [x] The storybook for the component has been updated

## Steps to Test

1. Pull down PR.
2. `npm run dev`.
3. Open http://localhost:6006/?path=/story/card--styled-body
4. Verify that the body of the card is white, a custom-style
5. Default padding is now 16px