### PR TITLE
Add Snackbar component

### DIFF
--- a/src/system/Snackbar/Snackbar.stories.tsx
+++ b/src/system/Snackbar/Snackbar.stories.tsx
@@ -1,0 +1,98 @@
+/** @jsxImportSource theme-ui */
+/**
+ * External dependencies
+ */
+
+/**
+ * Internal dependencies
+ */
+import React, { useState } from 'react';
+
+import { Snackbar } from '..';
+
+export default {
+	title: 'Snackbar',
+	component: Snackbar,
+};
+
+export const Default = () => {
+	const [ visible, setVisible ] = useState( true );
+	return (
+		<React.Fragment>
+			{ visible && (
+				<Snackbar
+					variant="error"
+					sx={ { mb: 4 } }
+					ctaText="Resolve"
+					ctaOnClick={ () => {
+						setVisible( false );
+					} }
+				>
+					Error message.
+				</Snackbar>
+			) }
+
+			<Snackbar
+				variant="warning"
+				sx={ { mb: 4 } }
+				ctaText="View"
+				ctaOnClick={ () => {
+					setVisible( false );
+				} }
+			>
+				Warning message.
+			</Snackbar>
+
+			<Snackbar
+				variant="info"
+				sx={ { mb: 4 } }
+				ctaText="View"
+				ctaOnClick={ () => {
+					setVisible( false );
+				} }
+			>
+				Tip or information.
+			</Snackbar>
+
+			<Snackbar
+				variant="success"
+				sx={ { mb: 4 } }
+				ctaText="Preview"
+				ctaOnClick={ () => {
+					setVisible( false );
+				} }
+			>
+				Success message.
+			</Snackbar>
+
+			<Snackbar
+				loading
+				variant="warning"
+				sx={ { mb: 4 } }
+				title="Operation in progress..."
+				ctaText="Pause"
+				ctaOnClick={ () => {
+					setVisible( false );
+				} }
+			>
+				Check back again in a few seconds.
+			</Snackbar>
+
+			<Snackbar
+				variant="sync"
+				sx={ { mb: 4 } }
+				title="Operation in progress..."
+				ctaText="Pause"
+				ctaOnClick={ () => {
+					setVisible( false );
+				} }
+			>
+				Check back again in a few seconds.
+			</Snackbar>
+
+			<Snackbar variant="system" sx={ { mb: 4 } }>
+				System message.
+			</Snackbar>
+		</React.Fragment>
+	);
+};

