### PR TITLE
ScreenReaderText: export component

### DIFF
--- a/src/system/index.js
+++ b/src/system/index.js
@@ -48,6 +48,7 @@ import * as Form from './NewForm';
 import { Notice } from './Notice';
 import { OptionRow } from './OptionRow';
 import { Progress } from './Progress';
+import { ScreenReaderText } from './ScreenReaderText';
 import { Spinner } from './Spinner';
 import { Table, TableRow, TableCell } from './Table';
 import { Tabs, TabsList, TabsContent, TabsTrigger } from './Tabs';
@@ -94,6 +95,7 @@ export {
 	Hr,
 	Input,
 	Label,
+	ScreenReaderText,
 	Spinner,
 	Table,
 	TableRow,


### PR DESCRIPTION
## Description

Is there a reason why we don't have the `ScreenReaderText` component exported? It would be useful to have for other projects 😄 

If we are okay to export it, I can add a story if we think it would be useful to have. 

## Checklist

- [ ] This PR has good automated test coverage
- [ ] The storybook for the component has been updated


