### PR TITLE
Add RadioGroupChip to exported components

### DIFF
--- a/src/system/Form/index.js
+++ b/src/system/Form/index.js
@@ -7,6 +7,7 @@ import { InputWithCopyButton } from './InputWithCopyButton';
 import { Label } from './Label';
 import { Radio } from './Radio/Radio';
 import { RadioBoxGroup } from './RadioBoxGroup';
+import { RadioGroupChip } from './RadioGroupChip';
 import { Textarea } from './Textarea';
 import { Toggle } from './Toggle';
 import { ToggleRow } from './ToggleRow';
@@ -18,6 +19,7 @@ export {
 	Label,
 	Radio,
 	RadioBoxGroup,
+	RadioGroupChip,
 	Textarea,
 	Toggle,
 	ToggleRow,

--- a/src/system/index.js
+++ b/src/system/index.js
@@ -31,6 +31,7 @@ import {
 	Validation,
 	Radio,
 	RadioBoxGroup,
+	RadioGroupChip,
 	Textarea,
 	Checkbox,
 } from './Form';
@@ -105,6 +106,7 @@ export {
 	LinkExternal,
 	Radio,
 	RadioBoxGroup,
+	RadioGroupChip,
 	Textarea,
 	Progress,
 	Text,


### PR DESCRIPTION
## Description

We forgot to export the `RadioGroupChip` component in this [PR](https://github.com/Automattic/vip-design-system/pull/436).
