### PR TITLE
Fix some warnings in the FormAutocomplete component

### DIFF
--- a/src/system/NewForm/FormAutocomplete.js
+++ b/src/system/NewForm/FormAutocomplete.js
@@ -91,7 +91,7 @@ const searchIconStyles = {
 	},
 };
 
-const DefaultArrow = config => <FormSelectArrow classNames={ config.className } />;
+const DefaultArrow = config => <FormSelectArrow className={ config.className } />;
 
 const FormAutocomplete = React.forwardRef(
 	(
@@ -368,7 +368,7 @@ FormAutocomplete.propTypes = {
 	getOptionValue: PropTypes.func,
 	hasError: PropTypes.bool,
 	isInline: PropTypes.bool,
-	label: PropTypes.string,
+	label: PropTypes.node,
 	loading: PropTypes.bool,
 	minLength: PropTypes.number,
 	noOptionsMessage: PropTypes.func,


### PR DESCRIPTION
## Description

We're currently passing the `classNames` prop to `<FormSelectArrow />` which gets passed on to the icon itself, resulting in the warning: `React does not recognize the classNames prop on a DOM element`

We also currently expect a string for the `label` prop, which causes a prop type warning when we pass it an element (e.g. by including screen reader text within the label).

## Steps to Test

1. Pull down PR.
1. `npm run dev`.
1. Open [Storybook](http://localhost:6006/?path=/story/form-autocomplete--with-arrow).
1. Check the console, verify no `React does not recognize the classNames prop on a DOM element` warning is present.
1. Update `src/system/NewForm/FormAutocomplete.stories.jsx`, passing `<></>` as the label to `<FormAutocomplete />`
2. Verify no prop type warnings are present in the console.
