### PR TITLE
[DRAFT] Example of a ThemeUIProvider Error

### DIFF
--- a/src/system/Bug.tsx
+++ b/src/system/Bug.tsx
@@ -1,0 +1,8 @@
+import React from 'react';
+import { ThemeUIProvider } from 'theme-ui';
+
+import { theme } from '../../src/system';
+
+export const Bug = () => {
+	return <ThemeUIProvider theme={ theme }>Empty</ThemeUIProvider>;
+};


### PR DESCRIPTION
## Description

I noticed that the `theme` we generate can't be used in Typescript project without either ignoring the type error or forcefully set the type as `Theme`.
