### PR TITLE
Accordion: Expose props for controlling component

### DIFF
--- a/src/system/Accordion/Accordion.test.tsx
+++ b/src/system/Accordion/Accordion.test.tsx
@@ -7,18 +7,19 @@
 import { render, screen } from '@testing-library/react';
 import userEvent from '@testing-library/user-event';
 import { axe } from 'jest-axe';
+import { useState } from 'react';
 import { ThemeUIProvider } from 'theme-ui';
 
 /**
  * Internal dependencies
  */
 import * as Accordion from './Accordion';
-import { theme } from '../';
+import { Button, theme } from '../';
 
 const renderWithTheme = children =>
 	render( <ThemeUIProvider theme={ theme }>{ children }</ThemeUIProvider> );
 
-const renderComponent = () =>
+const renderUncontrolledComponent = () =>
 	renderWithTheme(
 		<Accordion.Root defaultValue="one" sx={ { width: '400px' } }>
 			<Accordion.Item value="one">
@@ -32,7 +33,58 @@ const renderComponent = () =>
 		</Accordion.Root>
 	);
 
-describe( '<Accordion />', () => {
+const renderControlledComponent = () => {
+	const ControlledComponent = () => {
+		const [ value, setValue ] = useState( 'one' );
+
+		return (
+			<Accordion.Root value={ value } onValueChange={ setValue }>
+				<Accordion.Item value="one">
+					<Button
+						aria-controls="manage-content-one"
+						aria-expanded={ value === 'one' ? 'true' : 'false' }
+						data-state={ value === 'one' ? 'open' : 'closed' }
+						onClick={ () => {
+							if ( value === 'one' ) {
+								setValue( '' );
+							} else {
+								setValue( 'one' );
+							}
+						} }
+					>
+						trigger one
+					</Button>
+					<Accordion.Content id="manage-content-one">content one</Accordion.Content>
+				</Accordion.Item>
+				<Accordion.Item value="two">
+					<Button
+						aria-controls="manage-content-two"
+						aria-expanded={ value === 'two' ? 'true' : 'false' }
+						data-state={ value === 'two' ? 'open' : 'closed' }
+						onClick={ () => {
+							if ( value === 'two' ) {
+								setValue( '' );
+							} else {
+								setValue( 'two' );
+							}
+						} }
+					>
+						trigger two
+					</Button>
+					<Accordion.Content id="manage-content-two">content two</Accordion.Content>
+				</Accordion.Item>
+			</Accordion.Root>
+		);
+	};
+
+	return renderWithTheme( <ControlledComponent /> );
+};
+
+describe.each( [
+	[ 'Uncontrolled', renderUncontrolledComponent ],
+	[ 'Controlled', renderControlledComponent ],
+] )( '<Accordion />, %s', ( ...modeAndComponent ) => {
+	const [ , renderComponent ] = modeAndComponent;
 	it( 'renders the Accordion component with default value visible', async () => {
 		const { container } = renderComponent();
 

--- a/src/system/Accordion/Accordion.tsx
+++ b/src/system/Accordion/Accordion.tsx
@@ -54,6 +54,8 @@ interface RootProps {
 	className?: Argument;
 	sx?: ThemeUIStyleObject;
 	defaultValue?: string;
+	value?: string;
+	onValueChange?: ( value: string ) => void;
 }
 export const Item = ( { children, ...props }: AccordionItemProps ) => (
 	<AccordionPrimitive.Item


### PR DESCRIPTION
## Description

The primitive Accordion component ours is based on can be controlled or uncontrolled via `value` and `onValueChange`. However, they aren’t exposed in our component, so we get type errors as a result. 

This adds the optional types and uses existing tests to test against both versions of the component. 

## Checklist

- [x] This PR has good automated test coverage
- [ ] The storybook for the component has been updated***

***If we want to demonstrate this option, I can add a story. But if we would rather most usages be the uncontrolled option, then we should probably leave the stories as is. 

## Steps to Test

1. Pull down PR.
2. `npm run jest src/system/Accordion/Accordion.test.tsx`
3. Tests should continue to pass 