### PR TITLE
Make Tooltip arrows optional and update styles

### DIFF
--- a/src/system/Tooltip/Tooltip.css
+++ b/src/system/Tooltip/Tooltip.css
@@ -1,6 +1,33 @@
+:root {
+	--vip-tooltip-box-distance: 4px;
+	--vip-tooltip-color: var(--theme-ui-colors-texts-inverse);
+	--vip-tooltip-bg-color: var(--theme-ui-colors-layer-inverse);
+	--vip-tooltip-font-size: 12px;
+	--vip-tooltip-font-weight: 400;
+	--vip-tooltip-border-radius: 4px;
+	--vip-tooltip-horizontal-padding: 8px;
+	--vip-tooltip-vertical-padding: 4px;
+	--vip-tooltip-max-width: 210px;
+
+	--vip-tooltip-arrow-vertical-padding: 12px; /* creates an invisible area so the mouse can move from the trigger to the tooltip */
+	--vip-tooltip-arrow-horizontal-padding: 50%; /* creates an invisible area so the mouse can move from the trigger to the tooltip */
+}
+
 [data-vip-tooltip] {
+	--vip-tooltip-arrow-opacity: 0;
+	--vip-tooltip-arrow-visible-border: var(--vip-tooltip-box-distance) solid var(--vip-tooltip-bg-color);
+	--vip-tooltip-arrow-invisible-border: min(calc(var(--vip-tooltip-box-distance) - 2px), 10px) solid transparent;
+
 	position: relative;
 	cursor: help;
+  }
+
+  [data-vip-tooltip][data-vip-tooltip-arrow="true"] {
+	--vip-tooltip-box-distance: 8px;
+
+	--vip-tooltip-arrow-vertical-padding: 0;
+	--vip-tooltip-arrow-horizontal-padding: 0;
+	--vip-tooltip-arrow-opacity: 1;
   }
 
   [data-vip-tooltip]::before,
@@ -9,13 +36,18 @@
 	opacity: 0;
 	visibility: hidden;
 	transition: opacity .3s ease-in-out;
+	cursor: default;
   }
 
   [data-vip-tooltip]:focus-within::before,
-  [data-vip-tooltip]:focus-within::after,
-  [data-vip-tooltip]:hover::before,
-  [data-vip-tooltip]:hover::after {
+  [data-vip-tooltip]:hover::before {
 	opacity: 1;
+	visibility: visible;
+  }
+
+  [data-vip-tooltip]:focus-within::after,
+  [data-vip-tooltip]:hover::after {
+	opacity: var(--vip-tooltip-arrow-opacity);
 	visibility: visible;
   }
 
@@ -23,14 +55,13 @@
 	content: attr(data-vip-tooltip);
 	z-index: 9999;
 	width: max-content;
-	max-width: 210px;
-	color: #fff;
-	background: rgba(0,0,0, .7);
-	border-radius: 5px;
-	padding-left: 12px;
-	padding-right: 12px;
-	padding-top: 8px;
-	padding-bottom: 8px;
+	max-width: var(--vip-tooltip-max-width);
+	color: var(--vip-tooltip-color);
+	background: var(--vip-tooltip-bg-color);
+	font-size: var(--vip-tooltip-font-size);
+	font-weight: var(--vip-tooltip-font-weight);
+	border-radius: var(--vip-tooltip-border-radius);
+	padding: var(--vip-tooltip-vertical-padding) var(--vip-tooltip-horizontal-padding);
   }
 
   [data-vip-tooltip]::after {
@@ -44,14 +75,17 @@
 	bottom: 100%;
 	left: 50%;
 	transform: translate(-50%);
-	margin-bottom: 15px;
+  }
+
+  [data-vip-tooltip][data-vip-tooltip-position="top"]::before {
+	margin-bottom: var(--vip-tooltip-box-distance);
   }
 
   [data-vip-tooltip][data-vip-tooltip-position="top"]::after {
-	margin-bottom: 8px;
-	border-left: 5px solid transparent;
-	border-right: 5px solid transparent;
-	border-top: 7px solid rgba(0,0,0, .7);
+	border-left: var(--vip-tooltip-arrow-invisible-border);
+	border-right: var(--vip-tooltip-arrow-invisible-border);
+	border-top: var(--vip-tooltip-arrow-visible-border);
+	padding: 0 var(--vip-tooltip-arrow-horizontal-padding);
   }
 
   [data-vip-tooltip][data-vip-tooltip-position="bottom"]::before,
