### PR TITLE
Add align to DropdownContent and modify FilterDropdown to accept contentProps

### DIFF
--- a/src/system/Dropdown/DropdownContent.tsx
+++ b/src/system/Dropdown/DropdownContent.tsx
@@ -6,6 +6,7 @@ import React from 'react';
 
 export interface DropdownContentProps {
 	className?: string;
+	align?: 'start' | 'center' | 'end';
 }
 
 export const styles = {
@@ -18,13 +19,14 @@ export const styles = {
 };
 
 export const DropdownContent = React.forwardRef< HTMLDivElement, DropdownContentProps >(
-	( { className, ...props }, forwardRef ) => (
+	( { className, align = 'center', ...props }, forwardRef ) => (
 		<DropdownMenuPrimitive.DropdownMenuContent
 			className={ classNames( 'vip-dropdown-menu-content', className ) }
 			ref={ forwardRef }
 			sx={ styles }
+			align={ align }
 			{ ...props }
-		/>
+		></DropdownMenuPrimitive.DropdownMenuContent>
 	)
 );
 

--- a/src/system/Dropdown/DropdownContent.tsx
+++ b/src/system/Dropdown/DropdownContent.tsx
@@ -26,7 +26,7 @@ export const DropdownContent = React.forwardRef< HTMLDivElement, DropdownContent
 			sx={ styles }
 			align={ align }
 			{ ...props }
-		></DropdownMenuPrimitive.DropdownMenuContent>
+		/>
 	)
 );
 

--- a/src/system/FilterDropdown/FilterDropdown.tsx
+++ b/src/system/FilterDropdown/FilterDropdown.tsx
@@ -7,6 +7,7 @@ import { MdCheck, MdKeyboardArrowDown } from 'react-icons/md';
 
 import { Button } from '../Button';
 import * as Dropdown from '../Dropdown';
+import { DropdownContentProps } from '../Dropdown/DropdownContent';
 import { DropdownCheckboxItemProps } from '../Dropdown/DropdownItem';
 import ScreenReaderText from '../ScreenReaderText';
 
@@ -43,6 +44,7 @@ export type FilterDropdownProps = {
 	label?: React.ReactNode | string;
 	onSelect: ( filter: FilterDropDownFilterProp, key: string ) => void;
 	defaultValue?: string | null;
+	contentProps?: DropdownContentProps;
 };
 
 export const FilterDropdown = ( {
@@ -51,6 +53,7 @@ export const FilterDropdown = ( {
 	label,
 	onSelect,
 	defaultValue = null,
+	contentProps = {},
 }: FilterDropdownProps ) => {
 	const translate = useTranslate();
 	const filterKeys = Object.keys( filters );
@@ -59,6 +62,7 @@ export const FilterDropdown = ( {
 
 	return (
 		<Dropdown.Root
+			contentProps={ contentProps }
 			trigger={
 				<Button
 					className={ classNames( 'vip-filter-dropdown-trigger', className ) }


### PR DESCRIPTION
## Description

Adds the align prop for the `DropdownContent`, which can now be passed in through `FilterDropdown`.

Resolves https://a8c.slack.com/lists/T024FN1V2/F0890C9RQ74?record_id=Rec08DPR5AXMF

Keeps `center` as the default

## Checklist

- [ ] This PR has good automated test coverage
- [ ] The storybook for the component has been updated

## Steps to Test

Outline the steps to test and verify the PR here.

Example:

1. Pull down PR.
1. `npm run dev`.
1. Open Storybook.
1. Eat cookies.
1. Verify cookies are delicious.
