### PR TITLE
NavItemGroup: Add parentHref to make clickable

### DIFF
--- a/src/system/Nav/Nav.stories.tsx
+++ b/src/system/Nav/Nav.stories.tsx
@@ -190,6 +190,19 @@ export const Menu: Story = {
 				</NavItem.MenuGroup>
 
 				<NavItem.MenuGroup
+					label="Clickable Parent Navigation Item"
+					renderIcon={ size => <BiHistory size={ size } /> }
+					parentHref="https://random-website.com/"
+				>
+					<NavItem.Menu as={ CustomLink } href="https://google.com/">
+						Test
+					</NavItem.Menu>
+					<NavItem.Menu as={ CustomLink } href="https://wpvip.com/">
+						Item
+					</NavItem.Menu>
+				</NavItem.MenuGroup>
+
+				<NavItem.MenuGroup
 					label="Performance"
 					renderIcon={ size => <BiTachometer size={ size } /> }
 				>

--- a/src/system/Nav/NavItemGroup.tsx
+++ b/src/system/Nav/NavItemGroup.tsx
@@ -19,6 +19,7 @@ export interface NavItemGroupProps extends NavItemBaseProps {
 	renderIcon?: NavItemRenderIconProp;
 	activeChildren?: boolean;
 	label: string;
+	parentHref?: string;
 }
 
 const NavItemGroupBase = forwardRef< HTMLLIElement, NavItemGroupProps >(
@@ -33,6 +34,7 @@ const NavItemGroupBase = forwardRef< HTMLLIElement, NavItemGroupProps >(
 			renderIcon,
 			children,
 			sx,
+			parentHref,
 		}: NavItemGroupProps,
 		ref: Ref< HTMLLIElement >
 	) => {
@@ -51,9 +53,10 @@ const NavItemGroupBase = forwardRef< HTMLLIElement, NavItemGroupProps >(
 			>
 				<Collapsible.Root defaultOpen={ active } open={ isExpanded } onOpenChange={ handleExpand }>
 					<Collapsible.Trigger asChild>
-						<button
-							type="button"
-							aria-haspopup={ true }
+						<div
+							role="button"
+							tabIndex={ 0 }
+							aria-haspopup="true"
 							data-active={ active || undefined }
 							data-open={ isExpanded || undefined }
 							data-active-children={ activeChildren || undefined }
@@ -65,7 +68,22 @@ const NavItemGroupBase = forwardRef< HTMLLIElement, NavItemGroupProps >(
 							{ renderIcon ? (
 								<IconContainer>{ renderIcon( NAV_ITEM_ICON_SIZE ) }</IconContainer>
 							) : null }
-							{ label }
+
+							{ parentHref ? (
+								<a
+									href={ parentHref }
+									sx={ {
+										textDecoration: 'none',
+										color: 'inherit',
+										'&:hover': { textDecoration: 'none' },
+									} }
+									onClick={ e => e.stopPropagation() }
+								>
+									{ label }
+								</a>
+							) : (
+								label
+							) }
 
 							<BiChevronDown
 								data-arrow-indicator
@@ -73,8 +91,9 @@ const NavItemGroupBase = forwardRef< HTMLLIElement, NavItemGroupProps >(
 								size={ NAV_ITEM_ICON_SIZE }
 								sx={ { color: 'icon.secondary' } }
 							/>
-						</button>
+						</div>
 					</Collapsible.Trigger>
+
 					<Collapsible.Content sx={ navItemGroupContentStyles }>
 						<ul sx={ navItemGroupContentUlStyles }>{ children }</ul>
 					</Collapsible.Content>


### PR DESCRIPTION
## Description

Right now we don't allow the parent to be clickable. This allows passing in a `parentHref` prop to make it clickable.

## Checklist

- [ ] This PR has good automated test coverage
- [x] The storybook for the component has been updated

## Steps to Test

Outline the steps to test and verify the PR here.

Example:

1. Pull down PR.
1. `npm run dev`.
1. Open Storybook.
1. Eat cookies.
1. Verify cookies are delicious.
