### PR TITLE
Add/Button restyling

### DIFF
--- a/src/system/Button/Button.stories.tsx
+++ b/src/system/Button/Button.stories.tsx
@@ -19,6 +19,9 @@ export default {
 		disabled: {
 			control: { type: 'boolean' },
 		},
+		danger: {
+			control: { type: 'boolean' },
+		},
 		variant: {
 			type: 'select',
 			options: Object.values( ButtonVariant ),
@@ -66,6 +69,7 @@ This documentation is heavily inspired by the [U.S Web Design System (USWDS)](ht
 
 const Template = args => (
 	<div>
+		<h3>Default</h3>
 		<Table>
 			<TableRow>
 				<TableCell head>Variant</TableCell>
@@ -74,7 +78,6 @@ const Template = args => (
 				<TableCell head>Tertiary</TableCell>
 				<TableCell head>Ghost</TableCell>
 				<TableCell head>Display</TableCell>
-				<TableCell head>Danger</TableCell>
 				<TableCell head>Icon</TableCell>
 			</TableRow>
 			<TableRow>
@@ -100,11 +103,6 @@ const Template = args => (
 				<TableCell>
 					<Button variant="display" { ...args }>
 						Display
-					</Button>
-				</TableCell>
-				<TableCell>
-					<Button variant="danger" { ...args }>
-						Danger
 					</Button>
 				</TableCell>
 				<TableCell>
@@ -142,11 +140,6 @@ const Template = args => (
 					</Button>
 				</TableCell>
 				<TableCell>
-					<Button variant="danger" disabled { ...args }>
-						Danger
-					</Button>
-				</TableCell>
-				<TableCell>
 					<Button variant="icon" type="button" disabled { ...args }>
 						<BiCalendarHeart size={ 24 } />
 						<ScreenReaderText>domain.com</ScreenReaderText>
@@ -166,6 +159,52 @@ const Template = args => (
 				Button with grow width
 			</Button>
 		</div>
+
+		<h3>Danger</h3>
+		<Table>
+			<TableRow>
+				<TableCell head>Variant</TableCell>
+				<TableCell head>Primary</TableCell>
+				<TableCell head>Secondary</TableCell>
+				<TableCell head>Ghost</TableCell>
+			</TableRow>
+			<TableRow>
+				<TableCell>Default</TableCell>
+				<TableCell>
+					<Button danger { ...args }>
+						Primary
+					</Button>
+				</TableCell>
+				<TableCell>
+					<Button danger variant="secondary" { ...args }>
+						Secondary
+					</Button>
+				</TableCell>
+				<TableCell>
+					<Button danger variant="ghost" { ...args }>
+						Ghost
+					</Button>
+				</TableCell>
+			</TableRow>
+			<TableRow>
+				<TableCell>Disabled</TableCell>
+				<TableCell>
+					<Button variant="primary" danger disabled { ...args }>
+						Primary
+					</Button>
+				</TableCell>
+				<TableCell>
+					<Button variant="secondary" danger disabled { ...args }>
+						Secondary
+					</Button>
+				</TableCell>
+				<TableCell>
+					<Button variant="ghost" disabled { ...args }>
+						Ghost
+					</Button>
+				</TableCell>
+			</TableRow>
+		</Table>
 	</div>
 );
 

--- a/src/system/Button/Button.stories.tsx
+++ b/src/system/Button/Button.stories.tsx
@@ -3,14 +3,12 @@
 /**
  * External dependencies
  */
-import React from 'react';
 import { BiCalendarHeart } from 'react-icons/bi';
 
 /**
  * Internal dependencies
  */
-import { Button, ButtonVariant } from '..';
-import { Flex } from '../Flex/Flex';
+import { Button, ButtonVariant, Table, TableCell, TableRow } from '..';
 import ScreenReaderText from '../ScreenReaderText';
 
 export default {
@@ -68,42 +66,94 @@ This documentation is heavily inspired by the [U.S Web Design System (USWDS)](ht
 
 const Template = args => (
 	<div>
-		<Flex sx={ { gap: 2, flexDirection: 'row' } }>
-			<Button { ...args }>Primary</Button>
-
-			<Button variant="secondary" sx={ { ml: 2 } } { ...args }>
-				Secondary
-			</Button>
-
-			<Button variant="tertiary" sx={ { ml: 2 } } { ...args }>
-				Tertiary
-			</Button>
-
-			<Button variant="ghost" sx={ { ml: 2 } } { ...args }>
-				Ghost
-			</Button>
-
-			<Button variant="display" sx={ { ml: 2 } } { ...args }>
-				Display
-			</Button>
-
-			<Button variant="danger" sx={ { ml: 2 } } { ...args }>
-				Danger
-			</Button>
-
-			<Button variant="primary" disabled={ true } sx={ { ml: 2 } } { ...args }>
-				Disabled
-			</Button>
-
-			<Button variant="text" sx={ { ml: 2 } } as="a" href="https://google/com" { ...args }>
-				Button link
-			</Button>
-
-			<Button variant="icon" sx={ { ml: 2 } } type="button" { ...args }>
-				<BiCalendarHeart size={ 24 } />
-				<ScreenReaderText>domain.com</ScreenReaderText>
-			</Button>
-		</Flex>
+		<Table>
+			<TableRow>
+				<TableCell head>Variant</TableCell>
+				<TableCell head>Primary</TableCell>
+				<TableCell head>Secondary</TableCell>
+				<TableCell head>Tertiary</TableCell>
+				<TableCell head>Ghost</TableCell>
+				<TableCell head>Display</TableCell>
+				<TableCell head>Danger</TableCell>
+				<TableCell head>Icon</TableCell>
+			</TableRow>
+			<TableRow>
+				<TableCell>Default</TableCell>
+				<TableCell>
+					<Button { ...args }>Primary</Button>
+				</TableCell>
+				<TableCell>
+					<Button variant="secondary" { ...args }>
+						Secondary
+					</Button>
+				</TableCell>
+				<TableCell>
+					<Button variant="tertiary" { ...args }>
+						Tertiary
+					</Button>
+				</TableCell>
+				<TableCell>
+					<Button variant="ghost" { ...args }>
+						Ghost
+					</Button>
+				</TableCell>
+				<TableCell>
+					<Button variant="display" { ...args }>
+						Display
+					</Button>
+				</TableCell>
+				<TableCell>
+					<Button variant="danger" { ...args }>
+						Danger
+					</Button>
+				</TableCell>
+				<TableCell>
+					<Button variant="icon" type="button" { ...args }>
+						<BiCalendarHeart size={ 24 } />
+						<ScreenReaderText>domain.com</ScreenReaderText>
+					</Button>
+				</TableCell>
+			</TableRow>
+			<TableRow>
+				<TableCell>Disabled</TableCell>
+				<TableCell>
+					<Button variant="primary" disabled { ...args }>
+						Primary
+					</Button>
+				</TableCell>
+				<TableCell>
+					<Button variant="secondary" disabled={ true } { ...args }>
+						Secondary
+					</Button>
+				</TableCell>
+				<TableCell>
+					<Button variant="tertiary" disabled { ...args }>
+						Tertiary
+					</Button>
+				</TableCell>
+				<TableCell>
+					<Button variant="ghost" disabled { ...args }>
+						Ghost
+					</Button>
+				</TableCell>
+				<TableCell>
+					<Button variant="display" disabled { ...args }>
+						Display
+					</Button>
+				</TableCell>
+				<TableCell>
+					<Button variant="danger" disabled { ...args }>
+						Danger
+					</Button>
+				</TableCell>
+				<TableCell>
+					<Button variant="icon" type="button" disabled { ...args }>
+						<BiCalendarHeart size={ 24 } />
+						<ScreenReaderText>domain.com</ScreenReaderText>
+					</Button>
+				</TableCell>
+			</TableRow>
+		</Table>
 
 		<div sx={ { mt: 3 } }>
 			<Button variant="secondary" href="https://google/com" { ...args } full>

--- a/src/system/Button/Button.tsx
+++ b/src/system/Button/Button.tsx
@@ -26,6 +26,7 @@ export interface ButtonProps extends ThemeButtonProps {
 	full?: boolean;
 	grow?: boolean;
 	variant?: keyof typeof ButtonVariant; // converts the enum to a string union type
+	danger?: boolean;
 }
 
 const Button = forwardRef< HTMLButtonElement, ButtonProps >(
@@ -39,6 +40,7 @@ const Button = forwardRef< HTMLButtonElement, ButtonProps >(
 			full,
 			grow,
 			variant = 'primary',
+			danger,
 			...rest
 		},
 		ref
@@ -46,7 +48,6 @@ const Button = forwardRef< HTMLButtonElement, ButtonProps >(
 		const disabledAttributes =
 			disabled && preferAriaDisabled === true ? { 'aria-disabled': true } : { disabled };
 		let disabledStyles = {};
-		let dangerStyles = {};
 
 		const handleOnClick = useCallback(
 			( event: ButtonClickType ) => {
@@ -61,7 +62,13 @@ const Button = forwardRef< HTMLButtonElement, ButtonProps >(
 			[ disabled, onClick ]
 		);
 
-		if ( disabled && variant !== 'text' && variant !== 'ghost' && variant !== 'tertiary' ) {
+		if (
+			disabled &&
+			! danger &&
+			variant !== 'text' &&
+			variant !== 'ghost' &&
+			variant !== 'tertiary'
+		) {
 			disabledStyles = {
 				opacity: 0.7,
 				backgroundColor: 'input.border.disabled',
@@ -84,7 +91,6 @@ const Button = forwardRef< HTMLButtonElement, ButtonProps >(
 					},
 					flexGrow: Boolean( grow ) === true ? '1' : undefined,
 					width: Boolean( full ) === true ? '100%' : undefined,
-					...dangerStyles,
 					...sx,
 				} }
 				{ ...rest }
@@ -92,6 +98,7 @@ const Button = forwardRef< HTMLButtonElement, ButtonProps >(
 				variant={ variant }
 				onClick={ handleOnClick }
 				className={ classNames( 'vip-button-component', className ) }
+				data-danger={ danger }
 				ref={ ref }
 			/>
 		);

--- a/src/system/Button/Button.tsx
+++ b/src/system/Button/Button.tsx
@@ -29,9 +29,24 @@ export interface ButtonProps extends ThemeButtonProps {
 }
 
 const Button = forwardRef< HTMLButtonElement, ButtonProps >(
-	( { className, disabled, preferAriaDisabled, onClick, sx, full, grow, ...rest }, ref ) => {
+	(
+		{
+			className,
+			disabled,
+			preferAriaDisabled,
+			onClick,
+			sx,
+			full,
+			grow,
+			variant = 'primary',
+			...rest
+		},
+		ref
+	) => {
 		const disabledAttributes =
 			disabled && preferAriaDisabled === true ? { 'aria-disabled': true } : { disabled };
+		let disabledStyles = {};
+		let dangerStyles = {};
 
 		const handleOnClick = useCallback(
 			( event: ButtonClickType ) => {
@@ -46,27 +61,35 @@ const Button = forwardRef< HTMLButtonElement, ButtonProps >(
 			[ disabled, onClick ]
 		);
 
+		if ( disabled && variant !== 'text' && variant !== 'ghost' && variant !== 'tertiary' ) {
+			disabledStyles = {
+				opacity: 0.7,
+				backgroundColor: 'input.border.disabled',
+				color: 'texts.secondary',
+			};
+		}
+
 		return (
 			<ThemeButton
 				sx={ {
 					'&:focus': 'none',
 					'&:focus-visible': ( theme: ButtonTheme ) => theme.outline,
 					'&[disabled], &[aria-disabled="true"]': {
-						opacity: 0.7,
-						backgroundColor: 'input.border.disabled',
-						color: 'texts.secondary',
 						cursor: 'not-allowed',
 						pointerEvents: 'none',
+						...disabledStyles,
 					},
 					'&:hover, &:focus': {
 						textDecoration: 'none',
 					},
 					flexGrow: Boolean( grow ) === true ? '1' : undefined,
 					width: Boolean( full ) === true ? '100%' : undefined,
+					...dangerStyles,
 					...sx,
 				} }
 				{ ...rest }
 				{ ...disabledAttributes }
+				variant={ variant }
 				onClick={ handleOnClick }
 				className={ classNames( 'vip-button-component', className ) }
 				ref={ ref }

--- a/src/system/Button/Button.tsx
+++ b/src/system/Button/Button.tsx
@@ -9,7 +9,7 @@ interface ButtonTheme extends Theme {
 }
 
 export enum ButtonVariant {
-	'danger',
+	'danger', // will be deprecated in the future
 	'display',
 	'ghost',
 	'icon',
@@ -40,7 +40,7 @@ const Button = forwardRef< HTMLButtonElement, ButtonProps >(
 			full,
 			grow,
 			variant = 'primary',
-			danger,
+			danger = variant === 'danger', // fallback for danger variant used before the prop was added
 			...rest
 		},
 		ref

--- a/src/system/Wizard/Wizard.stories.tsx
+++ b/src/system/Wizard/Wizard.stories.tsx
@@ -34,6 +34,7 @@ export const Default = () => {
 		{
 			title: 'Configure DNS',
 			titleVariant: 'h2',
+			summaryTitle: 'Summary of Configure DNS',
 		},
 		{
 			title: 'Configure Certificate',
@@ -47,7 +48,13 @@ export const Default = () => {
 	return (
 		<React.Fragment>
 			<Box mt={ 4 }>
-				<Wizard activeStep={ 0 } steps={ steps } completed={ [ 1 ] } className="vip-wizard-xyz" />
+				<Wizard
+					activeStep={ 0 }
+					steps={ steps }
+					completed={ [ 1 ] }
+					summaryAs="dl"
+					className="vip-wizard-xyz"
+				/>
 			</Box>
 		</React.Fragment>
 	);

--- a/src/system/Wizard/WizardStep.tsx
+++ b/src/system/Wizard/WizardStep.tsx
@@ -79,7 +79,7 @@ export const WizardStep = React.forwardRef< HTMLDivElement, WizardStepProps >(
 		if ( statusText !== '' ) {
 			statusText = `Status: ${ statusText }`;
 		}
-		const stepText = `Step ${ order } of ${ totalSteps }`;
+		const stepText = `STEP ${ order } OF ${ totalSteps }`;
 
 		const borderLeftColor = `wizard.step.border.${ status }`;
 		const statusIconColor = `wizard.step.icon.${ status }`;
@@ -104,6 +104,7 @@ export const WizardStep = React.forwardRef< HTMLDivElement, WizardStepProps >(
 					backgroundColor: active ? 'background' : 'transparent',
 					borderRadius: 0,
 					borderBottom: active ? 'none' : '1px solid',
+					borderRight: active ? 'none' : '1px solid',
 					'&:first-of-type': {
 						borderTopWidth: '1px',
 						borderTopStyle: 'solid',
@@ -168,8 +169,8 @@ export const WizardStep = React.forwardRef< HTMLDivElement, WizardStepProps >(
 						</Button>
 					) }
 				</Flex>
-				{ ! active && ( complete || skipped ) && summary && (
-					<DescriptionList as={ summaryAs } list={ summary } title={ summaryTitle } />
+				{ ! active && ( complete || skipped ) && ( summary || summaryTitle ) && (
+					<DescriptionList as={ summaryAs } list={ summary || [] } title={ summaryTitle } />
 				) }
 
 				{ subTitle && active && <Text sx={ { mb: 3, mt: 2 } }>{ subTitle }</Text> }

--- a/src/system/theme/index.js
+++ b/src/system/theme/index.js
@@ -388,6 +388,11 @@ export default {
 				border: '1px solid',
 				borderColor: 'button.tertiary.border.hover',
 			},
+
+			'&[disabled], &[aria-disabled="true"]': {
+				backgroundColor: 'button.tertiary.background.default',
+				color: 'texts.disabled',
+			},
 		},
 
 		display: {
@@ -417,6 +422,11 @@ export default {
 				color: 'button.ghost.label.hover',
 				border: '1px solid',
 				borderColor: 'transparent',
+			},
+
+			'&[disabled], &[aria-disabled="true"]': {
+				backgroundColor: 'button.ghost.background.default',
+				color: 'texts.disabled',
 			},
 		},
 

--- a/src/system/theme/index.js
+++ b/src/system/theme/index.js
@@ -362,6 +362,30 @@ export default {
 					fill: 'inherit',
 				},
 			},
+			'&[data-danger="true"]': {
+				color: 'button.danger.primary.label.default',
+				bg: 'button.danger.primary.background.default',
+				border: '1px solid',
+				borderColor: 'transparent',
+			},
+
+			'&:hover[data-danger="true"]': {
+				backgroundColor: 'button.danger.primary.background.hover',
+				color: 'button.danger.primary.label.hover',
+				border: '1px solid',
+				borderColor: 'transparent',
+			},
+
+			'&[disabled], &[aria-disabled="true"]': {
+				backgroundColor: 'button.primary.background.disabled',
+				color: 'button.primary.label.disabled',
+				opacity: 0.7,
+			},
+
+			'&[disabled][data-danger="true"], &[aria-disabled="true"][data-danger="true"]': {
+				backgroundColor: 'button.secondary.background.disabled',
+				color: 'button.secondary.label.default',
+			},
 		},
 
 		secondary: {
@@ -372,6 +396,32 @@ export default {
 			'&:hover': {
 				backgroundColor: 'button.secondary.background.hover',
 				color: 'button.secondary.label.hover',
+			},
+
+			'&[data-danger="true"]': {
+				color: 'button.danger.secondary.label.default',
+				bg: 'button.danger.secondary.background.default',
+				border: '1px solid',
+				borderColor: 'button.danger.secondary.border.default',
+			},
+
+			'&:hover[data-danger="true"]': {
+				backgroundColor: 'button.danger.secondary.background.hover',
+				color: 'button.danger.secondary.label.hover',
+				border: '1px solid',
+				borderColor: 'transparent',
+			},
+
+			'&[disabled], &[aria-disabled="true"]': {
+				backgroundColor: 'button.secondary.background.disabled',
+				color: 'button.secondary.label.disabled',
+			},
+
+			'&[disabled][data-danger="true"], &[aria-disabled="true"][data-danger="true"]': {
+				backgroundColor: 'button.danger.secondary.background.default',
+				color: 'button.secondary.label.disabled',
+				border: '1px solid',
+				borderColor: 'button.secondary.border.default',
 			},
 		},
 
@@ -408,6 +458,11 @@ export default {
 				border: '1px solid',
 				borderColor: 'transparent',
 			},
+
+			'&[disabled], &[aria-disabled="true"]': {
+				backgroundColor: 'button.display.background.disabled',
+				color: 'button.display.label.disabled',
+			},
 		},
 
 		ghost: {
@@ -427,6 +482,18 @@ export default {
 			'&[disabled], &[aria-disabled="true"]': {
 				backgroundColor: 'button.ghost.background.default',
 				color: 'texts.disabled',
+			},
+
+			'&[data-danger="true"]': {
+				color: 'button.danger.ghost.label.default',
+				bg: 'button.danger.ghost.background.default',
+			},
+
+			'&:hover[data-danger="true"]': {
+				backgroundColor: 'button.danger.ghost.background.hover',
+				color: 'button.danger.ghost.label.hover',
+				border: '1px solid',
+				borderColor: 'transparent',
 			},
 		},
 


### PR DESCRIPTION
## Description

Based on new Button requests, I'm removing the variant "danger" and using it as a prop. Now we have the primary+danger, secondary+danger and ghost+danger styling, as we have in Figma.

### Storybook

<img width="1564" height="602" alt="image" src="https://github.com/user-attachments/assets/8faf959e-edca-4f7d-8ce8-3a7a7b9f653e" />

### Figma

<img width="1226" height="329" alt="image" src="https://github.com/user-attachments/assets/5673d1b0-dce2-43d9-83e5-1353c7067a77" />

<img width="443" height="311" alt="image" src="https://github.com/user-attachments/assets/065e29f8-c867-48bb-b030-49beb3721609" />



## Checklist

- [ ] This PR has good automated test coverage
- [ ] The storybook for the component has been updated

## Steps to Test

Outline the steps to test and verify the PR here.

Example:

1. Pull down PR.
1. `npm run dev`.
1. Open Storybook.
1. Eat cookies.
1. Verify cookies are delicious.
