### PR TITLE
Added Possibilities to add ButtonID to Confirmation Dialog

### DIFF
--- a/src/system/NewConfirmationDialog/NewConfirmationDialog.js
+++ b/src/system/NewConfirmationDialog/NewConfirmationDialog.js
@@ -18,6 +18,7 @@ const NewConfirmationDialogContent = ( {
 	onConfirm,
 	onClose,
 	className = null,
+	buttonId,
 } ) => (
 	<Box className={ classNames( 'vip-confirmation-dialog-component', className ) }>
 		<Flex sx={ { justifyContent: 'flex-end', mt: 4 } }>
@@ -27,6 +28,7 @@ const NewConfirmationDialogContent = ( {
 			<NewDialog.Close>
 				<Button
 					variant={ buttonVariant }
+					id= { buttonId }
 					onClick={ () => {
 						onConfirm();
 						onClose();
@@ -56,6 +58,7 @@ const NewConfirmationDialog = ( {
 	buttonVariant,
 	title,
 	body = '',
+	buttonId,
 	...props
 } ) => {
 	const directTrigger = React.cloneElement( trigger, { onClick: onConfirm } );
@@ -76,6 +79,7 @@ const NewConfirmationDialog = ( {
 					body={ body }
 					label={ label }
 					buttonVariant={ buttonVariant }
+					buttonId={ buttonId }
 				/>
 			) }
 			trigger={ trigger }
@@ -92,6 +96,7 @@ NewConfirmationDialog.propTypes = {
 	body: PropTypes.node,
 	label: PropTypes.node,
 	buttonVariant: PropTypes.string,
+	buttonId: PropTypes.string,
 };
 
 export { NewConfirmationDialog };

--- a/src/system/NewConfirmationDialog/NewConfirmationDialog.js
+++ b/src/system/NewConfirmationDialog/NewConfirmationDialog.js
@@ -28,7 +28,7 @@ const NewConfirmationDialogContent = ( {
 			<NewDialog.Close>
 				<Button
 					variant={ buttonVariant }
-					id= { buttonId }
+					id={ buttonId }
 					onClick={ () => {
 						onConfirm();
 						onClose();

--- a/src/system/NewConfirmationDialog/NewConfirmationDialog.stories.jsx
+++ b/src/system/NewConfirmationDialog/NewConfirmationDialog.stories.jsx
@@ -26,6 +26,7 @@ export const Default = () => {
 				body="A modal is used to perform more detailed actions that don&lsquo;t necessarily need the context
 					behind."
 				onConfirm={ () => setAnswer( '👍' ) }
+				buttonId="ConfirmIsJohnDoe"
 				needsConfirm={ true }
 			/>
 


### PR DESCRIPTION
## Description

This PR introduces the ability to set a custom ID or CSS selector for the confirmation button in NewConfirmationDialog. This enhancement enables better feature usage tracking in Pendo.

Related Issue: #463 

## Steps to Test

Outline the steps to test and verify the PR here.

Example:

1. Pull down PR.
1. `npm run dev`.
1. Open Storybook.
1. Go to `/docs/dialog-newconfirmationdialog--docs`.
1. Verify buttonID "ConfirmIsJohnDoe" is present
