### PR TITLE
Autocomplete Allow Custom

### DIFF
--- a/src/system/NewForm/FormAutocomplete.js
+++ b/src/system/NewForm/FormAutocomplete.js
@@ -85,6 +85,12 @@ const inlineStyles = {
 	borderWidth: 0,
 };
 
+const allowCustomStyles = {
+	'& .autocomplete__option--no-results': {
+		cursor: 'pointer',
+	},
+};
+
 const searchIconStyles = {
 	'& .autocomplete__input.autocomplete__input': {
 		paddingLeft: 6,
@@ -120,6 +126,7 @@ const FormAutocomplete = React.forwardRef(
 			resetOnBlur = false, // resets the input value to the selection if the input is blurred. Returns null if selection is empty
 			source,
 			value,
+			allowCustom = false,
 			...props
 		},
 		forwardRef
@@ -199,9 +206,13 @@ const FormAutocomplete = React.forwardRef(
 
 		const handleTypeChange = useCallback(
 			query => {
-				return options.filter(
+				const filteredOptions = options.filter(
 					option => optionLabel( option ).toLowerCase().indexOf( query.toLowerCase() ) >= 0
 				);
+				if ( allowCustom && filteredOptions.length === 0 ) {
+					return [ { label: query, value: query } ];
+				}
+				return filteredOptions;
 			},
 			[ options ]
 		);
@@ -319,6 +330,7 @@ const FormAutocomplete = React.forwardRef(
 						...defaultStyles,
 						...( isInline && inlineStyles ),
 						...( searchIcon && searchIconStyles ),
+						...( allowCustom && allowCustomStyles ),
 						...( hasError ? { borderColor: 'input.border.error' } : {} ),
 					} }
 				>
@@ -382,6 +394,7 @@ FormAutocomplete.propTypes = {
 	source: PropTypes.func,
 	value: PropTypes.string,
 	dropdownArrow: PropTypes.node,
+	allowCustom: PropTypes.bool,
 };
 
 FormAutocomplete.displayName = 'FormAutocomplete';

--- a/src/system/NewForm/FormAutocomplete.stories.jsx
+++ b/src/system/NewForm/FormAutocomplete.stories.jsx
@@ -67,6 +67,12 @@ const DefaultComponent = ( { label = 'Label', width = 250, ...rest } ) => {
 export const Default = DefaultComponent.bind( {} );
 Default.args = args;
 
+export const WithAllowCustom = DefaultComponent.bind( {} );
+WithAllowCustom.args = {
+	...Default.args,
+	allowCustom: true,
+};
+
 export const Inline = DefaultComponent.bind( {} );
 Inline.args = {
 	...Default.args,

--- a/src/system/NewForm/FormAutocompleteMultiselect.js
+++ b/src/system/NewForm/FormAutocompleteMultiselect.js
@@ -155,6 +155,7 @@ const FormAutocompleteMultiselect = React.forwardRef(
 			value,
 			listType = 'button',
 			initialValue = [],
+			allowCustom = false,
 			...props
 		},
 		forwardRef
@@ -220,6 +221,10 @@ const FormAutocompleteMultiselect = React.forwardRef(
 
 		const onValueChange = useCallback(
 			inputValue => {
+				// if ( allowCustom && ! selectedOptions.includes( inputValue ) ) {
+				// 	setCurrentOption( { action: OPTION_ACTION.ADD, option: inputValue } );
+				// 	setSelectedOptions( [ ...selectedOptions, inputValue ] );
+				// }
 				if ( inputValue && ! selectedOptions.includes( inputValue ) ) {
 					setCurrentOption( { action: OPTION_ACTION.ADD, option: inputValue } );
 					setSelectedOptions( [ ...selectedOptions, inputValue ] );
@@ -245,11 +250,16 @@ const FormAutocompleteMultiselect = React.forwardRef(
 		);
 
 		const handleTypeChange = useCallback(
-			query =>
-				options.filter(
+			query => {
+				const filteredOptions = options.filter(
 					option => optionLabel( option ).toLowerCase().indexOf( query.toLowerCase() ) >= 0
-				),
-			[ options ]
+				);
+				if ( allowCustom && filteredOptions.length === 0 ) {
+					return [ { label: query, value: query } ];
+				}
+				return filteredOptions;
+			},
+			[ options, allowCustom ]
 		);
 
 		const handleInputChange = useCallback(
@@ -384,7 +394,7 @@ const FormAutocompleteMultiselect = React.forwardRef(
 						</Validation>
 					) }
 					<div sx={ { fontSize: 1 } }>
-						{ selectedOptions.length } item{ selectedOptions.length > 1 ? 's' : '' } selected
+						{ selectedOptions.length } item{ selectedOptions.length === 1 ? '' : 's' } selected
 					</div>
 				</Flex>
 				<div sx={ { display: 'inline-flex', flexWrap: 'wrap', maxWidth: '100%' } }>
@@ -428,6 +438,7 @@ FormAutocompleteMultiselect.propTypes = {
 	value: PropTypes.string,
 	dropdownArrow: PropTypes.node,
 	initialValue: PropTypes.array,
+	allowCustom: PropTypes.bool,
 };
 
 FormAutocompleteMultiselect.displayName = 'FormAutocompleteMultiselect';

--- a/src/system/NewForm/FormAutocompleteMultiselect.js
+++ b/src/system/NewForm/FormAutocompleteMultiselect.js
@@ -221,10 +221,6 @@ const FormAutocompleteMultiselect = React.forwardRef(
 
 		const onValueChange = useCallback(
 			inputValue => {
-				// if ( allowCustom && ! selectedOptions.includes( inputValue ) ) {
-				// 	setCurrentOption( { action: OPTION_ACTION.ADD, option: inputValue } );
-				// 	setSelectedOptions( [ ...selectedOptions, inputValue ] );
-				// }
 				if ( inputValue && ! selectedOptions.includes( inputValue ) ) {
 					setCurrentOption( { action: OPTION_ACTION.ADD, option: inputValue } );
 					setSelectedOptions( [ ...selectedOptions, inputValue ] );

--- a/src/system/NewForm/FormAutocompleteMultiselect.stories.jsx
+++ b/src/system/NewForm/FormAutocompleteMultiselect.stories.jsx
@@ -86,6 +86,15 @@ export const Default = () => {
 	);
 };
 
+export const WithAllowCustom = () => {
+	const customArgs = {
+		...args,
+		allowCustom: true,
+	};
+
+	return <DefaultComponent { ...customArgs } />;
+};
+
 export const WithBadges = () => {
 	const customArgs = {
 		...args,


### PR DESCRIPTION
## Description

- Add allowCustom prop on `<FormAutocomplete />` and `<FormAutocompleteMulti />`

<img width="318" height="154" alt="image" src="https://github.com/user-attachments/assets/fc42018f-3f8f-4175-9751-c6a1c280c61e" /><br />

<img width="311" height="222" alt="image" src="https://github.com/user-attachments/assets/502e7294-ea03-45e6-9893-456ee6939b55" /><br />

<img width="303" height="140" alt="image" src="https://github.com/user-attachments/assets/1b4c5eff-60bf-45de-bf8f-ac341a73f717" />


## Checklist

- [ ] This PR has good automated test coverage
- [ ] The storybook for the component has been updated

## Steps to Test

Outline the steps to test and verify the PR here.

Example:

1. Pull down PR.
1. `npm run dev`.
1. Open Storybook.
1. Eat cookies.
1. Verify cookies are delicious.