@@ -59,14 +93,17 @@
 	top: 100%;
 	left: 50%;
 	transform: translate(-50%);
-	margin-top: 15px;
+  }
+
+  [data-vip-tooltip][data-vip-tooltip-position="bottom"]::before {
+	margin-top: var(--vip-tooltip-box-distance);
   }
 
   [data-vip-tooltip][data-vip-tooltip-position="bottom"]::after {
-	margin-top: 8px;
-	border-left: 5px solid transparent;
-	border-right: 5px solid transparent;
-	border-bottom: 7px solid rgba(0,0,0, .7);
+	border-left: var(--vip-tooltip-arrow-invisible-border);
+	border-right: var(--vip-tooltip-arrow-invisible-border);
+	border-bottom: var(--vip-tooltip-arrow-visible-border);
+	padding: 0 var(--vip-tooltip-arrow-horizontal-padding);
   }
 
   [data-vip-tooltip][data-vip-tooltip-position="right"]::before,
@@ -74,14 +111,17 @@
 	top: 50%;
 	left: 100%;
 	transform: translate(0, -50%);
-	margin-left: 15px;
+  }
+
+  [data-vip-tooltip][data-vip-tooltip-position="right"]::before {
+	margin-left: var(--vip-tooltip-box-distance);
   }
 
   [data-vip-tooltip][data-vip-tooltip-position="right"]::after {
-	margin-left: 8px;
-	border-top: 5px solid transparent;
-	border-right: 7px solid rgba(0,0,0, .7);
-	border-bottom: 5px solid transparent;
+	border-top: var(--vip-tooltip-arrow-invisible-border);
+	border-right: var(--vip-tooltip-arrow-visible-border);
+	border-bottom: var(--vip-tooltip-arrow-invisible-border);
+	padding: var(--vip-tooltip-arrow-vertical-padding) 0;
   }
 
   [data-vip-tooltip][data-vip-tooltip-position="left"]::before,
@@ -89,12 +129,15 @@
 	top: 50%;
 	right: 100%;
 	transform: translate(0, -50%);
-	margin-right: 15px;
+  }
+
+  [data-vip-tooltip][data-vip-tooltip-position="left"]::before {
+	margin-right: var(--vip-tooltip-box-distance);
   }
 
   [data-vip-tooltip][data-vip-tooltip-position="left"]::after {
-	margin-right: 8px;
-	border-top: 5px solid transparent;
-	border-left: 7px solid rgba(0,0,0, .7);
-	border-bottom: 5px solid transparent;
+	border-top: var(--vip-tooltip-arrow-invisible-border);
+	border-left: var(--vip-tooltip-arrow-visible-border);
+	border-bottom: var(--vip-tooltip-arrow-invisible-border);
+	padding: var(--vip-tooltip-arrow-vertical-padding) 0;
   }

--- a/src/system/Tooltip/Tooltip.stories.tsx
+++ b/src/system/Tooltip/Tooltip.stories.tsx
@@ -1,7 +1,7 @@
 /**
  * Internal dependencies
  */
