### PR TITLE
[PLTFRM-1004] Use targeted CSS properties in Label component

### DIFF
--- a/src/system/Form/Checkbox/styles.ts
+++ b/src/system/Form/Checkbox/styles.ts
@@ -36,7 +36,6 @@ export const checkboxStyle = ( variant: string ): ThemeUIStyleObject => {
 		},
 		'& ~ label': {
 			fontWeight: 'regular',
-			color: inputBaseText,
 			m: 0,
 			ml: 2,
 		},

--- a/src/system/Form/Checkbox/styles.ts
+++ b/src/system/Form/Checkbox/styles.ts
@@ -4,7 +4,6 @@ import {
 	baseControlBorderStyle,
 	baseControlFocusStyle,
 	inputBaseBackground,
-	inputBaseText,
 } from '../Input.styles';
 
 // The output willl be 16px because of the 1px border.

--- a/src/system/Form/Label.stories.tsx
+++ b/src/system/Form/Label.stories.tsx
@@ -1,8 +1,9 @@
 /** @jsxImportSource theme-ui */
 import React from 'react';
 import { Form, Label } from '..';
+import type { Meta, StoryObj } from '@storybook/react';
 
-export default {
+const meta: Meta< typeof Label > = {
 	title: 'Form/Label',
 	component: Label,
 	parameters: { docs: { source: { type: 'auto' } } },
@@ -15,7 +16,7 @@ export default {
 		required: {
 			control: 'boolean',
 			defaultValue: false,
-			description: 'Whether to show the required asterisk',
+			description: 'Whether to show the required label',
 		},
 		clickable: {
 			control: 'boolean',
@@ -35,19 +36,19 @@ export default {
 	},
 };
 
-const Template = args => (
-	<Form.Root>
-		<Label { ...args }>{ args.children }</Label>
-	</Form.Root>
-);
+export default meta;
 
-export const Default = Template.bind( {} );
-Default.args = {
-	children: 'Label text',
+type Story = StoryObj< typeof Label >;
+
+export const Default: Story = {
+	args: {
+		children: 'Label text',
+	},
 };
 
-export const Required = Template.bind( {} );
-Required.args = {
-	children: 'Label text',
-	required: true,
+export const Required: Story = {
+	args: {
+		children: 'Label text',
+		required: true,
+	},
 };

--- a/src/system/Form/Label.stories.tsx
+++ b/src/system/Form/Label.stories.tsx
@@ -1,6 +1,7 @@
 /** @jsxImportSource theme-ui */
-import React from 'react';
-import { Form, Label } from '..';
+
+import { Label } from '..';
+
 import type { Meta, StoryObj } from '@storybook/react';
 
 const meta: Meta< typeof Label > = {

--- a/src/system/Form/Label.stories.tsx
+++ b/src/system/Form/Label.stories.tsx
@@ -1,36 +1,53 @@
 /** @jsxImportSource theme-ui */
-
-/**
- * Internal dependencies
- */
+import React from 'react';
 import { Form, Label } from '..';
 
 export default {
 	title: 'Form/Label',
+	component: Label,
+	parameters: { docs: { source: { type: 'auto' } } },
+	argTypes: {
+		children: {
+			control: 'text',
+			defaultValue: 'Label text',
+			description: 'The label content',
+		},
+		required: {
+			control: 'boolean',
+			defaultValue: false,
+			description: 'Whether to show the required asterisk',
+		},
+		clickable: {
+			control: 'boolean',
+			defaultValue: false,
+			description: 'Whether the label should have pointer cursor',
+		},
+		sx: {
+			control: 'object',
+			description: 'Theme UI sx-style overrides',
+		},
+		as: {
+			control: 'select',
+			options: [ 'label', 'span', 'div' ],
+			defaultValue: 'label',
+			description: 'The HTML element to render as',
+		},
+	},
 };
 
-const DefaultComponent = props => (
+const Template = args => (
 	<Form.Root>
-		<Label { ...props }>Label</Label>
+		<Label { ...args }>{ args.children }</Label>
 	</Form.Root>
 );
 
-export const Default = () => {
-	return (
-		<>
-			<DefaultComponent />
-		</>
-	);
+export const Default = Template.bind( {} );
+Default.args = {
+	children: 'Label text',
 };
 
-export const Required = () => {
-	const args = {
-		required: true,
-	};
-
-	return (
-		<>
-			<DefaultComponent { ...args } />
-		</>
-	);
+export const Required = Template.bind( {} );
+Required.args = {
+	children: 'Label text',
+	required: true,
 };

--- a/src/system/Form/Label.tsx
+++ b/src/system/Form/Label.tsx
@@ -31,7 +31,10 @@ export const Label = React.forwardRef< HTMLLabelElement, LabelProps >(
 		<Box
 			as={ as }
 			sx={ {
-				all: 'unset',
+				margin: 0,
+				padding: 0,
+				border: 0,
+				outline: 0,
 				...baseLabelStyle,
 				display: 'block',
 				mb: 2,


### PR DESCRIPTION
## Description

We want to change the color of the options of a checkbox form, but our current code isn't allowing us to do that (see Linear issue for screenshot).

1) **Label component:** Replace `all: 'unset'` to specific CSS properties instead since `all: 'unset'` resets any custom CSS we pass down, making it just default to the default color.

2) **Checkbox component:** Remove the hardcoded color for labels in the Checkbox component so it doesn't override the custom CSS colors we pass down to the `<Label>` component

3) **Label component Storybook:** Update the Storybook for the `<Label>` component so we can test our changes on the UI.

| BEFORE |
| ------------- | 
|<img width="1107" alt="Screenshot 2025-06-17 at 6 03 02 PM" src="https://github.com/user-attachments/assets/3610d554-9017-4e3c-82cc-655441d343ef" />|

| AFTER |
| ------------- | 
|<img width="1058" alt="Screenshot 2025-06-17 at 6 05 38 PM" src="https://github.com/user-attachments/assets/96072269-4dff-4ade-a6ec-d754602309bb" />|



## Checklist

- [ ] This PR has good automated test coverage
- [x] The storybook for the component has been updated

## Steps to Test

### Test with local Dashboard:
Follow instructions in this PR: https://github.com/Automattic/vip-dashboard/pull/4519

### Test only the design system bit:
1. Pull down PR.
1. `npm run dev`.
1. Go to: http://localhost:6006/?path=/story/form-label--default
1. Controls tab > Add this to the `sx` field:
```
{
  "color": "texts.secondary"
}
```
1. Inspect the label and make sure:
- Color is `--theme-ui-colors-texts-secondary` and not `--theme-ui-colors-input-text-default`
- Margin/padding/border/outline is all `0`
