### PR TITLE
fix [PLTFRM-996]: fix wrong color tokens for slider in dark mode

### DIFF
--- a/src/system/theme/generated/valet-theme-dark.json
+++ b/src/system/theme/generated/valet-theme-dark.json
@@ -606,21 +606,21 @@
   "slider": {
     "background": {
       "default": {
-        "value": "#d7d4d3",
+        "value": "#514e4d",
         "type": "color"
       },
       "disabled": {
-        "value": "#d7d4d3",
+        "value": "#514e4d",
         "type": "color"
       }
     },
     "handle": {
       "default": {
-        "value": "#13191e",
+        "value": "#d7d4d3",
         "type": "color"
       },
       "disabled": {
-        "value": "#9b9796",
+        "value": "#827f7e",
         "type": "color"
       }
     }

--- a/tokens/valet-core/wpvip-product-dark.json
+++ b/tokens/valet-core/wpvip-product-dark.json
@@ -606,21 +606,21 @@
   "slider": {
     "background": {
       "default": {
-        "value": "{color.gray.15}",
+        "value": "{color.gray.70}",
         "type": "color"
       },
       "disabled": {
-        "value": "{color.gray.15}",
+        "value": "{color.gray.70}",
         "type": "color"
       }
     },
     "handle": {
       "default": {
-        "value": "{color.black}",
+        "value": "{color.gray.15}",
         "type": "color"
       },
       "disabled": {
-        "value": "{color.gray.40}",
+        "value": "{color.gray.50}",
         "type": "color"
       }
     }


### PR DESCRIPTION
## Description

Colors were added in https://github.com/Automattic/vip-design-system/pull/522 that were incorrect for dark mode. This pr fixes that mistake.

## Checklist

- [ ] This PR has good automated test coverage
- [ ] The storybook for the component has been updated

## Steps to Test

Outline the steps to test and verify the PR here.

Example:

1. Pull down PR.
1. `npm run dev`.
1. Open Storybook.
1. Eat cookies.
1. Verify cookies are delicious.
