### PR TITLE
Set overflowY as auth for dialogs to allow 400% zooming

### DIFF
--- a/src/system/NewDialog/NewDialog.stories.jsx
+++ b/src/system/NewDialog/NewDialog.stories.jsx
@@ -19,7 +19,8 @@ export default {
 
 const defaultProps = {
 	title: 'User settings',
-	description: 'Use this form to manage your settings',
+	description:
+		"Lorem Ipsum is simply dummy text of the printing and typesetting industry. Lorem Ipsum has been the industry's standard dummy text ever since the 1500s, when an unknown printer took a galley of type and scrambled it to make a type specimen book",
 };
 
 export const Default = () => (

--- a/src/system/NewDialog/styles.ts
+++ b/src/system/NewDialog/styles.ts
@@ -15,5 +15,6 @@ export const contentStyles: ThemeUIStyleObject = {
 	maxWidth: '640px',
 	maxHeight: '85vh',
 	padding: 6,
+	overflowY: 'auto',
 	'> h1, > h2': { marginTop: '0 !important' },
 };


### PR DESCRIPTION
## Description

<img width="706" alt="image" src="https://github.com/user-attachments/assets/5b8c1c65-f1d8-4842-af2c-3fe5736a233d">

<img width="721" alt="image" src="https://github.com/user-attachments/assets/9d6cfcf8-1a24-4849-bb41-c45371e90365">

Allow Dialogs to have vertical scroll automatically.

## Checklist

- [ ] This PR has good automated test coverage
- [x] The storybook for the component has been updated

## Steps to Test

1. Pull down PR.
2. `npm run dev`.
4. Open http://localhost:6006/?path=/story/dialog-newdialog--default
5. Zoom your browser to 400% until the dialog creates a scroll to avoid the content overlaps