-import {Tooltip, Button, Heading, Text, Link, Box, Grid} from '..';
+import { Tooltip, Button, Heading, Text, Link, Box, Grid } from '..';
 
 export default {
 	title: 'Tooltip',
@@ -117,11 +117,7 @@ export const Basic = () => (
 				arrow={ true }
 			/>
 
-			<Tooltip
-				trigger={ <Button>Right</Button> }
-				title="On the Right"
-				position="right"
-			/>
+			<Tooltip trigger={ <Button>Right</Button> } title="On the Right" position="right" />
 
 			<Tooltip
 				trigger={ <Button>Right with Arrow</Button> }

--- a/src/system/Tooltip/Tooltip.stories.tsx
+++ b/src/system/Tooltip/Tooltip.stories.tsx
@@ -1,7 +1,7 @@
 /**
  * Internal dependencies
  */
-import { Tooltip, Button, Heading, Text, Link, Box } from '..';
+import {Tooltip, Button, Heading, Text, Link, Box, Grid} from '..';
 
 export default {
 	title: 'Tooltip',
@@ -73,30 +73,63 @@ export const Basic = () => (
 			Pass a trigger and title, the trigger component will be cloned and injected with a{ ' ' }
 			<code>[vip-tooltip]</code> HTML attribute.
 		</Text>
+		<Grid
+			columns={ [ 'repeat(2, minmax(max-content, 1fr))' ] }
+			gap={ '100px 200px' }
+			padding={ '100px 200px' }
+		>
+			<Tooltip
+				trigger={ <Button sx={ { mr: 3 } }>Top</Button> }
+				title="At the top"
+				position="top"
+			/>
 
-		<Tooltip
-			trigger={ <Button sx={ { mr: 3 } }>Button with top tooltip</Button> }
-			title="On the top"
-			position="top"
-		/>
+			<Tooltip
+				trigger={ <Button sx={ { mr: 3 } }>Top with Arrow</Button> }
+				title="At the top with arrow"
+				position="top"
+				arrow={ true }
+			/>
 
-		<Tooltip
-			trigger={ <Button sx={ { mr: 3 } }>Button with bottom tooltip</Button> }
-			title="On the Bottom"
-			position="bottom"
-		/>
+			<Tooltip
+				trigger={ <Button sx={ { mr: 3 } }>Bottom</Button> }
+				title="At the Bottom"
+				position="bottom"
+			/>
 
-		<Tooltip
-			trigger={ <Button sx={ { mr: 3 } }>Button with left tooltip</Button> }
-			title="On the Left"
-			position="left"
-		/>
+			<Tooltip
+				trigger={ <Button sx={ { mr: 3 } }>Bottom with Arrow</Button> }
+				title="At the Bottom with arrow"
+				position="bottom"
+				arrow={ true }
+			/>
 
-		<Tooltip
-			trigger={ <Button>Button with right tooltip</Button> }
-			title="On the Right"
-			position="right"
-		/>
+			<Tooltip
+				trigger={ <Button sx={ { mr: 3 } }>Left</Button> }
+				title="On the Left"
+				position="left"
+			/>
+
+			<Tooltip
+				trigger={ <Button sx={ { mr: 3 } }>Left with Arrow</Button> }
+				title="On the Left with arrow"
+				position="left"
+				arrow={ true }
+			/>
+
+			<Tooltip
+				trigger={ <Button>Right</Button> }
+				title="On the Right"
+				position="right"
+			/>
+
+			<Tooltip
+				trigger={ <Button>Right with Arrow</Button> }
+				title="On the Right with arrow"
+				position="right"
+				arrow={ true }
+			/>
+		</Grid>
 	</>
 );
 
@@ -111,6 +144,8 @@ export const Container = () => (
 
 		<Box sx={ { backgroundColor: 'red' } }>
 			<Tooltip>
+				<br />
+
 				<Button data-vip-tooltip-position="top" data-vip-tooltip="Test test" sx={ { ml: 3 } }>
 					This is another way
 				</Button>
@@ -122,7 +157,8 @@ export const Container = () => (
 				<Link
 					href="http://google.com"
 					data-vip-tooltip-position="right"
-					data-vip-tooltip="is simply dummy text of the printing and typesetting industry. Lorem Ipsum has been the industry's standard dummy text ever since the 1500"
+					data-vip-tooltip-arrow="true"
+					data-vip-tooltip="Lorem Ipsum has been the industry's standard dummy text ever since the 1500"
 					sx={ { ml: 3 } }
 				>
 					Use with links too

--- a/src/system/Tooltip/Tooltip.stories.tsx
+++ b/src/system/Tooltip/Tooltip.stories.tsx
@@ -74,44 +74,32 @@ export const Basic = () => (
 			<code>[vip-tooltip]</code> HTML attribute.
 		</Text>
 		<Grid
-			columns={ [ 'repeat(2, minmax(max-content, 1fr))' ] }
-			gap={ '100px 200px' }
-			padding={ '100px 200px' }
+			columns={ [ 'auto auto' ] }
+			gap={ '100px 160px' }
+			sx={ { justifyContent: 'center', pt: '50px' } }
 		>
-			<Tooltip
-				trigger={ <Button sx={ { mr: 3 } }>Top</Button> }
-				title="At the top"
-				position="top"
-			/>
+			<Tooltip trigger={ <Button>Top</Button> } title="At the top" position="top" />
 
 			<Tooltip
-				trigger={ <Button sx={ { mr: 3 } }>Top with Arrow</Button> }
+				trigger={ <Button>Top with Arrow</Button> }
 				title="At the top with arrow"
 				position="top"
 				arrow={ true }
 			/>
 
-			<Tooltip
-				trigger={ <Button sx={ { mr: 3 } }>Bottom</Button> }
-				title="At the Bottom"
-				position="bottom"
-			/>
+			<Tooltip trigger={ <Button>Bottom</Button> } title="At the Bottom" position="bottom" />
 
 			<Tooltip
-				trigger={ <Button sx={ { mr: 3 } }>Bottom with Arrow</Button> }
+				trigger={ <Button>Bottom with Arrow</Button> }
 				title="At the Bottom with arrow"
 				position="bottom"
 				arrow={ true }
 			/>
 
-			<Tooltip
-				trigger={ <Button sx={ { mr: 3 } }>Left</Button> }
-				title="On the Left"
-				position="left"
-			/>
+			<Tooltip trigger={ <Button>Left</Button> } title="On the Left" position="left" />
 
 			<Tooltip
-				trigger={ <Button sx={ { mr: 3 } }>Left with Arrow</Button> }
+				trigger={ <Button>Left with Arrow</Button> }
 				title="On the Left with arrow"
 				position="left"
 				arrow={ true }
@@ -123,6 +111,27 @@ export const Basic = () => (
 				trigger={ <Button>Right with Arrow</Button> }
 				title="On the Right with arrow"
 				position="right"
+				arrow={ true }
+			/>
+
+			<Tooltip
+				trigger={
+					<Button disabled={ true } preferAriaDisabled={ true }>
+						Disabled (use focus)
+					</Button>
+				}
+				title="Disabled trigger"
+				position="top"
+			/>
+
+			<Tooltip
+				trigger={
+					<Button disabled={ true } preferAriaDisabled={ true }>
+						Disabled with Arrow (use focus)
+					</Button>
+				}
+				title="Disabled trigger with arrow"
+				position="top"
 				arrow={ true }
 			/>
 		</Grid>

--- a/src/system/Tooltip/Tooltip.tsx
+++ b/src/system/Tooltip/Tooltip.tsx
@@ -13,6 +13,7 @@ export interface TooltipProps {
 	title?: string;
 	trigger?: ReactElement;
 	position?: 'top' | 'bottom' | 'left' | 'right';
+	arrow?: boolean;
 }
 
 const Tooltip = ( {
@@ -20,12 +21,14 @@ const Tooltip = ( {
 	trigger,
 	children,
 	position = 'top',
+	arrow = false,
 }: PropsWithChildren< TooltipProps > ) => {
 	const triggerCloned = trigger
 		? cloneElement( trigger, {
 				'data-vip-tooltip': title,
 				'aria-label': title,
 				'data-vip-tooltip-position': position,
+				'data-vip-tooltip-arrow': `${ arrow }`,
 		  } )
 		: null;
 


### PR DESCRIPTION
## Description

- Make `Tooltip` arrows optional (false by default)
- Update styles

#### Requirements
- https://a8c.slack.com/archives/C013N7TDZAT/p1753365107303139?thread_ts=1749223140.127729&cid=C013N7TDZAT
   <img height="200" src="https://github.com/user-attachments/assets/edf8fdee-d36d-4941-ad91-a59644c3c7b8" />

- https://a8c.slack.com/archives/C013N7TDZAT/p1755075710032819?thread_ts=1749223140.127729&cid=C013N7TDZAT
   <img  height="200" src="https://github.com/user-attachments/assets/1c5289b4-3412-4da5-bf8f-11d17429a9a4" />


## Preview

<img width="1870" height="1408" alt="Screenshot_2025-08-13_6 -08-53" src="https://github.com/user-attachments/assets/e9a27617-66bf-47b2-a16a-1ce9b85649b2" />