### PR TITLE
Fixed Dropdown disabled state

### DIFF
--- a/src/system/Dropdown/Dropdown.stories.jsx
+++ b/src/system/Dropdown/Dropdown.stories.jsx
@@ -55,7 +55,9 @@ export const ComplexOptions = () => {
 			<Dropdown.Root trigger={ <Button>See options</Button> }>
 				<Dropdown.Item>New Tab</Dropdown.Item>
 				<Dropdown.Item>New Window</Dropdown.Item>
-				<Dropdown.Item disabled>New Private Window</Dropdown.Item>
+				<Dropdown.Item disabled onSelect={ () => console.log( 'disabled' ) }>
+					New Private Window
+				</Dropdown.Item>
 				<Dropdown.Sub>
 					<Dropdown.SubTrigger>
 						More Tools

--- a/src/system/Dropdown/Dropdown.stories.jsx
+++ b/src/system/Dropdown/Dropdown.stories.jsx
@@ -1,3 +1,4 @@
+/* eslint-disable no-console */
 /**
  * External dependencies
  */

--- a/src/system/Dropdown/DropdownItem.tsx
+++ b/src/system/Dropdown/DropdownItem.tsx
@@ -43,7 +43,8 @@ export const styles: ThemeUIStyleObject = {
 	},
 	'&[data-disabled]': {
 		color: 'muted',
-		pointerEvents: 'none',
+		pointerEvents: 'auto',
+		cursor: 'not-allowed',
 	},
 	'&[data-highlighted]': {
 		backgroundColor: 'hover',
@@ -91,9 +92,10 @@ export const DropdownRadioItem = React.forwardRef< HTMLDivElement, DropdownRadio
 DropdownRadioItem.displayName = 'DropdownRadioItem';
 
 export const DropdownSubTrigger = React.forwardRef< HTMLDivElement, DropdownSubTriggerItemProps >(
-	( { className, ...props }, forwardRef ) => (
+	( { className, disabled, ...props }, forwardRef ) => (
 		<DropdownMenuPrimitive.SubTrigger
 			className={ classNames( 'vip-dropdown-sub-trigger', className ) }
+			disabled={ disabled }
 			ref={ forwardRef }
 			sx={ {
 				...styles,
@@ -103,6 +105,10 @@ export const DropdownSubTrigger = React.forwardRef< HTMLDivElement, DropdownSubT
 						color: 'primary',
 					},
 				},
+				...( disabled && {
+					cursor: 'not-allowed',
+					color: 'muted',
+				} ),
 			} }
 			{ ...props }
 		/>


### PR DESCRIPTION
## Description

- Fixed state adding `cursor: not-allowed` on `<Dropdown.Item />` component

<img width="264" height="347" alt="image" src="https://github.com/user-attachments/assets/67d1461b-6326-4f6a-adae-1a30222f1bdf" />

## Checklist

- [ ] This PR has good automated test coverage
- [ ] The storybook for the component has been updated

## Steps to Test

Outline the steps to test and verify the PR here.

Example:

1. Pull down PR.
1. `npm run dev`.
1. Open Storybook.
1. Eat cookies.
1. Verify cookies are delicious.
