### PR TITLE
Add support colors to theme configuration

### DIFF
--- a/src/system/Accordion/Accordion.stories.tsx
+++ b/src/system/Accordion/Accordion.stories.tsx
@@ -27,7 +27,9 @@ const ExampleContent = () => (
 const ExampleAccordion = () => (
 	<Accordion.Root defaultValue="teamPermissions" sx={ { width: '250px' } }>
 		<Accordion.Item value="teamPermissions">
-			<Accordion.TriggerWithIcon icon={ <RiUserAddLine /> }>
+			<Accordion.TriggerWithIcon
+				icon={ <RiUserAddLine sx={ { color: 'support.accent.success' } } /> }
+			>
 				Team & Permissions
 			</Accordion.TriggerWithIcon>
 			<Accordion.Content>
@@ -35,7 +37,9 @@ const ExampleAccordion = () => (
 			</Accordion.Content>
 		</Accordion.Item>
 		<Accordion.Item value="addContentMedia">
-			<Accordion.TriggerWithIcon icon={ <BiBookContent /> }>
+			<Accordion.TriggerWithIcon
+				icon={ <BiBookContent sx={ { color: 'support.accent.success' } } /> }
+			>
 				Add Content & Media
 			</Accordion.TriggerWithIcon>
 			<Accordion.Content>
@@ -43,7 +47,11 @@ const ExampleAccordion = () => (
 			</Accordion.Content>
 		</Accordion.Item>
 		<Accordion.Item value="addCode">
-			<Accordion.TriggerWithIcon icon={ <RiCodeSSlashFill /> }>Add Code</Accordion.TriggerWithIcon>
+			<Accordion.TriggerWithIcon
+				icon={ <RiCodeSSlashFill sx={ { color: 'support.accent.success' } } /> }
+			>
+				Add Code
+			</Accordion.TriggerWithIcon>
 			<Accordion.Content>
 				<ExampleContent />
 			</Accordion.Content>

--- a/src/system/theme/index.js
+++ b/src/system/theme/index.js
@@ -53,6 +53,10 @@ const getComponentColors = ( theme, gColor, gVariants ) => ( {
 		...theme.tag,
 	},
 
+	support: {
+		...theme.support,
+	},
+
 	// Notice
 	notice: {
 		// extending the notice theme to support the alert variant


### PR DESCRIPTION
## Description

Adds support colors to the exported theme so we can use them

## Checklist

- [ ] This PR has good automated test coverage
- [x] The storybook for the component has been updated

## Steps to Test

1. Open https://deploy-preview-512--vip-design-system-components.netlify.app/?path=/docs/accordion--docs
2. Make sure the Accordion icons are green
