### PR TITLE
Change default disabled attributes for buttons

### DIFF
--- a/src/system/Button/Button.stories.tsx
+++ b/src/system/Button/Button.stories.tsx
@@ -119,4 +119,13 @@ const Template = args => (
 	</div>
 );
 
+const PreferAriaDisabledTemplate = args => (
+	<div>
+		<Button { ...args } preferAriaDisabled>
+			Primary
+		</Button>
+	</div>
+);
+
 export const Default = Template.bind( {} );
+export const PreferAriaDisabled = PreferAriaDisabledTemplate.bind( {} );

--- a/src/system/Button/Button.test.tsx
+++ b/src/system/Button/Button.test.tsx
@@ -33,6 +33,28 @@ describe( '<Button />', () => {
 				{ BUTTON_TEXT }
 			</Button>
 		);
+
+		const component = screen.getByText( BUTTON_TEXT );
+
+		expect( component ).toBeInTheDocument();
+		expect( component ).toHaveAttribute( 'disabled', '' );
+		expect( component ).not.toHaveAttribute( 'aria-disabled' );
+
+		fireEvent.click( component );
+		expect( onClick ).toHaveBeenCalledTimes( 0 );
+
+		// Check for accessibility issues
+		expect( await axe( container ) ).toHaveNoViolations();
+	} );
+
+	it( 'renders the Button with aria-disabled prop', async () => {
+		const onClick = jest.fn( () => {} );
+		const { container } = render(
+			<Button disabled preferAriaDisabled onClick={ onClick }>
+				{ BUTTON_TEXT }
+			</Button>
+		);
+
 		const component = screen.getByText( BUTTON_TEXT );
 
 		expect( component ).toBeInTheDocument();

--- a/src/system/Button/Button.tsx
+++ b/src/system/Button/Button.tsx
@@ -21,6 +21,7 @@ export enum ButtonVariant {
 
 export interface ButtonProps extends ThemeButtonProps {
 	disabled?: boolean;
+	preferAriaDisabled?: boolean;
 	onClick?: ( event: ButtonClickType ) => void;
 	full?: boolean;
 	grow?: boolean;
@@ -28,10 +29,11 @@ export interface ButtonProps extends ThemeButtonProps {
 }
 
 const Button = forwardRef< HTMLButtonElement, ButtonProps >(
-	( { className, disabled, onClick, sx, full, grow, ...rest }, ref ) => {
+	( { className, disabled, preferAriaDisabled, onClick, sx, full, grow, ...rest }, ref ) => {
+		const useAriaDisabled = preferAriaDisabled === true;
 		const handleOnClick = useCallback(
 			( event: ButtonClickType ) => {
-				if ( disabled ) {
+				if ( preferAriaDisabled && disabled ) {
 					return event.preventDefault();
 				}
 
@@ -47,7 +49,7 @@ const Button = forwardRef< HTMLButtonElement, ButtonProps >(
 				sx={ {
 					'&:focus': 'none',
 					'&:focus-visible': ( theme: ButtonTheme ) => theme.outline,
-					'&[aria-disabled="true"]': {
+					'&[disabled], &[aria-disabled="true"]': {
 						opacity: 0.7,
 						backgroundColor: 'input.border.disabled',
 						color: 'texts.secondary',
@@ -62,7 +64,8 @@ const Button = forwardRef< HTMLButtonElement, ButtonProps >(
 					...sx,
 				} }
 				{ ...rest }
-				aria-disabled={ disabled }
+				aria-disabled={ useAriaDisabled ? disabled : undefined }
+				disabled={ ! useAriaDisabled && disabled }
 				onClick={ handleOnClick }
 				className={ classNames( 'vip-button-component', className ) }
 				ref={ ref }

--- a/src/system/Button/Button.tsx
+++ b/src/system/Button/Button.tsx
@@ -30,7 +30,8 @@ export interface ButtonProps extends ThemeButtonProps {
 
 const Button = forwardRef< HTMLButtonElement, ButtonProps >(
 	( { className, disabled, preferAriaDisabled, onClick, sx, full, grow, ...rest }, ref ) => {
-		const useAriaDisabled = preferAriaDisabled === true;
+		const disabledAttributes =
+			preferAriaDisabled === true ? { 'aria-disabled': true } : { disabled };
 		const handleOnClick = useCallback(
 			( event: ButtonClickType ) => {
 				if ( preferAriaDisabled && disabled ) {
@@ -64,8 +65,7 @@ const Button = forwardRef< HTMLButtonElement, ButtonProps >(
 					...sx,
 				} }
 				{ ...rest }
-				aria-disabled={ useAriaDisabled ? disabled : undefined }
-				disabled={ ! useAriaDisabled && disabled }
+				{ ...disabledAttributes }
 				onClick={ handleOnClick }
 				className={ classNames( 'vip-button-component', className ) }
 				ref={ ref }

--- a/src/system/Button/ButtonSubmit.tsx
+++ b/src/system/Button/ButtonSubmit.tsx
@@ -49,6 +49,7 @@ export const ButtonSubmit = React.forwardRef< HTMLButtonElement, ButtonSubmitPro
 				ref={ ref }
 				className={ classNames( 'vip-button-submit-component', `vip-button-submit-${ variant }` ) }
 				disabled={ disabled || loading }
+				preferAriaDisabled={ true }
 				variant={ variant }
 				aria-busy={ loading }
 				{ ...rest }


### PR DESCRIPTION
## Description

Once upon a time, my old boss said: "If you don't change your mind over time, you're crazy". 
Welcome to the "putting back disabled attribute show" 😆  !

Long history short: During our new accessibility audit, we realized that adding `aria-disabled` to all `disabled` interactions might not fit all situations perfectly. For forms, we want to keep this behavior since we should always provide feedback to our users when they try to submit a form.

Some references:

- https://kittygiraudel.com/2024/03/29/on-disabled-and-aria-disabled-attributes/
- https://axesslab.com/disabled-buttons-suck/

## Checklist

- [x] This PR has good automated test coverage
- [x] The storybook for the component has been updated

## Steps to Test

1. Pull down PR.
2. `npm run dev`.
3. Open http://localhost:6006/?path=/story/button--prefer-aria-disabled
4. This rendered button has `aria-disabled` instead of disabled
5. Open http://localhost:6006/?path=/story/button--default
6. Inspect the disabled button. It has a `disabled` attribute
