### PR TITLE
Remove bg color to remove avatar border

### DIFF
--- a/src/system/Avatar/Avatar.tsx
+++ b/src/system/Avatar/Avatar.tsx
@@ -32,7 +32,6 @@ export const Avatar = forwardRef< HTMLElement, AvatarImageProps >(
 				width: size,
 				overflow: 'hidden',
 				border: 'none',
-				backgroundColor: 'icon.primary',
 				display: 'inline-flex',
 				alignItems: 'center',
 				justifyContent: 'center',
@@ -53,6 +52,7 @@ export const Avatar = forwardRef< HTMLElement, AvatarImageProps >(
 						borderRadius: '100%',
 						width: '100%',
 						display: 'block',
+						border: 'none',
 					} }
 				/>
 			) : (

--- a/src/system/Avatar/Avatar.tsx
+++ b/src/system/Avatar/Avatar.tsx
@@ -52,7 +52,6 @@ export const Avatar = forwardRef< HTMLElement, AvatarImageProps >(
 						borderRadius: '100%',
 						width: '100%',
 						display: 'block',
-						border: 'none',
 					} }
 				/>
 			) : (


### PR DESCRIPTION
## Description

Remove avatar border.
Slack [convo](https://a8c.slack.com/archives/C03A93G9BBP/p1732123296997829) 

## Checklist

- [ ] This PR has good automated test coverage
- [ ] The storybook for the component has been updated

## Steps to Test

Outline the steps to test and verify the PR here.

1. Pull down PR.
2. `npm run dev`.
3. Make sure the avatar does not have a thin gray border on light photos like this
<img width="349" alt="image" src="https://github.com/user-attachments/assets/36fd57ad-f4fa-4c41-87c3-7b126b7a93a0">
It should be like
<img width="413" alt="image" src="https://github.com/user-attachments/assets/6669e7fe-021f-43aa-b280-479faced5ca3">

