### PR TITLE
NewConfirmationDialog: Add disabled prop to confirm button

### DIFF
--- a/src/system/NewConfirmationDialog/NewConfirmationDialog.js
+++ b/src/system/NewConfirmationDialog/NewConfirmationDialog.js
@@ -18,7 +18,7 @@ const NewConfirmationDialogContent = ( {
 	onConfirm,
 	onClose,
 	className = null,
-	disabled = false,
+	buttonDisabled = false,
 } ) => (
 	<Box className={ classNames( 'vip-confirmation-dialog-component', className ) }>
 		<Flex sx={ { justifyContent: 'flex-end', mt: 4 } }>
@@ -29,12 +29,12 @@ const NewConfirmationDialogContent = ( {
 				<Button
 					variant={ buttonVariant }
 					onClick={ () => {
-						if ( ! disabled ) {
+						if ( ! buttonDisabled ) {
 							onConfirm();
 							onClose();
 						}
 					} }
-					disabled={ disabled }
+					disabled={ buttonDisabled }
 				>
 					{ label }
 				</Button>
@@ -50,7 +50,7 @@ NewConfirmationDialogContent.propTypes = {
 	onClose: PropTypes.func,
 	onConfirm: PropTypes.func,
 	className: PropTypes.any,
-	disabled: PropTypes.bool,
+	buttonDisabled: PropTypes.bool,
 };
 
 const NewConfirmationDialog = ( {

--- a/src/system/NewConfirmationDialog/NewConfirmationDialog.js
+++ b/src/system/NewConfirmationDialog/NewConfirmationDialog.js
@@ -18,6 +18,7 @@ const NewConfirmationDialogContent = ( {
 	onConfirm,
 	onClose,
 	className = null,
+	disabled = false,
 } ) => (
 	<Box className={ classNames( 'vip-confirmation-dialog-component', className ) }>
 		<Flex sx={ { justifyContent: 'flex-end', mt: 4 } }>
@@ -28,9 +29,12 @@ const NewConfirmationDialogContent = ( {
 				<Button
 					variant={ buttonVariant }
 					onClick={ () => {
-						onConfirm();
-						onClose();
+						if ( ! disabled ) {
+							onConfirm();
+							onClose();
+						}
 					} }
+					disabled={ disabled }
 				>
 					{ label }
 				</Button>
@@ -46,6 +50,7 @@ NewConfirmationDialogContent.propTypes = {
 	onClose: PropTypes.func,
 	onConfirm: PropTypes.func,
 	className: PropTypes.any,
+	disabled: PropTypes.bool,
 };
 
 const NewConfirmationDialog = ( {

--- a/src/system/NewConfirmationDialog/NewConfirmationDialog.js
+++ b/src/system/NewConfirmationDialog/NewConfirmationDialog.js
@@ -29,10 +29,8 @@ const NewConfirmationDialogContent = ( {
 				<Button
 					variant={ buttonVariant }
 					onClick={ () => {
-						if ( ! buttonDisabled ) {
-							onConfirm();
-							onClose();
-						}
+						onConfirm();
+						onClose();
 					} }
 					disabled={ buttonDisabled }
 				>


### PR DESCRIPTION
## Description

Adds the `disabled` prop to the confirm button for NewConfirmationDialog.

## Checklist

- [ ] This PR has good automated test coverage
- [ ] The storybook for the component has been updated

## Steps to Test

Outline the steps to test and verify the PR here.

Example:

1. Pull down PR.
1. `npm run dev`.
1. Open Storybook.
1. Eat cookies.
1. Verify cookies are delicious.