--- a/src/system/Snackbar/Snackbar.stories.tsx
+++ b/src/system/Snackbar/Snackbar.stories.tsx
@@ -78,18 +78,6 @@ export const Default = () => {
 				Check back again in a few seconds.
 			</Snackbar>
 
-			<Snackbar
-				variant="sync"
-				sx={ { mb: 4 } }
-				title="Operation in progress..."
-				ctaText="Pause"
-				ctaOnClick={ () => {
-					setVisible( false );
-				} }
-			>
-				Check back again in a few seconds.
-			</Snackbar>
-
 			<Snackbar variant="system" sx={ { mb: 4 } }>
 				System message.
 			</Snackbar>

--- a/src/system/Snackbar/Snackbar.test.tsx
+++ b/src/system/Snackbar/Snackbar.test.tsx
@@ -1,0 +1,90 @@
+/** @jsxImportSource theme-ui */
+/* eslint-disable @typescript-eslint/ban-ts-comment */
+// @ts-nocheck
+
+import { render, screen } from '@testing-library/react';
+import userEvent from '@testing-library/user-event';
+import { axe } from 'jest-axe';
+import { ThemeUIProvider } from 'theme-ui';
+
+import { Snackbar } from './Snackbar';
+import { theme } from '../';
+
+jest.mock( '@theme-ui/match-media' );
+
+const renderWithTheme = children =>
+	render( <ThemeUIProvider theme={ theme }>{ children }</ThemeUIProvider> );
+
+describe( '<Snackbar />', () => {
+	it( 'renders the basic Snackbar component', async () => {
+		const { container } = renderWithTheme( <Snackbar title="Test Title">Test content</Snackbar> );
+
+		// Check for title and content
+		expect( screen.getByText( 'Test Title' ) ).toBeInTheDocument();
+		expect( screen.getByText( 'Test content' ) ).toBeInTheDocument();
+
+		// Check for accessibility issues
+		expect( await axe( container ) ).toHaveNoViolations();
+	} );
+
+	it( 'renders different variants correctly', () => {
+		const variants = [ 'error', 'info', 'success', 'system', 'warning' ] as const;
+
+		variants.forEach( variant => {
+			const { container } = renderWithTheme(
+				<Snackbar variant={ variant } title={ `${ variant } title` }>
+					{ `${ variant } content` }
+				</Snackbar>
+			);
+
+			expect( screen.getByText( `${ variant } title` ) ).toBeInTheDocument();
+			expect( screen.getByText( `${ variant } content` ) ).toBeInTheDocument();
+			expect( container.querySelector( '.vip-snackbar-component' ) ).toBeInTheDocument();
+		} );
+	} );
+
+	it( 'renders with loading state', () => {
+		const { container } = renderWithTheme( <Snackbar loading>Loading content</Snackbar> );
+
+		expect( screen.getByText( 'Loading content' ) ).toBeInTheDocument();
+		expect( container.querySelector( '.vip-spinner-component' ) ).toBeInTheDocument();
+	} );
+
+	it( 'handles CTA click correctly', async () => {
+		const mockOnClick = jest.fn();
+		const user = userEvent.setup();
+
+		renderWithTheme(
+			<Snackbar ctaText="Click me" ctaOnClick={ mockOnClick }>
+				Content with CTA
+			</Snackbar>
+		);
+
+		const ctaButton = screen.getByText( 'Click me' );
+		await user.click( ctaButton );
+
+		expect( mockOnClick ).toHaveBeenCalledTimes( 1 );
+	} );
+
+	it( 'renders CTA with href correctly', () => {
+		renderWithTheme(
+			<Snackbar ctaText="Visit Link" ctaHref="https://example.com">
+				Content with link
+			</Snackbar>
+		);
+
+		const link = screen.getByText( 'Visit Link' );
+		expect( link ).toHaveAttribute( 'href', 'https://example.com' );
+	} );
+
+	it( 'applies custom className and styles', () => {
+		const { container } = renderWithTheme(
+			<Snackbar className="custom-class" sx={ { backgroundColor: 'red' } } title="Styled Snackbar">
+				Styled content
+			</Snackbar>
+		);
+
+		const snackbarElement = container.querySelector( '.vip-snackbar-component' );
+		expect( snackbarElement ).toHaveClass( 'custom-class' );
+	} );
+} );

--- a/src/system/Snackbar/Snackbar.tsx
+++ b/src/system/Snackbar/Snackbar.tsx
@@ -89,20 +89,20 @@ export const Snackbar = React.forwardRef< HTMLDivElement, SnackbarProps >(
 				sx={ {
 					p: 4,
 					boxShadow: 'none',
-					bg: 'layer.inverse',
+					bg: 'snackbar.background',
 					border: '1px solid',
 					borderRadius: 1,
-					color: 'texts.inverse',
+					color: 'snackbar.text',
 					fontSize: 2,
 					a: {
-						color: 'texts.inverse',
+						color: 'snackbar.link',
 					},
 					ul: {
 						pl: 5,
 					},
 					...sx,
 				} }
-				className={ classNames( 'vip-notice-component', className ) }
+				className={ classNames( 'vip-snackbar-component', className ) }
 				ref={ forwardRef }
 				{ ...props }
 			>

--- a/src/system/Snackbar/Snackbar.tsx
+++ b/src/system/Snackbar/Snackbar.tsx
@@ -1,0 +1,167 @@
+/** @jsxImportSource theme-ui */
+
+/**
+ * External dependencies
+ */
+import classNames from 'classnames';
+import React from 'react';
+import { MdError, MdWarning, MdInfo, MdCheckCircle, MdLock, MdSync } from 'react-icons/md';
+import { Grid, ThemeUIStyleObject } from 'theme-ui';
+
+/**
+ * Internal dependencies
+ */
+import { Box, Flex, Heading, Spinner } from '..';
+
+interface SnackbarIconProps {
+	color: string;
+	variant: ColorVariants;
+	loading?: boolean;
+}
+
+export type SnackbarProps = React.HTMLAttributes< HTMLDivElement > & {
+	children?: React.ReactNode;
+	sx?: ThemeUIStyleObject;
+	title?: React.ReactNode;
+	variant?: ColorVariants;
+	loading?: boolean;
+	isDismissable?: boolean;
+	className?: string;
+	ctaOnClick?: () => void;
+	ctaText?: string;
+	ctaHref?: string;
+};
+
+type ColorVariants = 'error' | 'info' | 'success' | 'sync' | 'system' | 'warning';
+
+const SnackbarIcon = ( { color, variant, loading }: SnackbarIconProps ) => {
+	const sx = { color, flex: '0 0 auto' };
+	const size = 24;
+
+	if ( loading ) {
+		return <Spinner sx={ sx } size={ size } />;
+	}
+
+	const elements = {
+		default: MdWarning,
+		error: MdError,
+		info: MdInfo,
+		success: MdCheckCircle,
+		sync: MdSync,
+		system: MdLock,
+		warning: MdWarning,
+	};
+
+	const Element = elements[ variant ] || elements.default;
+
+	return <Element sx={ sx } size={ size } aria-hidden="true" />;
+};
+
+export const Snackbar = React.forwardRef< HTMLDivElement, SnackbarProps >(
+	(
+		{
+			children,
+			className = null,
+			sx = {},
+			title,
+			variant = 'warning',
+			loading = false,
+			isDismissable = false,
+			ctaOnClick,
+			ctaText,
+			ctaHref = undefined,
+			...props
+		},
+		forwardRef
+	) => {
+		const columns = [ '24px', 'auto' ];
+		const hasCta = ctaText && ( ctaOnClick || ctaHref );
+		if ( hasCta ) {
+			columns.push( 'auto' );
+		}
+		if ( isDismissable ) {
+			columns.push( '24px' );
+		}
+
+		return (
+			<Grid
+				columns={ columns.join( ' ' ) }
+				variant="notice"
+				sx={ {
+					p: 4,
+					boxShadow: 'none',
+					bg: 'layer.inverse',
+					border: '1px solid',
+					borderRadius: 1,
+					color: 'texts.inverse',
+					fontSize: 2,
+					a: {
+						color: 'texts.inverse',
+					},
+					ul: {
+						pl: 5,
+					},
+					...sx,
+				} }
+				className={ classNames( 'vip-notice-component', className ) }
+				ref={ forwardRef }
+				{ ...props }
+			>
+				<Box>
+					<Flex
+						sx={ {
+							flexDirection: 'column', // the trick here is to have a flex column with the icon at the bottom and an empty div that fills the space
+							minHeight: '24px',
+							maxHeight: '32px', // we're forcing the max height so that the icon is, at max, aligned between the first and the second line of text
+							alignItems: 'flex-end', // we want the icon to be aligned to the bottom
+							height: '100%', // specifying the height will allow the box to match the height of the content.
+						} }
+					>
+						<Box
+							sx={ {
+								flex: '1 100%', // we need this empty div to make the icon align to the bottom
+							} }
+						></Box>
+						<SnackbarIcon
+							loading={ loading }
+							color={ `snackbar.icon.${ variant }` }
+							variant={ variant }
+						/>
+					</Flex>
+				</Box>
+				<Box>
+					<Grid columns={ [ 'auto auto' ] } sx={ { justifyItems: 'flex-start flex-end' } }>
+						<Box sx={ { justifyContent: 'flex-start' } }>
+							{ title && (
+								<Heading
+									as="p"
+									sx={ {
+										color: 'texts.inverse',
+										mb: 0,
+										fontSize: 1,
+										fontWeight: '700',
+									} }
+								>
+									{ title }
+								</Heading>
+							) }
+							{ children && (
+								<span sx={ { fontSize: 1, color: 'texts.inverse' } }>{ children }</span>
+							) }
+						</Box>
+					</Grid>
+				</Box>
+				{ ctaText && ( ctaOnClick || ctaHref ) && (
+					<Box sx={ { textAlign: 'right', fontSize: 1, px: 2 } }>
+						<a href={ ctaHref } sx={ { cursor: 'pointer' } } onClick={ ctaOnClick }>
+							{ ctaText }
+						</a>
+					</Box>
+				) }
+				{ isDismissable && <Box></Box> }
+			</Grid>
+		);
+	}
+);
+
+Snackbar.displayName = 'Snackbar';

--- a/src/system/Snackbar/Snackbar.tsx
+++ b/src/system/Snackbar/Snackbar.tsx
@@ -5,7 +5,7 @@
  */
 import classNames from 'classnames';
 import React from 'react';
-import { MdError, MdWarning, MdInfo, MdCheckCircle, MdLock, MdSync } from 'react-icons/md';
+import { MdError, MdWarning, MdInfo, MdCheckCircle, MdLock } from 'react-icons/md';
 import { Grid, ThemeUIStyleObject } from 'theme-ui';
 
 /**
@@ -15,7 +15,7 @@ import { Box, Flex, Heading, Spinner } from '..';
 
 interface SnackbarIconProps {
 	color: string;
-	variant: ColorVariants;
+	variant: ColorVariants | 'loading';
 	loading?: boolean;
 }
 
@@ -32,14 +32,14 @@ export type SnackbarProps = React.HTMLAttributes< HTMLDivElement > & {
 	ctaHref?: string;
 };
 
-type ColorVariants = 'error' | 'info' | 'success' | 'sync' | 'system' | 'warning';
+type ColorVariants = 'error' | 'info' | 'success' | 'system' | 'warning';
 
 const SnackbarIcon = ( { color, variant, loading }: SnackbarIconProps ) => {
 	const sx = { color, flex: '0 0 auto' };
 	const size = 24;
 
 	if ( loading ) {
-		return <Spinner sx={ sx } size={ size } />;
+		return <Spinner strokeWidth={ 3 } sx={ sx } size={ size } variant="loading" />;
 	}
 
 	const elements = {
@@ -47,7 +47,6 @@ const SnackbarIcon = ( { color, variant, loading }: SnackbarIconProps ) => {
 		error: MdError,
 		info: MdInfo,
 		success: MdCheckCircle,
-		sync: MdSync,
 		system: MdLock,
 		warning: MdWarning,
 	};
@@ -124,7 +123,7 @@ export const Snackbar = React.forwardRef< HTMLDivElement, SnackbarProps >(
 						></Box>
 						<SnackbarIcon
 							loading={ loading }
-							color={ `snackbar.icon.${ variant }` }
+							color={ `snackbar.icon.${ loading ? 'loading' : variant }` }
 							variant={ variant }
 						/>
 					</Flex>

--- a/src/system/Snackbar/index.ts
+++ b/src/system/Snackbar/index.ts
@@ -1,0 +1,6 @@
+/**
+ * Internal dependencies
+ */
+import { Snackbar } from './Snackbar';
+
+export { Snackbar };

--- a/src/system/index.js
+++ b/src/system/index.js
@@ -50,6 +50,7 @@ import { Notice } from './Notice';
 import { OptionRow } from './OptionRow';
 import { Progress } from './Progress';
 import { ScreenReaderText } from './ScreenReaderText';
+import { Snackbar } from './Snackbar';
 import { Spinner } from './Spinner';
 import { Table, TableRow, TableCell } from './Table';
 import { Tabs, TabsList, TabsContent, TabsTrigger } from './Tabs';
@@ -119,6 +120,7 @@ export {
 	Toggle,
 	ToggleRow,
 	Toolbar,
+	Snackbar,
 	Validation,
 	Wizard,
 	WizardStep,

--- a/src/system/theme/index.js
+++ b/src/system/theme/index.js
@@ -81,6 +81,7 @@ const getComponentColors = ( theme, gColor, gVariants ) => ( {
 	// Snackbar
 	snackbar: {
 		icon: {
+			loading: theme.text.inverse,
 			...theme.support.icon,
 		},
 	},

--- a/src/system/theme/index.js
+++ b/src/system/theme/index.js
@@ -84,6 +84,9 @@ const getComponentColors = ( theme, gColor, gVariants ) => ( {
 			loading: theme.text.inverse,
 			...theme.support.icon,
 		},
+		link: theme.text.inverse,
+		text: theme.text.inverse,
+		background: theme.layer.inverse,
 	},
 
 	// layer

--- a/src/system/theme/index.js
+++ b/src/system/theme/index.js
@@ -78,6 +78,13 @@ const getComponentColors = ( theme, gColor, gVariants ) => ( {
 		},
 	},
 
+	// Snackbar
+	snackbar: {
+		icon: {
+			...theme.support.icon,
+		},
+	},
+
 	// layer
 	layer: {
 		...theme.layer,


### PR DESCRIPTION
## Description

Add Snackbar component based on component in [WordPress Core](https://wordpress.github.io/gutenberg/?path=/story/components-snackbar--default).

<img width="452" alt="image" src="https://github.com/user-attachments/assets/4c2d35ff-fee8-4953-8c9a-34140d153794" />


## Checklist

- [ ] This PR has good automated test coverage
- [x] The storybook for the component has been updated

## Steps to Test

1. Pull down PR.
1. `npm run dev`.
1. Open Storybook.
1. Verify if the loading and 5 variants will be working as expected
1. Verify if don't have any a11y issues
