### PR TITLE
Extract the chip variant of radio-box-group to a different component

### DIFF
--- a/src/system/Form/RadioBoxGroup.js
+++ b/src/system/Form/RadioBoxGroup.js
@@ -95,103 +95,6 @@ const RadioOption = ( {
 	);
 };
 
-const ChipOption = ( {
-	defaultValue,
-	option: { id, value, label },
-	name,
-	disabled,
-	onChangeHandler,
-} ) => {
-	const checked = `${ defaultValue }` === `${ value }`;
-	const forLabel = id || value;
-	const ref = React.useRef( null );
-	const describedById = `input-radio-box-${ forLabel }-description`;
-
-	return (
-		<div
-			id={ `o${ forLabel }` }
-			onClick={ () => {
-				ref.current?.click();
-			} }
-			sx={ {
-				display: 'inline-flex',
-				position: 'relative',
-				background: checked ? 'layer.4' : undefined,
-				color: 'text',
-				minHeight: '32px',
-				boxShadow: checked ? 'low' : undefined,
-				'&:hover': {
-					background: checked ? 'layer.4' : 'layer.1',
-				},
-				borderRadius: 1,
-			} }
-		>
-			<input
-				ref={ ref }
-				type="radio"
-				id={ forLabel }
-				disabled={ disabled }
-				name={ name }
-				checked={ checked }
-				aria-checked={ checked }
-				value={ value }
-				onChange={ onChangeHandler }
-				aria-labelledby={ describedById }
-				sx={ {
-					opacity: 0,
-					height: 0,
-					width: 0,
-					position: 'absolute',
-					'&:focus-visible + label': theme => theme.outline,
-				} }
-			/>
-
-			<label
-				id={ describedById }
-				htmlFor={ forLabel }
-				sx={ {
-					height: '100%',
-					display: 'flex',
-					flexDirection: 'column',
-					justifyContent: 'center',
-					width: '100%',
-					px: 3,
-					fontWeight: 400,
-					fontSize: 2,
-					cursor: 'pointer',
-					borderRadius: 1,
-				} }
-			>
-				{ label }
-			</label>
-		</div>
-	);
-};
-
-ChipOption.propTypes = RadioOption.propTypes = {
-	defaultValue: PropTypes.string,
-	option: PropTypes.object,
-	name: PropTypes.string,
-	onChangeHandler: PropTypes.func,
-	disabled: PropTypes.bool,
-	width: PropTypes.string,
-};
-
-const groupStyleOverrides = {
-	chip: {
-		background: 'layer.3',
-		p: 1,
-		display: 'inline-flex',
-		gap: 1,
-		borderRadius: 1,
-	},
-	primary: {
-		display: 'inline-block',
-		mb: 2,
-		p: 0,
-	},
-};
-
 const RadioBoxGroup = React.forwardRef(
 	(
 		{
@@ -205,7 +108,6 @@ const RadioBoxGroup = React.forwardRef(
 			errorMessage,
 			hasError,
 			required,
-			variant = 'primary',
 			...props
 		},
 		forwardRef
@@ -220,13 +122,8 @@ const RadioBoxGroup = React.forwardRef(
 			[ onChange ]
 		);
 
-		let Option = RadioOption;
-		if ( variant === 'chip' ) {
-			Option = ChipOption;
-		}
-
 		const renderedOptions = options.map( option => (
-			<Option
+			<RadioOption
 				defaultValue={ defaultValue }
 				disabled={ disabled }
 				key={ option?.id || option?.value }
@@ -242,7 +139,9 @@ const RadioBoxGroup = React.forwardRef(
 				<fieldset
 					sx={ {
 						border: 0,
-						...groupStyleOverrides[ variant ],
+						display: 'inline-block',
+						mb: 2,
+						p: 0,
 						...( hasError
 							? { border: '1px solid', borderColor: 'input.border.error', borderRadius: 2, p: 2 }
 							: {} ),
@@ -264,7 +163,7 @@ const RadioBoxGroup = React.forwardRef(
 						sx={ {
 							display: 'flex',
 							flexWrap: 'wrap',
-							gap: variant === 'chip' ? 1 : 2,
+							gap: 2,
 						} }
 					>
 						{ renderedOptions }
@@ -295,7 +194,6 @@ RadioBoxGroup.propTypes = {
 	errorMessage: PropTypes.string,
 	hasError: PropTypes.bool,
 	required: PropTypes.bool,
-	variant: PropTypes.oneOf( [ 'primary', 'chip' ] ),
 };
 
 export { RadioBoxGroup };

--- a/src/system/Form/RadioBoxGroup.stories.jsx
+++ b/src/system/Form/RadioBoxGroup.stories.jsx
@@ -83,29 +83,3 @@ export const Errors = () => {
 		/>
 	);
 };
-
-export const ChipVariant = () => {
-	const [ value, setValue ] = useState( 'table' );
-
-	return (
-		<RadioBoxGroup
-			defaultValue={ value }
-			onChange={ e => setValue( e.target.value ) }
-			options={ [
-				{
-					label: 'Table',
-					value: 'table',
-				},
-				{
-					label: 'Grid',
-					value: 'grid',
-				},
-				{
-					label: 'Card',
-					value: 'card',
-				},
-			] }
-			variant="chip"
-		/>
-	);
-};

--- a/src/system/Form/RadioBoxGroup.test.jsx
+++ b/src/system/Form/RadioBoxGroup.test.jsx
@@ -31,8 +31,8 @@ const defaultProps = {
 };
 
 describe( '<RadioBoxGroup />', () => {
-	it.each( [ 'primary', 'chip' ] )( 'renders the default variant', async variant => {
-		const { container } = render( <RadioBoxGroup { ...defaultProps } variant={ variant } /> );
+	it( 'renders the component', async () => {
+		const { container } = render( <RadioBoxGroup { ...defaultProps } /> );
 
 		const dom = await screen.findAllByRole( 'radio' );
 

--- a/src/system/Form/RadioGroupChip.stories.tsx
+++ b/src/system/Form/RadioGroupChip.stories.tsx
@@ -1,0 +1,82 @@
+/**
+ * External dependencies
+ */
+import { useState } from 'react';
+
+/**
+ * Internal dependencies
+ */
+import { RadioGroupChip } from './RadioGroupChip';
+
+export default {
+	title: 'RadioGroupChip',
+	component: RadioGroupChip,
+	parameters: {
+		docs: {
+			description: {
+				component: `
+A radio-group-chip is a group of radio buttons that are styled as boxes. This component is used
+to allow users to select one option from a list of options.
+
+## Guidance
+
+### When to use the component
+
+- <strong>Select an option in a form.</strong> Use a radio-box-group when you want users to select
+a single option from a list of options.
+- <strong>Use as a toggle-group.</strong> Use a radio-box-group with the chip variant when you want
+to allow users to toggle between different options.
+
+-------
+
+This documentation is heavily inspired by the [U.S Web Design System (USWDS)](https://designsystem.digital.gov/components/tooltip/#package). We use USWDS as trusted source of truth for accessibility and usability best practices.
+
+## Component Properties
+`,
+			},
+		},
+	},
+};
+
+export const MediumSize = () => {
+	const [ value, setValue ] = useState( 'table' );
+
+	return (
+		<RadioGroupChip
+			defaultValue={ value }
+			onChange={ e => setValue( e.target.value ) }
+			options={ [
+				{
+					label: 'Table',
+					value: 'table',
+				},
+				{
+					label: 'Grid',
+					value: 'grid',
+				},
+			] }
+		/>
+	);
+};
+
+export const SmallSize = () => {
+	const [ value, setValue ] = useState( 'table' );
+
+	return (
+		<RadioGroupChip
+			defaultValue={ value }
+			onChange={ e => setValue( e.target.value ) }
+			options={ [
+				{
+					label: 'Table',
+					value: 'table',
+				},
+				{
+					label: 'Grid',
+					value: 'grid',
+				},
+			] }
+			size="small"
+		/>
+	);
+};

--- a/src/system/Form/RadioGroupChip.stories.tsx
+++ b/src/system/Form/RadioGroupChip.stories.tsx
@@ -16,16 +16,7 @@ export default {
 			description: {
 				component: `
 A radio-group-chip is a group of radio buttons that are styled as boxes. This component is used
-to allow users to select one option from a list of options.
-
-## Guidance
-
-### When to use the component
-
-- <strong>Select an option in a form.</strong> Use a radio-box-group when you want users to select
-a single option from a list of options.
-- <strong>Use as a toggle-group.</strong> Use a radio-box-group with the chip variant when you want
-to allow users to toggle between different options.
+to allow users to toggle between different options
 
 -------
 

--- a/src/system/Form/RadioGroupChip.test.tsx
+++ b/src/system/Form/RadioGroupChip.test.tsx
@@ -1,0 +1,44 @@
+/**
+ * External dependencies
+ */
+import { render, screen } from '@testing-library/react';
+import { axe } from 'jest-axe';
+
+/**
+ * Internal dependencies
+ */
+import { RadioGroupChip } from './RadioGroupChip';
+
+const defaultProps = {
+	options: [
+		{
+			label: 'One',
+			value: 'one',
+		},
+		{
+			label: 'Two',
+			value: 'two',
+		},
+		{
+			label: 'Three',
+			value: 'three',
+		},
+	],
+	onChange: jest.fn(),
+};
+
+describe( '<RadioGroupChip />', () => {
+	it( 'renders the default variant', async () => {
+		const { container } = render( <RadioGroupChip { ...defaultProps } /> );
+
+		const dom = await screen.findAllByRole( 'radio' );
+
+		expect( dom ).toHaveLength( 3 );
+		expect( dom[ 0 ] ).toHaveAttribute( 'value', 'one' );
+		expect( dom[ 1 ] ).toHaveAttribute( 'value', 'two' );
+		expect( dom[ 2 ] ).toHaveAttribute( 'value', 'three' );
+
+		// Check for accessibility issues
+		expect( await axe( container ) ).toHaveNoViolations();
+	} );
+} );

--- a/src/system/Form/RadioGroupChip.tsx
+++ b/src/system/Form/RadioGroupChip.tsx
@@ -1,0 +1,216 @@
+/** @jsxImportSource theme-ui */
+
+/**
+ * External dependencies
+ */
+import React, { useCallback } from 'react';
+import { Theme } from 'theme-ui';
+
+import { RequiredLabel } from './RequiredLabel';
+import { Validation } from './Validation';
+import ScreenReaderText from '../ScreenReaderText';
+
+/**
+ * Internal dependencies
+ */
+
+interface InputTheme extends Theme {
+	outline?: Record< string, string >;
+}
+
+type Option = {
+	id?: string;
+	value: string;
+	label: React.ReactNode | string;
+};
+
+type ChipOptionProps = {
+	defaultValue?: string;
+	option: Option;
+	name: string;
+	disabled?: boolean;
+	onChangeHandler: ( e: React.ChangeEvent< HTMLInputElement > ) => void;
+	size: 'small' | 'medium';
+};
+
+const ChipOption = ( {
+	defaultValue,
+	option: { id, value, label },
+	name,
+	disabled,
+	onChangeHandler,
+	size = 'medium',
+}: ChipOptionProps ) => {
+	const checked = `${ defaultValue }` === `${ value }`;
+	const forLabel = id || value;
+	const ref = React.useRef( null );
+	const describedById = `input-radio-box-${ forLabel }-description`;
+
+	return (
+		<div
+			id={ `o${ forLabel }` }
+			onClick={ () => {
+				if ( ref.current ) {
+					( ref.current as HTMLInputElement ).click();
+				}
+			} }
+			sx={ {
+				display: 'inline-flex',
+				position: 'relative',
+				background: checked ? 'layer.4' : undefined,
+				color: 'text',
+				minHeight: size === 'small' ? '22px' : '32px',
+				boxShadow: checked ? 'low' : undefined,
+				'&:hover': {
+					background: checked ? 'layer.4' : 'layer.1',
+				},
+				borderRadius: 1,
+			} }
+		>
+			<input
+				ref={ ref }
+				type="radio"
+				id={ forLabel }
+				disabled={ disabled }
+				name={ name }
+				checked={ checked }
+				aria-checked={ checked }
+				value={ value }
+				onChange={ onChangeHandler }
+				aria-labelledby={ describedById }
+				sx={ {
+					opacity: 0,
+					height: 0,
+					width: 0,
+					position: 'absolute',
+					'&:focus-visible + label': ( theme: InputTheme ) => theme.outline,
+				} }
+			/>
+
+			<label
+				id={ describedById }
+				htmlFor={ forLabel }
+				sx={ {
+					height: '100%',
+					display: 'flex',
+					flexDirection: 'column',
+					justifyContent: 'center',
+					width: '100%',
+					px: size === 'small' ? 1 : 3,
+					fontWeight: 400,
+					fontSize: size === 'small' ? 1 : 2,
+					cursor: 'pointer',
+					borderRadius: 1,
+				} }
+			>
+				{ label }
+			</label>
+		</div>
+	);
+};
+
+type RadioGroupChipProps = {
+	optionWidth?: string;
+	name?: string;
+	onChange: ( e: React.ChangeEvent< HTMLInputElement >, option?: Option ) => void;
+	groupLabel?: string;
+	defaultValue?: string;
+	options: Option[];
+	disabled?: boolean;
+	errorMessage?: string;
+	hasError?: boolean;
+	required?: boolean;
+	size?: 'small' | 'medium';
+};
+
+const RadioGroupChip = React.forwardRef(
+	(
+		{
+			name = '',
+			onChange,
+			groupLabel,
+			defaultValue,
+			options,
+			disabled,
+			errorMessage,
+			hasError,
+			required,
+			size = 'medium',
+			...props
+		}: RadioGroupChipProps,
+		forwardRef
+	) => {
+		const onChangeHandler = useCallback(
+			( e: React.ChangeEvent< HTMLInputElement > ) => {
+				const optionTriggered = options.find(
+					option => `${ option.value }` === `${ e.target.value }`
+				);
+				onChange( e, optionTriggered );
+			},
+			[ onChange ]
+		);
+
+		const renderedOptions = options.map( option => (
+			<ChipOption
+				defaultValue={ defaultValue }
+				disabled={ disabled }
+				key={ option?.id || option?.value }
+				name={ name }
+				option={ option }
+				onChangeHandler={ onChangeHandler }
+				size={ size }
+			/>
+		) );
+
+		return (
+			<div>
+				<fieldset
+					sx={ {
+						border: 0,
+						background: 'layer.3',
+						p: size === 'small' ? '2px' : 1,
+						display: 'inline-flex',
+						gap: 1,
+						borderRadius: 1,
+						...( hasError
+							? { border: '1px solid', borderColor: 'input.border.error', borderRadius: 2, p: 2 }
+							: {} ),
+					} }
+					// eslint-disable-next-line @typescript-eslint/ban-ts-comment
+					// @ts-expect-error
+					ref={ forwardRef }
+					aria-required={ required }
+					role="radiogroup"
+					{ ...props }
+				>
+					{ groupLabel ? (
+						<legend sx={ { mb: 2 } }>
+							{ groupLabel }
+							{ required ? <RequiredLabel /> : null }
+						</legend>
+					) : (
+						<ScreenReaderText>Choose an option</ScreenReaderText>
+					) }
+					<div
+						sx={ {
+							display: 'flex',
+							gap: 1,
+						} }
+					>
+						{ renderedOptions }
+					</div>
+				</fieldset>
+
+				{ hasError && errorMessage && (
+					<Validation isValid={ false } describedId={ groupLabel }>
+						{ errorMessage }
+					</Validation>
+				) }
+			</div>
+		);
+	}
+);
+
+RadioGroupChip.displayName = 'RadioGroupChip';
+
+export { RadioGroupChip };


### PR DESCRIPTION
## Description

Presently we have a `chip` variant of the `RadioBoxGroup` component. We are in need for a small size of this `chip` variant. But the component `RadioBoxGroup` does not provide any size prop, nor does its other variant need any.

So in this PR we are extracting the `chip` variant to a separate component `RadioGroupChip` and adding a `size` prop with `small` and `medium` values. 

![output](https://github.com/user-attachments/assets/6183acca-a8f2-4ca8-bc24-447f9d0abc13)


## Steps to Test

1. Pull down PR.
1. `npm run dev`.
1. Open http://localhost:6006/?path=/docs/radiogroupchip--docs
