### PR TITLE
Add FormAutocompleteMultiselectSentinel component

### DIFF
--- a/src/system/NewForm/FormAutocompleteMultiselectSentinel.stories.tsx
+++ b/src/system/NewForm/FormAutocompleteMultiselectSentinel.stories.tsx
@@ -1,0 +1,493 @@
+/** @jsxImportSource theme-ui */
+
+/**
+ * External dependencies
+ */
+import { useCallback, useEffect, useState } from 'react';
+
+/**
+ * Internal dependencies
+ */
+import * as Form from '.';
+import {
+	FormAutocompleteMultiselectSentinel,
+	type ComboboxItem,
+} from './FormAutocompleteMultiselectSentinel';
+
+export default {
+	title: 'Form/AutocompleteMultiSentinel',
+	component: FormAutocompleteMultiselectSentinel,
+	argTypes: {
+		// ── Async data fetching ──────────────────────────────────────────────────
+		onFetchItems: {
+			description:
+				'Scroll-triggered pagination callback. Receives the zero-based page number and returns a promise that resolves to a page of items. Required to enable async mode.',
+			table: { category: 'Async data fetching' },
+		},
+		onFetchLabels: {
+			description:
+				'Lightweight label-only fetch used by the two-stage type-ahead search. Returns `{ id, label }` pairs for one page. Provide alongside `onFetchByIds` to enable two-stage mode; if either is absent the component falls back to debounced `onFetchItems` calls.',
+			table: { category: 'Async data fetching' },
+		},
+		onFetchByIds: {
+			description:
+				'Targeted full-item fetch for the second stage of type-ahead search. Receives an array of IDs whose labels matched the query and returns the corresponding full `ComboboxItem` objects.',
+			table: { category: 'Async data fetching' },
+		},
+		pageSize: {
+			description:
+				'Number of items per page. The component detects end-of-results when a returned page contains fewer items than this value. Default: `100`.',
+			control: { type: 'number' },
+			table: { category: 'Async data fetching', defaultValue: { summary: 100 } },
+		},
+		debounce: {
+			description:
+				'Debounce delay in milliseconds applied to the type-ahead search in async mode. Increasing this value reduces the number of fetch calls made while the user is still typing. Default: `300`.',
+			control: { type: 'number' },
+			table: { category: 'Async data fetching', defaultValue: { summary: 300 } },
+		},
+		// ── Static options ───────────────────────────────────────────────────────
+		options: {
+			description:
+				'Static list of `{ id, label }` items shown in the dropdown. Used when `onFetchItems` is not provided.',
+			table: { category: 'Static options' },
+		},
+		initialValue: {
+			description: 'Items that are pre-selected when the component first renders.',
+			table: { category: 'Static options' },
+		},
+		// ── Field labelling & help ───────────────────────────────────────────────
+		label: {
+			description:
+				'Label text displayed above the input, or inline when `isInline` is true. Accepts a string or any React node.',
+			control: { type: 'text' },
+			table: { category: 'Field labelling & help' },
+		},
+		forLabel: {
+			description:
+				'The `id` applied to the input element. Used to associate the input with its label and for ARIA attributes. Auto-generated if omitted.',
+			control: { type: 'text' },
+			table: { category: 'Field labelling & help' },
+		},
+		helperText: {
+			description: 'Optional hint text rendered below the input.',
+			control: { type: 'text' },
+			table: { category: 'Field labelling & help' },
+		},
+		placeholder: {
+			description:
+				'Placeholder text shown inside the input when nothing has been typed. Default: `"Search…"`.',
+			control: { type: 'text' },
+			table: { category: 'Field labelling & help', defaultValue: { summary: 'Search…' } },
+		},
+		isInline: {
+			description: 'Renders the label inline inside the input field rather than above it.',
+			control: { type: 'boolean' },
+			table: { category: 'Field labelling & help' },
+		},
+		// ── Validation & error ───────────────────────────────────────────────────
+		required: {
+			description:
+				'Marks the field as required. Adds a required indicator to the label and sets `aria-required` on the input.',
+			control: { type: 'boolean' },
+			table: { category: 'Validation & error' },
+		},
+		hasError: {
+			description:
+				'When true, renders the input with an error border and displays the `errorMessage`.',
+			control: { type: 'boolean' },
+			table: { category: 'Validation & error' },
+		},
+		errorMessage: {
+			description:
+				'Validation error message displayed below the input. Only visible when `hasError` is true.',
+			control: { type: 'text' },
+			table: { category: 'Validation & error' },
+		},
+		// ── Appearance ───────────────────────────────────────────────────────────
+		listType: {
+			description:
+				'Controls how selected items are displayed below the input. `"button"` renders removable pill buttons; `"badge"` renders compact inline badges. Default: `"button"`.',
+			control: { type: 'radio' },
+			options: [ 'button', 'badge' ],
+			table: {
+				category: 'Appearance',
+				defaultValue: { summary: 'button' },
+			},
+		},
+		searchIcon: {
+			description: 'When true, shows a search icon on the left side of the input field.',
+			control: { type: 'boolean' },
+			table: { category: 'Appearance' },
+		},
+		loading: {
+			description:
+				'When true, shows a spinner inside the input to indicate an external loading state.',
+			control: { type: 'boolean' },
+			table: { category: 'Appearance' },
+		},
+		// ── Callbacks ────────────────────────────────────────────────────────────
+		onChange: {
+			description:
+				'Called whenever the selection changes with two arguments: `selectedOptions` (full `ComboboxItem[]`) and `labels` (string array of selected labels). Matches the original two-argument signature for compatibility.',
+			table: { category: 'Callbacks' },
+		},
+		noOptionsMessage: {
+			description:
+				'Function that returns the message shown in the dropdown when no options match the current input value. Default: `() => "No results found."`.',
+			table: { category: 'Callbacks' },
+		},
+		// ── HTML passthrough ─────────────────────────────────────────────────────
+		className: {
+			description: 'Additional CSS class name applied to the root element.',
+			control: { type: 'text' },
+			table: { category: 'HTML passthrough' },
+		},
+	},
+};
+
+// ── Shared data ───────────────────────────────────────────────────────────────
+
+const FLAVORS: ComboboxItem[] = [
+	{ id: 1, label: 'Chocolate' },
+	{ id: 2, label: 'Strawberry' },
+	{ id: 3, label: 'Vanilla' },
+	{ id: 4, label: 'Pistachio' },
+	{ id: 5, label: 'Bubblegum' },
+	{ id: 6, label: 'Ube' },
+	{ id: 7, label: 'Mango' },
+	{ id: 8, label: 'Buko' },
+	{ id: 9, label: 'Durian' },
+	{ id: 10, label: 'Leche Flan' },
+];
+
+const COUNTRIES: ComboboxItem[] = [
+	{ id: 1, label: 'Afghanistan' },
+	{ id: 2, label: 'Albania' },
+	{ id: 3, label: 'Algeria' },
+	{ id: 4, label: 'Andorra' },
+	{ id: 5, label: 'Angola' },
+	{ id: 6, label: 'Argentina' },
+	{ id: 7, label: 'Armenia' },
+	{ id: 8, label: 'Australia' },
+	{ id: 9, label: 'Austria' },
+	{ id: 10, label: 'Azerbaijan' },
+	{ id: 11, label: 'Bahrain' },
+	{ id: 12, label: 'Bangladesh' },
+	{ id: 13, label: 'Belarus' },
+	{ id: 14, label: 'Belgium' },
+	{ id: 15, label: 'Bolivia' },
+	{ id: 16, label: 'Bosnia and Herzegovina' },
+	{ id: 17, label: 'Brazil' },
+	{ id: 18, label: 'Bulgaria' },
+	{ id: 19, label: 'Cambodia' },
+	{ id: 20, label: 'Cameroon' },
+	{ id: 21, label: 'Canada' },
+	{ id: 22, label: 'Chile' },
+	{ id: 23, label: 'China' },
+	{ id: 24, label: 'Colombia' },
+	{ id: 25, label: 'Croatia' },
+	{ id: 26, label: 'Cuba' },
+	{ id: 27, label: 'Cyprus' },
+	{ id: 28, label: 'Czech Republic' },
+	{ id: 29, label: 'Denmark' },
+	{ id: 30, label: 'Dominican Republic' },
+	{ id: 31, label: 'Ecuador' },
+	{ id: 32, label: 'Egypt' },
+	{ id: 33, label: 'Estonia' },
+	{ id: 34, label: 'Ethiopia' },
+	{ id: 35, label: 'Finland' },
+	{ id: 36, label: 'France' },
+	{ id: 37, label: 'Georgia' },
+	{ id: 38, label: 'Germany' },
+	{ id: 39, label: 'Ghana' },
+	{ id: 40, label: 'Greece' },
+	{ id: 41, label: 'Guatemala' },
+	{ id: 42, label: 'Hungary' },
+	{ id: 43, label: 'Iceland' },
+	{ id: 44, label: 'India' },
+	{ id: 45, label: 'Indonesia' },
+	{ id: 46, label: 'Iran' },
+	{ id: 47, label: 'Iraq' },
+	{ id: 48, label: 'Ireland' },
+	{ id: 49, label: 'Israel' },
+	{ id: 50, label: 'Italy' },
+	{ id: 51, label: 'Jamaica' },
+	{ id: 52, label: 'Japan' },
+	{ id: 53, label: 'Jordan' },
+	{ id: 54, label: 'Kazakhstan' },
+	{ id: 55, label: 'Kenya' },
+	{ id: 56, label: 'Latvia' },
+	{ id: 57, label: 'Lebanon' },
+	{ id: 58, label: 'Lithuania' },
+	{ id: 59, label: 'Luxembourg' },
+	{ id: 60, label: 'Malaysia' },
+	{ id: 61, label: 'Mexico' },
+	{ id: 62, label: 'Morocco' },
+	{ id: 63, label: 'Netherlands' },
+	{ id: 64, label: 'New Zealand' },
+	{ id: 65, label: 'Nigeria' },
+	{ id: 66, label: 'Norway' },
+	{ id: 67, label: 'Pakistan' },
+	{ id: 68, label: 'Peru' },
+	{ id: 69, label: 'Philippines' },
+	{ id: 70, label: 'Poland' },
+	{ id: 71, label: 'Portugal' },
+	{ id: 72, label: 'Romania' },
+	{ id: 73, label: 'Russia' },
+	{ id: 74, label: 'Saudi Arabia' },
+	{ id: 75, label: 'Serbia' },
+	{ id: 76, label: 'Singapore' },
+	{ id: 77, label: 'Slovakia' },
+	{ id: 78, label: 'Slovenia' },
+	{ id: 79, label: 'South Africa' },
+	{ id: 80, label: 'South Korea' },
+	{ id: 81, label: 'Spain' },
+	{ id: 82, label: 'Sweden' },
+	{ id: 83, label: 'Switzerland' },
+	{ id: 84, label: 'Thailand' },
+	{ id: 85, label: 'Tunisia' },
+	{ id: 86, label: 'Turkey' },
+	{ id: 87, label: 'Ukraine' },
+	{ id: 88, label: 'United Arab Emirates' },
+	{ id: 89, label: 'United Kingdom' },
+	{ id: 90, label: 'United States' },
+	{ id: 91, label: 'Uruguay' },
+	{ id: 92, label: 'Venezuela' },
+	{ id: 93, label: 'Vietnam' },
+	{ id: 94, label: 'Yemen' },
+	{ id: 95, label: 'Zimbabwe' },
+];
+
+const PAGE_SIZE = 20;
+
+// ── Stories ───────────────────────────────────────────────────────────────────
+
+/**
+ * Static list of options — no async fetching.
+ */
+export const Default = () => {
+	const [ selected, setSelected ] = useState< ComboboxItem[] >( [] );
+	return (
+		<Form.Root>
+			<div sx={ { width: 320 } }>
+				<FormAutocompleteMultiselectSentinel
+					forLabel="sentinel-default"
+					label="Ice Cream Flavors"
+					options={ FLAVORS }
+					placeholder="Search flavors…"
+					required
+					onChange={ ( items, labels ) => {
+						setSelected( items );
+						// eslint-disable-next-line no-console
+						console.log( 'onChange labels:', labels );
+					} }
+				/>
+			</div>
+			<div sx={ { mt: 3, fontSize: 1 } }>
+				Selected: { selected.map( i => i.label ).join( ', ' ) || 'none' }
+			</div>
+		</Form.Root>
+	);
+};
+
+/**
+ * Pre-selected items supplied via initialValue.
+ */
+export const WithInitialValue = () => (
+	<Form.Root>
+		<div sx={ { width: 320 } }>
+			<FormAutocompleteMultiselectSentinel
+				forLabel="sentinel-initial"
+				label="Ice Cream Flavors"
+				options={ FLAVORS }
+				initialValue={ FLAVORS.slice( 0, 2 ) }
+			/>
+		</div>
+	</Form.Root>
+);
+
+/**
+ * Selected items rendered as badges instead of buttons.
+ */
+export const WithBadges = () => (
+	<Form.Root>
+		<div sx={ { width: 320 } }>
+			<FormAutocompleteMultiselectSentinel
+				forLabel="sentinel-badges"
+				label="Ice Cream Flavors"
+				options={ FLAVORS }
+				listType="badge"
+			/>
+		</div>
+	</Form.Root>
+);
+
+/**
+ * Error and validation message.
+ */
+export const WithValidationError = () => (
+	<Form.Root>
+		<div sx={ { width: 320 } }>
+			<FormAutocompleteMultiselectSentinel
+				forLabel="sentinel-error"
+				label="Select domains"
+				options={ FLAVORS }
+				required
+				hasError
+				errorMessage="At least one selection is required."
+				searchIcon
+			/>
+		</div>
+	</Form.Root>
+);
+
+/**
+ * Label rendered inline with the input.
+ */
+export const Inline = () => (
+	<Form.Root>
+		<div sx={ { width: 400 } }>
+			<FormAutocompleteMultiselectSentinel
+				forLabel="sentinel-inline"
+				label="Flavors"
+				options={ FLAVORS }
+				isInline
+			/>
+		</div>
+	</Form.Root>
+);
+
+/**
+ * Async pagination — scroll to the bottom of the dropdown to load more items.
+ * Each page has a simulated 800 ms delay.
+ */
+export const AsyncPagination = () => {
+	const fetchItems = useCallback( async ( page: number ): Promise< ComboboxItem[] > => {
+		await new Promise< void >( resolve => setTimeout( resolve, 800 ) );
+		const start = page * PAGE_SIZE;
+		return COUNTRIES.slice( start, start + PAGE_SIZE );
+	}, [] );
+
+	return (
+		<Form.Root>
+			<div sx={ { width: 320 } }>
+				<FormAutocompleteMultiselectSentinel
+					forLabel="sentinel-async"
+					label="Select Countries"
+					onFetchItems={ fetchItems }
+					pageSize={ PAGE_SIZE }
+					placeholder="Search countries…"
+					helperText="Scroll to the bottom of the list to load more countries."
+				/>
+			</div>
+		</Form.Root>
+	);
+};
+
+/**
+ * Two-stage type-ahead search — labels are scanned across all pages first,
+ * then full items are fetched only for matching IDs.
+ *
+ * Try "vi" — Bolivia is in page 1 (already loaded), Vietnam is in page 5
+ * (discovered via the label scan).
+ */
+export const AsyncTwoStageSearch = () => {
+	const fetchItems = useCallback( async ( page: number ): Promise< ComboboxItem[] > => {
+		await new Promise< void >( resolve => setTimeout( resolve, 1200 ) );
+		const start = page * PAGE_SIZE;
+		return COUNTRIES.slice( start, start + PAGE_SIZE );
+	}, [] );
+
+	const fetchLabels = useCallback(
+		async ( page: number ): Promise< Array< { id: string | number; label: string } > > => {
+			await new Promise< void >( resolve => setTimeout( resolve, 600 ) );
+			const start = page * PAGE_SIZE;
+			return COUNTRIES.slice( start, start + PAGE_SIZE ).map( ( { id, label } ) => ( {
+				id,
+				label,
+			} ) );
+		},
+		[]
+	);
+
+	const fetchByIds = useCallback(
+		async ( ids: Array< string | number > ): Promise< ComboboxItem[] > => {
+			await new Promise< void >( resolve => setTimeout( resolve, 400 ) );
+			return COUNTRIES.filter( c => ids.includes( c.id ) );
+		},
+		[]
+	);
+
+	return (
+		<Form.Root>
+			<div sx={ { width: 320 } }>
+				<FormAutocompleteMultiselectSentinel
+					forLabel="sentinel-two-stage"
+					label="Select Countries"
+					onFetchItems={ fetchItems }
+					onFetchLabels={ fetchLabels }
+					onFetchByIds={ fetchByIds }
+					pageSize={ PAGE_SIZE }
+					placeholder="Search countries…"
+					helperText='Try "vi" — Bolivia loads from page 1, Vietnam is found via label scan.'
+				/>
+			</div>
+		</Form.Root>
+	);
+};
+
+/**
+ * Demonstrates the fetch error sentinel state. On load, 5 items appear in the
+ * dropdown immediately. The sentinel is visible at the bottom. After a short
+ * pause it transitions to "Loading more results…", then to the error state
+ * when the next page fetch fails.
+ *
+ * The dropdown opens and the pagination is triggered automatically so the full
+ * sequence plays out without any user interaction.
+ */
+export const AsyncFetchError = () => {
+	const fetchItems = useCallback( async ( page: number ): Promise< ComboboxItem[] > => {
+		if ( page === 0 ) {
+			// First page resolves immediately so items appear right away
+			return COUNTRIES.slice( 0, 5 );
+		}
+		// Subsequent pages show "Loading…" briefly then fail
+		await new Promise< void >( resolve => setTimeout( resolve, 1500 ) );
+		throw new Error( 'Simulated network error' );
+	}, [] );
+
+	useEffect( () => {
+		// Open the dropdown after the first page has loaded
+		const openTimer = setTimeout( () => {
+			document.getElementById( 'sentinel-fetch-error' )?.click();
+
+			// Dispatch a scroll event on the listbox to trigger the sentinel fetch.
+			// Since all 5 items fit within the max-height, distanceFromBottom is 0
+			// which satisfies the < 60 px threshold in handleListScroll.
+			const scrollTimer = setTimeout( () => {
+				const listbox = document.getElementById( 'sentinel-fetch-error-listbox' );
+				listbox?.dispatchEvent( new Event( 'scroll', { bubbles: true } ) );
+			}, 150 );
+
+			return () => clearTimeout( scrollTimer );
+		}, 200 );
+
+		return () => clearTimeout( openTimer );
+	}, [] );
+
+	return (
+		<Form.Root>
+			<div sx={ { width: 320 } }>
+				<FormAutocompleteMultiselectSentinel
+					forLabel="sentinel-fetch-error"
+					label="Select Countries"
+					onFetchItems={ fetchItems }
+					pageSize={ 5 }
+					placeholder="Search countries…"
+					helperText="The dropdown opens automatically to demo the error sentinel state."
+				/>
+			</div>
+		</Form.Root>
+	);
+};

--- a/src/system/NewForm/FormAutocompleteMultiselectSentinel.test.tsx
+++ b/src/system/NewForm/FormAutocompleteMultiselectSentinel.test.tsx
@@ -47,12 +47,12 @@ describe( '<FormAutocompleteMultiselectSentinel />', () => {
 			const { container } = render(
 				<FormAutocompleteMultiselectSentinel forLabel="a11y-empty" label="Test" />
 			);
-			await expect( await axe( container ) ).toHaveNoViolations();
+			expect( await axe( container ) ).toHaveNoViolations();
 		} );
 
 		it( 'passes axe with static options', async () => {
 			const { container } = render( <FormAutocompleteMultiselectSentinel { ...defaultProps } /> );
-			await expect( await axe( container ) ).toHaveNoViolations();
+			expect( await axe( container ) ).toHaveNoViolations();
 		} );
 
 		it( 'passes axe with error state', async () => {
@@ -63,7 +63,7 @@ describe( '<FormAutocompleteMultiselectSentinel />', () => {
 					errorMessage="Selection required."
 				/>
 			);
-			await expect( await axe( container ) ).toHaveNoViolations();
+			expect( await axe( container ) ).toHaveNoViolations();
 		} );
 	} );
 
@@ -262,7 +262,7 @@ describe( '<FormAutocompleteMultiselectSentinel />', () => {
 	// ── Keyboard navigation ───────────────────────────────────────────────────
 
 	describe( 'keyboard navigation', () => {
-		it( 'opens dropdown and sets first option active on ArrowDown', async () => {
+		it( 'opens dropdown and sets first option active on ArrowDown', () => {
 			render( <FormAutocompleteMultiselectSentinel { ...defaultProps } /> );
 			const input = screen.getByRole( 'combobox' );
 			fireEvent.keyDown( input, { key: 'ArrowDown' } );

--- a/src/system/NewForm/FormAutocompleteMultiselectSentinel.test.tsx
+++ b/src/system/NewForm/FormAutocompleteMultiselectSentinel.test.tsx
@@ -1,0 +1,364 @@
+/**
+ * External dependencies
+ */
+import { render, screen, fireEvent, waitFor, within } from '@testing-library/react';
+import userEvent from '@testing-library/user-event';
+import { axe } from 'jest-axe';
+
+/**
+ * Internal dependencies
+ */
+import {
+	FormAutocompleteMultiselectSentinel,
+	type ComboboxItem,
+} from './FormAutocompleteMultiselectSentinel';
+
+const staticOptions: ComboboxItem[] = [
+	{ id: 1, label: 'Chocolate' },
+	{ id: 2, label: 'Strawberry' },
+	{ id: 3, label: 'Vanilla' },
+];
+
+const defaultProps = {
+	label: 'Ice Cream Flavors',
+	forLabel: 'ice-cream',
+	options: staticOptions,
+};
+
+// ── jsdom polyfills ───────────────────────────────────────────────────────────
+
+// jsdom does not implement scrollIntoView — mock it to prevent errors in the
+// keyboard-navigation effect that scrolls the active option into view.
+beforeAll( () => {
+	window.HTMLElement.prototype.scrollIntoView = jest.fn();
+} );
+
+// ── Helpers ───────────────────────────────────────────────────────────────────
+
+const openDropdown = async ( input: HTMLElement ) => {
+	await userEvent.click( input );
+};
+
+// ── Accessibility ─────────────────────────────────────────────────────────────
+
+describe( '<FormAutocompleteMultiselectSentinel />', () => {
+	describe( 'accessibility', () => {
+		it( 'passes axe with no options', async () => {
+			const { container } = render(
+				<FormAutocompleteMultiselectSentinel forLabel="a11y-empty" label="Test" />
+			);
+			await expect( await axe( container ) ).toHaveNoViolations();
+		} );
+
+		it( 'passes axe with static options', async () => {
+			const { container } = render( <FormAutocompleteMultiselectSentinel { ...defaultProps } /> );
+			await expect( await axe( container ) ).toHaveNoViolations();
+		} );
+
+		it( 'passes axe with error state', async () => {
+			const { container } = render(
+				<FormAutocompleteMultiselectSentinel
+					{ ...defaultProps }
+					hasError
+					errorMessage="Selection required."
+				/>
+			);
+			await expect( await axe( container ) ).toHaveNoViolations();
+		} );
+	} );
+
+	// ── Rendering ─────────────────────────────────────────────────────────────
+
+	describe( 'rendering', () => {
+		it( 'renders the label', () => {
+			render( <FormAutocompleteMultiselectSentinel { ...defaultProps } /> );
+			expect( screen.getByLabelText( defaultProps.label ) ).toBeInTheDocument();
+		} );
+
+		it( 'renders the input with correct ARIA attributes', () => {
+			render( <FormAutocompleteMultiselectSentinel { ...defaultProps } /> );
+			const input = screen.getByRole( 'combobox' );
+			expect( input ).toHaveAttribute( 'aria-expanded', 'false' );
+			expect( input ).toHaveAttribute( 'aria-autocomplete', 'list' );
+		} );
+
+		it( 'renders the required attribute', () => {
+			render( <FormAutocompleteMultiselectSentinel { ...defaultProps } required /> );
+			const input = screen.getByRole( 'combobox' );
+			expect( input ).toHaveAttribute( 'aria-required', 'true' );
+		} );
+
+		it( 'renders the helper text with id for aria-describedby', () => {
+			render(
+				<FormAutocompleteMultiselectSentinel
+					{ ...defaultProps }
+					helperText="Select at least one."
+				/>
+			);
+			expect( screen.getByText( 'Select at least one.' ) ).toBeInTheDocument();
+		} );
+
+		it( 'shows error message when hasError is true', () => {
+			render(
+				<FormAutocompleteMultiselectSentinel
+					{ ...defaultProps }
+					hasError
+					errorMessage="Selection required."
+				/>
+			);
+			expect( screen.getByText( 'Selection required.' ) ).toBeInTheDocument();
+		} );
+
+		it( 'shows "0 items selected" by default', () => {
+			render( <FormAutocompleteMultiselectSentinel { ...defaultProps } /> );
+			expect( screen.getByText( '0 items selected' ) ).toBeInTheDocument();
+		} );
+
+		it( 'renders pre-selected items from initialValue', () => {
+			render(
+				<FormAutocompleteMultiselectSentinel
+					{ ...defaultProps }
+					initialValue={ [ staticOptions[ 0 ] ] }
+				/>
+			);
+			expect( screen.getByText( 'Chocolate' ) ).toBeInTheDocument();
+			expect( screen.getByText( '1 item selected' ) ).toBeInTheDocument();
+		} );
+	} );
+
+	// ── Dropdown ──────────────────────────────────────────────────────────────
+
+	describe( 'dropdown', () => {
+		it( 'opens when the input is clicked', async () => {
+			render( <FormAutocompleteMultiselectSentinel { ...defaultProps } /> );
+			const input = screen.getByRole( 'combobox' );
+			await openDropdown( input );
+			expect( screen.getByRole( 'listbox' ) ).toBeInTheDocument();
+			expect( input ).toHaveAttribute( 'aria-expanded', 'true' );
+		} );
+
+		it( 'shows all options when open with no input', async () => {
+			render( <FormAutocompleteMultiselectSentinel { ...defaultProps } /> );
+			await openDropdown( screen.getByRole( 'combobox' ) );
+			const listbox = screen.getByRole( 'listbox' );
+			expect( within( listbox ).getAllByRole( 'option' ) ).toHaveLength( 3 );
+		} );
+
+		it( 'filters options as the user types', async () => {
+			render( <FormAutocompleteMultiselectSentinel { ...defaultProps } /> );
+			const input = screen.getByRole( 'combobox' );
+			await openDropdown( input );
+			await userEvent.type( input, 'cho' );
+			const listbox = screen.getByRole( 'listbox' );
+			expect( within( listbox ).getAllByRole( 'option' ) ).toHaveLength( 1 );
+			expect( within( listbox ).getByText( 'Chocolate' ) ).toBeInTheDocument();
+		} );
+
+		it( 'shows no-results message when no options match', async () => {
+			render( <FormAutocompleteMultiselectSentinel { ...defaultProps } /> );
+			const input = screen.getByRole( 'combobox' );
+			await openDropdown( input );
+			await userEvent.type( input, 'zzz' );
+			expect( screen.getByText( 'No results found.' ) ).toBeInTheDocument();
+		} );
+
+		it( 'closes when Escape is pressed', async () => {
+			render( <FormAutocompleteMultiselectSentinel { ...defaultProps } /> );
+			const input = screen.getByRole( 'combobox' );
+			await openDropdown( input );
+			expect( screen.getByRole( 'listbox' ) ).toBeInTheDocument();
+			fireEvent.keyDown( input, { key: 'Escape' } );
+			expect( screen.queryByRole( 'listbox' ) ).not.toBeInTheDocument();
+		} );
+	} );
+
+	// ── Selection ─────────────────────────────────────────────────────────────
+
+	describe( 'selection', () => {
+		it( 'adds an item when clicked and calls onChange with two arguments', async () => {
+			const handleChange = jest.fn();
+			render(
+				<FormAutocompleteMultiselectSentinel { ...defaultProps } onChange={ handleChange } />
+			);
+			await openDropdown( screen.getByRole( 'combobox' ) );
+			await userEvent.click( screen.getByText( 'Chocolate' ) );
+
+			expect( handleChange ).toHaveBeenCalledTimes( 1 );
+			const [ selectedOptions, labels ] = handleChange.mock.calls[ 0 ];
+			expect( selectedOptions ).toEqual( [ { id: 1, label: 'Chocolate' } ] );
+			expect( labels ).toEqual( [ 'Chocolate' ] );
+		} );
+
+		it( 'adds an item via Enter key and calls onChange', async () => {
+			const handleChange = jest.fn();
+			render(
+				<FormAutocompleteMultiselectSentinel { ...defaultProps } onChange={ handleChange } />
+			);
+			const input = screen.getByRole( 'combobox' );
+			await openDropdown( input );
+			fireEvent.keyDown( input, { key: 'ArrowDown' } );
+			fireEvent.keyDown( input, { key: 'Enter' } );
+
+			expect( handleChange ).toHaveBeenCalledTimes( 1 );
+			const [ selectedOptions, labels ] = handleChange.mock.calls[ 0 ];
+			expect( selectedOptions[ 0 ] ).toMatchObject( { label: 'Chocolate' } );
+			expect( labels ).toEqual( [ 'Chocolate' ] );
+		} );
+
+		it( 'hides a selected item from the dropdown', async () => {
+			render( <FormAutocompleteMultiselectSentinel { ...defaultProps } /> );
+			await openDropdown( screen.getByRole( 'combobox' ) );
+			await userEvent.click( screen.getByText( 'Chocolate' ) );
+			await openDropdown( screen.getByRole( 'combobox' ) );
+			const listbox = screen.getByRole( 'listbox' );
+			expect( within( listbox ).queryByText( 'Chocolate' ) ).not.toBeInTheDocument();
+		} );
+
+		it( 'renders button chips by default for selected items', async () => {
+			render( <FormAutocompleteMultiselectSentinel { ...defaultProps } /> );
+			await openDropdown( screen.getByRole( 'combobox' ) );
+			await userEvent.click( screen.getByText( 'Chocolate' ) );
+			expect( screen.getByRole( 'button', { name: /chocolate/i } ) ).toBeInTheDocument();
+		} );
+
+		it( 'renders badge chips when listType is badge', async () => {
+			render( <FormAutocompleteMultiselectSentinel { ...defaultProps } listType="badge" /> );
+			await openDropdown( screen.getByRole( 'combobox' ) );
+			await userEvent.click( screen.getByText( 'Chocolate' ) );
+			// Badge renders the label text with an MdClose icon, not a <button> role
+			expect( screen.getByText( 'Chocolate' ) ).toBeInTheDocument();
+		} );
+
+		it( 'removes an item when the chip remove button is clicked', async () => {
+			const handleChange = jest.fn();
+			render(
+				<FormAutocompleteMultiselectSentinel
+					{ ...defaultProps }
+					initialValue={ [ staticOptions[ 0 ] ] }
+					onChange={ handleChange }
+				/>
+			);
+
+			const removeButton = screen.getByRole( 'button', { name: /chocolate/i } );
+			await userEvent.click( removeButton );
+
+			expect( handleChange ).toHaveBeenCalledTimes( 1 );
+			const [ selectedOptions, labels ] = handleChange.mock.calls[ 0 ];
+			expect( selectedOptions ).toEqual( [] );
+			expect( labels ).toEqual( [] );
+			expect( screen.getByText( '0 items selected' ) ).toBeInTheDocument();
+		} );
+
+		it( 'handles multiple selections and updates count correctly', async () => {
+			render( <FormAutocompleteMultiselectSentinel { ...defaultProps } /> );
+			await openDropdown( screen.getByRole( 'combobox' ) );
+			await userEvent.click( screen.getByText( 'Chocolate' ) );
+			await openDropdown( screen.getByRole( 'combobox' ) );
+			await userEvent.click( screen.getByText( 'Vanilla' ) );
+			expect( screen.getByText( '2 items selected' ) ).toBeInTheDocument();
+		} );
+	} );
+
+	// ── Keyboard navigation ───────────────────────────────────────────────────
+
+	describe( 'keyboard navigation', () => {
+		it( 'opens dropdown and sets first option active on ArrowDown', async () => {
+			render( <FormAutocompleteMultiselectSentinel { ...defaultProps } /> );
+			const input = screen.getByRole( 'combobox' );
+			fireEvent.keyDown( input, { key: 'ArrowDown' } );
+			expect( screen.getByRole( 'listbox' ) ).toBeInTheDocument();
+		} );
+
+		it( 'navigates options with ArrowDown and ArrowUp', async () => {
+			render( <FormAutocompleteMultiselectSentinel { ...defaultProps } /> );
+			const input = screen.getByRole( 'combobox' );
+			await openDropdown( input );
+			fireEvent.keyDown( input, { key: 'ArrowDown' } );
+			fireEvent.keyDown( input, { key: 'ArrowDown' } );
+			fireEvent.keyDown( input, { key: 'ArrowUp' } );
+			// Should be back at index 0 — aria-activedescendant points to first option
+			expect( input.getAttribute( 'aria-activedescendant' ) ).toContain( 'option-1' );
+		} );
+
+		it( 'navigates to last option with End key', async () => {
+			render( <FormAutocompleteMultiselectSentinel { ...defaultProps } /> );
+			const input = screen.getByRole( 'combobox' );
+			await openDropdown( input );
+			fireEvent.keyDown( input, { key: 'End' } );
+			expect( input.getAttribute( 'aria-activedescendant' ) ).toContain( 'option-3' );
+		} );
+
+		it( 'navigates to first option with Home key', async () => {
+			render( <FormAutocompleteMultiselectSentinel { ...defaultProps } /> );
+			const input = screen.getByRole( 'combobox' );
+			await openDropdown( input );
+			fireEvent.keyDown( input, { key: 'End' } );
+			fireEvent.keyDown( input, { key: 'Home' } );
+			expect( input.getAttribute( 'aria-activedescendant' ) ).toContain( 'option-1' );
+		} );
+	} );
+
+	// ── Async mode ────────────────────────────────────────────────────────────
+
+	describe( 'async mode', () => {
+		const page0: ComboboxItem[] = [
+			{ id: 10, label: 'Alpha' },
+			{ id: 11, label: 'Beta' },
+		];
+		const page1: ComboboxItem[] = [ { id: 12, label: 'Gamma' } ];
+
+		it( 'fetches the first page on mount', async () => {
+			const onFetchItems = jest.fn().mockResolvedValueOnce( page0 ).mockResolvedValueOnce( page1 );
+
+			render(
+				<FormAutocompleteMultiselectSentinel
+					forLabel="async-test"
+					label="Async"
+					onFetchItems={ onFetchItems }
+					pageSize={ 2 }
+				/>
+			);
+
+			await waitFor( () => expect( onFetchItems ).toHaveBeenCalledWith( 0 ) );
+		} );
+
+		it( 'shows loaded items in the dropdown', async () => {
+			const onFetchItems = jest.fn().mockResolvedValue( page0 );
+
+			render(
+				<FormAutocompleteMultiselectSentinel
+					forLabel="async-items"
+					label="Async Items"
+					onFetchItems={ onFetchItems }
+					pageSize={ 10 }
+				/>
+			);
+
+			await waitFor( () => expect( onFetchItems ).toHaveBeenCalled() );
+			await openDropdown( screen.getByRole( 'combobox' ) );
+
+			expect( screen.getByText( 'Alpha' ) ).toBeInTheDocument();
+			expect( screen.getByText( 'Beta' ) ).toBeInTheDocument();
+		} );
+
+		it( 'shows error state when onFetchItems rejects', async () => {
+			const onFetchItems = jest.fn().mockRejectedValue( new Error( 'Network error' ) );
+
+			render(
+				<FormAutocompleteMultiselectSentinel
+					forLabel="async-error"
+					label="Async Error"
+					onFetchItems={ onFetchItems }
+					pageSize={ 10 }
+				/>
+			);
+
+			await waitFor( () => expect( onFetchItems ).toHaveBeenCalled() );
+			await openDropdown( screen.getByRole( 'combobox' ) );
+
+			await waitFor( () => {
+				expect( screen.getByText( /Error loading additional results/i ) ).toBeInTheDocument();
+			} );
+		} );
+	} );
+} );

--- a/src/system/NewForm/FormAutocompleteMultiselectSentinel.tsx
+++ b/src/system/NewForm/FormAutocompleteMultiselectSentinel.tsx
@@ -1,0 +1,974 @@
+/** @jsxImportSource theme-ui */
+
+/**
+ * External dependencies
+ */
+import classNames from 'classnames';
+import React, {
+	useState,
+	useRef,
+	useEffect,
+	useId,
+	useCallback,
+	type KeyboardEvent,
+	type ChangeEvent,
+} from 'react';
+import { MdClose, MdKeyboardArrowDown, MdSearch, MdWarning } from 'react-icons/md';
+import { useThemeUI } from 'theme-ui';
+
+/**
+ * Internal dependencies
+ */
+import { FormAutocompleteMultiselectBadge } from './FormAutocompleteMultiselectBadge';
+import { FormAutocompleteMultiselectButton } from './FormAutocompleteMultiselectButton';
+import { Flex, Spinner } from '../';
+import { Validation } from '../Form';
+import { baseControlBorderStyle, inputBaseText } from '../Form/Input.styles';
+import { Label } from '../Form/Label';
+
+// ── Types ─────────────────────────────────────────────────────────────────────
+
+export interface ComboboxItem {
+	id: string | number;
+	label: string;
+}
+
+export interface FormAutocompleteMultiselectSentinelProps {
+	// --- Async data fetching (new capabilities) ---
+
+	/**
+	 * Scroll-triggered pagination. Receives the zero-based page number and
+	 * returns a page of items. Required for async mode.
+	 */
+	onFetchItems?: ( page: number ) => Promise< ComboboxItem[] >;
+
+	/**
+	 * Lightweight label-only fetch used by the two-stage type-ahead search.
+	 * Returns `{ id, label }` pairs for one page. Both onFetchLabels and
+	 * onFetchByIds must be provided to enable two-stage mode; if either is
+	 * absent the component falls back to debounced onFetchItems.
+	 */
+	onFetchLabels?: ( page: number ) => Promise< Array< { id: string | number; label: string } > >;
+
+	/**
+	 * Targeted full-item fetch. Receives an array of IDs whose labels matched
+	 * the search query and returns the corresponding full items.
+	 */
+	onFetchByIds?: ( ids: Array< string | number > ) => Promise< ComboboxItem[] >;
+
+	/** Items per page. Determines end-of-results when a page is shorter. Default: 100 */
+	pageSize?: number;
+
+	/** Optional hint text rendered below the input. */
+	helperText?: string;
+
+	/** Placeholder text shown inside the input when nothing has been typed. Default: 'Search…' */
+	placeholder?: string;
+
+	// --- Static options ---
+
+	/** Static item list — used when onFetchItems is not provided. */
+	options?: ComboboxItem[];
+
+	/** Items that are pre-selected when the component first renders. */
+	initialValue?: ComboboxItem[];
+
+	// --- Retained compatibility props ---
+
+	/** Additional CSS class name applied to the root element. */
+	className?: string;
+
+	/** Validation error message displayed below the input. Only visible when `hasError` is true. */
+	errorMessage?: string;
+
+	/**
+	 * The `id` applied to the input element, used to associate it with its label and
+	 * for aria attributes. Auto-generated if omitted.
+	 */
+	forLabel?: string;
+
+	/** When true, renders the input with an error border and displays `errorMessage`. */
+	hasError?: boolean;
+
+	/** Renders the label inline inside the input field rather than above it. */
+	isInline?: boolean;
+
+	/** Label text displayed above the input, or inline when `isInline` is true. */
+	label?: React.ReactNode;
+
+	/** When true, shows a spinner inside the input to indicate an external loading state. */
+	loading?: boolean;
+
+	/**
+	 * Function that returns the message shown in the dropdown when no options match
+	 * the current input value. Default: `() => 'No results found.'`
+	 */
+	noOptionsMessage?: () => string;
+
+	/**
+	 * Called whenever the selection changes.
+	 * Matches the original two-argument signature for compatibility:
+	 *   selectedOptions — full ComboboxItem array
+	 *   labels          — string array of selected labels
+	 */
+	onChange?: ( selectedOptions: ComboboxItem[], labels: string[] ) => void;
+
+	/** Marks the field as required, adds a required indicator to the label and sets aria-required on the input. */
+	required?: boolean;
+
+	/** Controls how selected items are displayed below the input. `'button'` renders removable pill buttons; `'badge'` renders compact badges. Default: 'button' */
+	listType?: 'button' | 'badge';
+
+	/** When true, shows a search icon on the left side of the input field. */
+	searchIcon?: boolean;
+
+	/**
+	 * Debounce delay in milliseconds applied to the type-ahead search when in async mode.
+	 * Increasing this reduces the number of fetch calls made while the user is still typing.
+	 * Default: 300
+	 */
+	debounce?: number;
+}
+
+// ── Styles ────────────────────────────────────────────────────────────────────
+
+const srOnly = {
+	border: '0',
+	clip: 'rect(0 0 0 0)',
+	height: '1px',
+	marginBottom: '-1px',
+	marginRight: '-1px',
+	overflow: 'hidden',
+	padding: '0',
+	position: 'absolute' as const,
+	whiteSpace: 'nowrap' as const,
+	width: '1px',
+};
+
+const inputWrapperStyles = {
+	display: 'flex',
+	alignItems: 'center',
+	backgroundColor: 'layer.2',
+	color: inputBaseText,
+	...baseControlBorderStyle,
+	borderRadius: 1,
+	minHeight: '36px',
+};
+
+const inputStyles = {
+	flex: '1 1 auto',
+	minWidth: 0,
+	px: 3,
+	py: 0,
+	minHeight: '36px',
+	lineHeight: '36px',
+	fontSize: 'inherit',
+	color: 'text',
+	backgroundColor: 'transparent',
+	borderWidth: 0,
+	outline: 'none',
+	'&:focus': { outline: 'none', boxShadow: 'none' },
+	'&::placeholder': {
+		color: 'input.text.placeholder',
+		opacity: 1,
+	},
+};
+
+const dropdownStyles = {
+	position: 'absolute' as const,
+	zIndex: 10,
+	width: '100%',
+	mt: 1,
+	backgroundColor: 'layer.2',
+	color: inputBaseText,
+	...baseControlBorderStyle,
+	borderRadius: 1,
+	maxHeight: '240px',
+	overflowY: 'auto' as const,
+	listStyle: 'none',
+	p: 0,
+	m: 0,
+};
+
+const optionBaseStyles = {
+	px: 3,
+	py: 2,
+	fontSize: 'inherit',
+	cursor: 'pointer',
+	userSelect: 'none' as const,
+	color: 'text',
+	borderBottomWidth: '1px',
+	borderBottomStyle: 'solid' as const,
+	borderBottomColor: 'input.border.default',
+	'&:last-child': { borderBottomWidth: 0 },
+};
+
+const optionActiveStyles = {
+	backgroundColor: 'input.background.primary',
+	borderBottomColor: 'input.background.primary',
+	color: '#ffffff',
+};
+
+// ── Selection status live region ───────────────────────────────────────────────
+
+const SelectionStatus = ( { status }: { status: string } ) => (
+	<div
+		sx={ srOnly }
+		id="vip-autocomplete-sentinel-status"
+		role="status"
+		aria-atomic="true"
+		aria-live="assertive"
+	>
+		{ status }
+	</div>
+);
+
+// ── Component ──────────────────────────────────────────────────────────────────
+
+const FormAutocompleteMultiselectSentinel = React.forwardRef<
+	HTMLInputElement,
+	FormAutocompleteMultiselectSentinelProps
+>(
+	(
+		{
+			onFetchItems,
+			onFetchLabels,
+			onFetchByIds,
+			pageSize = 100,
+			helperText,
+			placeholder = 'Search…',
+			options = [],
+			initialValue = [],
+			className,
+			errorMessage,
+			forLabel: forLabelProp,
+			hasError,
+			isInline,
+			label,
+			loading: externalLoading,
+			noOptionsMessage = () => 'No results found.',
+			onChange = () => {},
+			required,
+			listType = 'button',
+			searchIcon,
+			debounce = 300,
+		},
+		forwardRef
+	) => {
+		// ── ARIA IDs ────────────────────────────────────────────────────────────
+		const generatedId = useId();
+		const forLabel = forLabelProp ?? `vip-autocomplete-sentinel-${ generatedId }`;
+		const listboxId = `${ forLabel }-listbox`;
+		const helperTextId = `${ forLabel }-helper`;
+
+		// ── Core UI state ───────────────────────────────────────────────────────
+		const [ isOpen, setIsOpen ] = useState( false );
+		const [ inputValue, setInputValue ] = useState( '' );
+		const [ selectedItems, setSelectedItems ] = useState< ComboboxItem[] >( initialValue );
+		const [ activeIndex, setActiveIndex ] = useState< number | null >( null );
+		const [ selectionAnnouncement, setSelectionAnnouncement ] = useState( '' );
+		const [ loadAnnouncement, setLoadAnnouncement ] = useState( '' );
+
+		// ── Browse-mode pagination state ────────────────────────────────────────
+		const [ loadedItems, setLoadedItems ] = useState< ComboboxItem[] >( [] );
+		const [ isLoadingMore, setIsLoadingMore ] = useState( false );
+		const [ fetchError, setFetchError ] = useState( false );
+		const [ hasMore, setHasMore ] = useState( true );
+
+		// ── Two-stage search state ──────────────────────────────────────────────
+		const [ isSearchMode, setIsSearchMode ] = useState( false );
+		const [ searchResults, setSearchResults ] = useState< ComboboxItem[] >( [] );
+		const [ isSearching, setIsSearching ] = useState( false );
+		const [ searchError, setSearchError ] = useState( false );
+
+		// ── Refs — safe access inside async callbacks & effects ─────────────────
+		const loadingRef = useRef( false );
+		const pageRef = useRef( 0 );
+		const hasMoreRef = useRef( true );
+		const isOpenRef = useRef( false );
+		const isSearchModeRef = useRef( false );
+		const loadedItemsRef = useRef< ComboboxItem[] >( [] );
+		const searchGenRef = useRef( 0 );
+		const debounceRef = useRef< ReturnType< typeof setTimeout > | null >( null );
+		const isFirstRender = useRef( true );
+
+		// ── DOM refs ────────────────────────────────────────────────────────────
+		const inputRef = useRef< HTMLInputElement >( null );
+		const listboxRef = useRef< HTMLUListElement >( null );
+		const containerRef = useRef< HTMLDivElement >( null );
+		const optionRefs = useRef< ( HTMLLIElement | null )[] >( [] );
+
+		// ── Keyboard focus detection ─────────────────────────────────────────────
+		// Track whether focus arrived via keyboard (Tab) or mouse click.
+		// Browsers always apply :focus-visible to <input type="text"> on click,
+		// so CSS alone cannot distinguish the two — we use a JS-based flag instead.
+		const [ isKeyboardFocused, setIsKeyboardFocused ] = useState( false );
+		const isMouseInteractionRef = useRef( false );
+
+		// Access theme outline styles directly to avoid the problematic
+		// `{ '&': fn }` sx pattern which can cause rendering issues.
+		const { theme } = useThemeUI();
+		const outlineStyles = ( ( theme as any ).outline ?? {} ) as Record< string, string >;
+
+		// ── Derived flags ───────────────────────────────────────────────────────
+		const isAsync = Boolean( onFetchItems );
+		const isTwoStage = Boolean( onFetchLabels && onFetchByIds );
+		const sourceItems = isAsync ? loadedItems : options;
+
+		/**
+		 * Items visible in the dropdown:
+		 * - Search mode: merge loaded items + search results, deduped by id
+		 * - Browse mode: paginated source items
+		 * Both filter out already-selected items and apply the current text filter.
+		 */
+		const itemPool = isSearchMode
+			? [ ...loadedItems, ...searchResults.filter( r => ! loadedItems.some( l => l.id === r.id ) ) ]
+			: sourceItems;
+
+		const filteredItems = itemPool.filter( item => {
+			const isSelected = selectedItems.some( s => s.id === item.id );
+			const matchesFilter = item.label.toLowerCase().includes( inputValue.toLowerCase() );
+			return ! isSelected && matchesFilter;
+		} );
+
+		/**
+		 * Show the sentinel list item when there is anything to communicate:
+		 * browse loading/error/trigger, or search in-progress/error.
+		 */
+		const showSentinel =
+			isAsync &&
+			( isLoadingMore ||
+				fetchError ||
+				( hasMore && ! isSearchMode ) ||
+				isSearching ||
+				searchError );
+
+		// ── Ref sync effects ────────────────────────────────────────────────────
+		useEffect( () => {
+			loadedItemsRef.current = loadedItems;
+		}, [ loadedItems ] );
+		useEffect( () => {
+			isSearchModeRef.current = isSearchMode;
+		}, [ isSearchMode ] );
+
+		// ── Browse pagination fetch ─────────────────────────────────────────────
+		const fetchNextPage = useCallback( async () => {
+			if ( ! onFetchItems || loadingRef.current || ! hasMoreRef.current ) return;
+
+			loadingRef.current = true;
+			setIsLoadingMore( true );
+			setFetchError( false );
+			setLoadAnnouncement( 'Loading more results.' );
+
+			try {
+				const newItems = await onFetchItems( pageRef.current );
+				setLoadedItems( prev => [ ...prev, ...newItems ] );
+				pageRef.current += 1;
+
+				if ( newItems.length < pageSize ) {
+					hasMoreRef.current = false;
+					setHasMore( false );
+				}
+				setLoadAnnouncement(
+					`${ newItems.length } more result${ newItems.length === 1 ? '' : 's' } loaded.`
+				);
+			} catch {
+				setFetchError( true );
+				setLoadAnnouncement( 'Error: failed to retrieve additional results.' );
+			} finally {
+				loadingRef.current = false;
+				setIsLoadingMore( false );
+			}
+		}, [ onFetchItems, pageSize ] );
+
+		// ── Two-stage search ────────────────────────────────────────────────────
+		/**
+		 * Runs a two-stage type-ahead search:
+		 * 1. Fetch lightweight labels for all unloaded pages sequentially.
+		 * 2. Client-side filter labels against the query to find matching IDs
+		 *    not already in loadedItems.
+		 * 3. Fetch full items only for those IDs.
+		 *
+		 * The `gen` parameter is a generation counter; the function aborts if a
+		 * newer search has started (i.e. the user typed again).
+		 */
+		const runTwoStageSearch = useCallback(
+			async ( query: string, gen: number ) => {
+				setIsSearchMode( true );
+				setIsSearching( true );
+				setSearchError( false );
+				setSearchResults( [] );
+				setLoadAnnouncement( 'Searching for more results.' );
+
+				try {
+					// Stage 1: Scan all remaining pages for labels
+					const allNewLabels: Array< { id: string | number; label: string } > = [];
+					let labelPage = pageRef.current;
+
+					while ( true ) {
+						if ( searchGenRef.current !== gen ) return;
+						const labels = await onFetchLabels!( labelPage );
+						allNewLabels.push( ...labels );
+						labelPage++;
+						if ( labels.length < pageSize ) break;
+					}
+
+					if ( searchGenRef.current !== gen ) return;
+
+					// Stage 2: Filter labels against query; exclude already-loaded IDs
+					const loadedIds = new Set( loadedItemsRef.current.map( i => i.id ) );
+					const matchingIds = allNewLabels
+						.filter(
+							l => l.label.toLowerCase().includes( query.toLowerCase() ) && ! loadedIds.has( l.id )
+						)
+						.map( l => l.id );
+
+					// Stage 3: Fetch full items for the matches
+					let newItems: ComboboxItem[] = [];
+					if ( matchingIds.length > 0 ) {
+						if ( searchGenRef.current !== gen ) return;
+						newItems = await onFetchByIds!( matchingIds );
+					}
+
+					if ( searchGenRef.current !== gen ) return;
+					setSearchResults( newItems );
+					setLoadAnnouncement(
+						newItems.length > 0
+							? `Search complete. ${ newItems.length } additional result${
+									newItems.length === 1 ? '' : 's'
+							  } found.`
+							: 'Search complete. No additional results found.'
+					);
+				} catch {
+					if ( searchGenRef.current === gen ) {
+						setSearchError( true );
+						setLoadAnnouncement( 'Error: search failed.' );
+					}
+				} finally {
+					if ( searchGenRef.current === gen ) {
+						setIsSearching( false );
+					}
+				}
+			},
+			[ onFetchLabels, onFetchByIds, pageSize ]
+		);
+
+		// ── Exit search mode ────────────────────────────────────────────────────
+		const exitSearchMode = useCallback( () => {
+			searchGenRef.current++; // cancel any in-flight search
+			setIsSearchMode( false );
+			setSearchResults( [] );
+			setIsSearching( false );
+			setSearchError( false );
+		}, [] );
+
+		// ── Initial fetch on mount ──────────────────────────────────────────────
+		// eslint-disable-next-line react-hooks/exhaustive-deps
+		useEffect( () => {
+			if ( onFetchItems ) void fetchNextPage();
+		}, [] );
+
+		// ── Scroll-triggered browse pagination ──────────────────────────────────
+		const handleListScroll = useCallback( () => {
+			const el = listboxRef.current;
+			if (
+				! el ||
+				loadingRef.current ||
+				! hasMoreRef.current ||
+				! isAsync ||
+				isSearchModeRef.current
+			)
+				return;
+			const distanceFromBottom = el.scrollHeight - el.scrollTop - el.clientHeight;
+			if ( distanceFromBottom < 60 ) void fetchNextPage();
+		}, [ isAsync, fetchNextPage ] );
+
+		// ── Debounced type-ahead ────────────────────────────────────────────────
+		useEffect( () => {
+			if ( isFirstRender.current ) {
+				isFirstRender.current = false;
+				return;
+			}
+
+			const gen = ++searchGenRef.current;
+
+			// Empty query — immediately exit search mode, no debounce needed
+			if ( ! inputValue ) {
+				exitSearchMode();
+				return;
+			}
+
+			if ( ! isAsync || ! isOpenRef.current ) return;
+
+			if ( isTwoStage && hasMoreRef.current ) {
+				debounceRef.current = setTimeout(
+					() => void runTwoStageSearch( inputValue, gen ),
+					debounce
+				);
+			} else if ( hasMoreRef.current && ! loadingRef.current ) {
+				debounceRef.current = setTimeout( () => void fetchNextPage(), debounce );
+			}
+
+			return () => {
+				if ( debounceRef.current ) clearTimeout( debounceRef.current );
+			};
+		}, [ inputValue, isAsync, isTwoStage, fetchNextPage, runTwoStageSearch, exitSearchMode ] );
+
+		// ── Misc side effects ───────────────────────────────────────────────────
+
+		// Clear load live-region after screen readers consume it
+		useEffect( () => {
+			if ( ! loadAnnouncement ) return;
+			const id = setTimeout( () => setLoadAnnouncement( '' ), 1500 );
+			return () => clearTimeout( id );
+		}, [ loadAnnouncement ] );
+
+		// Trim stale option refs when filtered list shrinks
+		useEffect( () => {
+			optionRefs.current = optionRefs.current.slice( 0, filteredItems.length );
+		}, [ filteredItems.length ] );
+
+		// Scroll keyboard-focused option into view
+		useEffect( () => {
+			if ( activeIndex !== null ) {
+				optionRefs.current[ activeIndex ]?.scrollIntoView( { block: 'nearest' } );
+			}
+		}, [ activeIndex ] );
+
+		// Close dropdown on outside click
+		useEffect( () => {
+			const handle = ( e: MouseEvent ) => {
+				if ( containerRef.current && ! containerRef.current.contains( e.target as Node ) ) {
+					setIsOpen( false );
+					isOpenRef.current = false;
+					setActiveIndex( null );
+				}
+			};
+			document.addEventListener( 'mousedown', handle );
+			return () => document.removeEventListener( 'mousedown', handle );
+		}, [] );
+
+		// ── Helpers ─────────────────────────────────────────────────────────────
+		const openDropdown = useCallback( () => {
+			setIsOpen( true );
+			isOpenRef.current = true;
+		}, [] );
+
+		const closeDropdown = useCallback( () => {
+			setIsOpen( false );
+			isOpenRef.current = false;
+			setActiveIndex( null );
+		}, [] );
+
+		const selectItem = useCallback(
+			( item: ComboboxItem ) => {
+				const next = [ ...selectedItems, item ];
+				setSelectedItems( next );
+				onChange(
+					next,
+					next.map( i => i.label )
+				);
+				setInputValue( '' );
+				exitSearchMode();
+				closeDropdown();
+				setSelectionAnnouncement( `${ item.label } added to the list.` );
+				inputRef.current?.focus();
+			},
+			[ selectedItems, onChange, closeDropdown, exitSearchMode ]
+		);
+
+		const removeItem = useCallback(
+			( item: ComboboxItem ) => {
+				const next = selectedItems.filter( s => s.id !== item.id );
+				setSelectedItems( next );
+				onChange(
+					next,
+					next.map( i => i.label )
+				);
+				setSelectionAnnouncement( `${ item.label } removed from the list.` );
+			},
+			[ selectedItems, onChange ]
+		);
+
+		const clearInputText = useCallback( () => {
+			setInputValue( '' );
+			setActiveIndex( null );
+			exitSearchMode();
+			inputRef.current?.focus();
+		}, [ exitSearchMode ] );
+
+		// ── Event handlers ───────────────────────────────────────────────────────
+		const handleInputChange = ( e: ChangeEvent< HTMLInputElement > ) => {
+			setInputValue( e.target.value );
+			setActiveIndex( null );
+			openDropdown();
+		};
+
+		const handleChevronClick = () => {
+			if ( isOpen ) closeDropdown();
+			else {
+				openDropdown();
+				inputRef.current?.focus();
+			}
+		};
+
+		const handleInputKeyDown = ( e: KeyboardEvent< HTMLInputElement > ) => {
+			switch ( e.key ) {
+				case 'ArrowDown':
+					e.preventDefault();
+					if ( ! isOpen ) {
+						openDropdown();
+						setActiveIndex( 0 );
+					} else {
+						setActiveIndex( prev => {
+							if ( filteredItems.length === 0 ) return null;
+							if ( prev === null || prev >= filteredItems.length - 1 ) return 0;
+							return prev + 1;
+						} );
+					}
+					break;
+
+				case 'ArrowUp':
+					e.preventDefault();
+					if ( isOpen && filteredItems.length > 0 ) {
+						setActiveIndex( prev => {
+							if ( prev === null || prev === 0 ) return filteredItems.length - 1;
+							return prev - 1;
+						} );
+					}
+					break;
+
+				case 'Enter':
+					e.preventDefault();
+					if ( isOpen && activeIndex !== null && filteredItems[ activeIndex ] ) {
+						selectItem( filteredItems[ activeIndex ] );
+					} else {
+						openDropdown();
+					}
+					break;
+
+				case 'Escape':
+					e.preventDefault();
+					if ( isOpen ) {
+						closeDropdown();
+						setInputValue( '' );
+						exitSearchMode();
+					}
+					break;
+
+				case 'Tab':
+					closeDropdown();
+					break;
+
+				case 'Home':
+					if ( isOpen && filteredItems.length > 0 ) {
+						e.preventDefault();
+						setActiveIndex( 0 );
+					}
+					break;
+
+				case 'End':
+					if ( isOpen && filteredItems.length > 0 ) {
+						e.preventDefault();
+						setActiveIndex( filteredItems.length - 1 );
+					}
+					break;
+			}
+		};
+
+		const activeDescendant =
+			activeIndex !== null && filteredItems[ activeIndex ]
+				? `${ listboxId }-option-${ filteredItems[ activeIndex ].id }`
+				: undefined;
+
+		const ListComponent =
+			listType === 'badge' ? FormAutocompleteMultiselectBadge : FormAutocompleteMultiselectButton;
+
+		const SelectLabel = () => (
+			<Label required={ required } htmlFor={ forLabel }>
+				{ label }
+			</Label>
+		);
+
+		const inlineLabel = Boolean( isInline && label );
+
+		// ── Render ───────────────────────────────────────────────────────────────
+		return (
+			<div
+				className={ classNames( 'vip-form-autocomplete-sentinel-component', className ) }
+				ref={ containerRef }
+			>
+				{ /* Polite live region for load/search announcements */ }
+				<div role="status" aria-live="polite" aria-atomic="true" sx={ srOnly }>
+					{ loadAnnouncement }
+				</div>
+
+				{ label && ! isInline && <SelectLabel /> }
+
+				<div sx={ { position: 'relative' } }>
+					{ /* Input wrapper */ }
+					<div
+						onMouseDown={ () => {
+							isMouseInteractionRef.current = true;
+							// Clear after the focus event has fired so subsequent
+							// Tab presses are detected correctly.
+							setTimeout( () => {
+								isMouseInteractionRef.current = false;
+							}, 0 );
+						} }
+						sx={ {
+							...inputWrapperStyles,
+							...( isKeyboardFocused ? outlineStyles : {} ),
+							...( hasError ? { borderColor: 'input.border.error' } : {} ),
+						} }
+					>
+						{ inlineLabel && (
+							<span sx={ { flexShrink: 0, pl: 3, fontSize: 'inherit' } }>
+								<SelectLabel />
+							</span>
+						) }
+
+						{ searchIcon && (
+							<MdSearch
+								sx={ { ml: 3, flexShrink: 0, color: 'input.text.placeholder' } }
+								aria-hidden="true"
+							/>
+						) }
+
+						<input
+							ref={ node => {
+								( inputRef as React.MutableRefObject< HTMLInputElement | null > ).current = node;
+								if ( typeof forwardRef === 'function' ) {
+									forwardRef( node );
+								} else if ( forwardRef ) {
+									( forwardRef as React.MutableRefObject< HTMLInputElement | null > ).current =
+										node;
+								}
+							} }
+							id={ forLabel }
+							type="text"
+							role="combobox"
+							aria-expanded={ isOpen }
+							aria-controls={ isOpen ? listboxId : undefined }
+							aria-autocomplete="list"
+							aria-activedescendant={ activeDescendant }
+							aria-required={ required }
+							aria-describedby={
+								[ `describe-${ forLabel }-validation`, helperText ? helperTextId : '' ]
+									.filter( Boolean )
+									.join( ' ' ) || undefined
+							}
+							value={ inputValue }
+							onChange={ handleInputChange }
+							onKeyDown={ handleInputKeyDown }
+							onClick={ openDropdown }
+							onFocus={ () => {
+								if ( ! isMouseInteractionRef.current ) setIsKeyboardFocused( true );
+							} }
+							onBlur={ () => setIsKeyboardFocused( false ) }
+							placeholder={ placeholder }
+							autoComplete="off"
+							spellCheck={ false }
+							sx={ {
+								...inputStyles,
+								...( searchIcon ? { pl: 2 } : {} ),
+							} }
+						/>
+
+						{ /* Clear typed text button */ }
+						{ inputValue && (
+							<button
+								type="button"
+								onClick={ clearInputText }
+								aria-label="Clear search text"
+								sx={ {
+									display: 'flex',
+									alignItems: 'center',
+									justifyContent: 'center',
+									width: '32px',
+									height: '32px',
+									mr: 1,
+									color: 'input.text.placeholder',
+									backgroundColor: 'transparent',
+									border: 'none',
+									borderRadius: 1,
+									cursor: 'pointer',
+									flexShrink: 0,
+									'&:hover': { color: 'text' },
+									'&:focus-visible': ( theme: any ) => theme.outline,
+								} }
+							>
+								<MdClose size={ 14 } aria-hidden="true" />
+							</button>
+						) }
+
+						{ /* Chevron toggle — decorative, excluded from tab order */ }
+						<button
+							type="button"
+							onClick={ handleChevronClick }
+							tabIndex={ -1 }
+							aria-hidden="true"
+							sx={ {
+								display: 'flex',
+								alignItems: 'center',
+								justifyContent: 'center',
+								width: '32px',
+								height: '32px',
+								mr: 1,
+								color: 'input.text.placeholder',
+								backgroundColor: 'transparent',
+								border: 'none',
+								borderRadius: 1,
+								cursor: 'pointer',
+								flexShrink: 0,
+								transition: 'transform 150ms ease',
+								transform: isOpen ? 'rotate(180deg)' : 'rotate(0deg)',
+								'&:hover': { color: 'text' },
+							} }
+						>
+							<MdKeyboardArrowDown size={ 18 } aria-hidden="true" />
+						</button>
+
+						{ /* External loading spinner inside the input */ }
+						{ externalLoading && <Spinner size={ 16 } sx={ { mr: 3, flexShrink: 0 } } /> }
+					</div>
+
+					{ /* Dropdown listbox */ }
+					{ isOpen && (
+						<ul
+							ref={ listboxRef }
+							id={ listboxId }
+							role="listbox"
+							aria-label={ typeof label === 'string' ? label : undefined }
+							aria-busy={ isLoadingMore || isSearching }
+							aria-multiselectable="true"
+							onScroll={ handleListScroll }
+							sx={ dropdownStyles }
+						>
+							{ /* Empty state */ }
+							{ filteredItems.length === 0 && ! isLoadingMore && ! isSearching && (
+								<li
+									role="option"
+									aria-selected={ false }
+									aria-disabled="true"
+									sx={ {
+										px: 3,
+										py: 2,
+										fontSize: 'inherit',
+										color: 'input.text.placeholder',
+										cursor: 'default',
+										userSelect: 'none',
+									} }
+								>
+									{ noOptionsMessage() }
+								</li>
+							) }
+
+							{ /* Option items */ }
+							{ filteredItems.map( ( item, index ) => {
+								const isActive = index === activeIndex;
+								return (
+									<li
+										key={ item.id }
+										ref={ el => {
+											optionRefs.current[ index ] = el;
+										} }
+										id={ `${ listboxId }-option-${ item.id }` }
+										role="option"
+										aria-selected={ false }
+										sx={ {
+											...optionBaseStyles,
+											...( isActive
+												? optionActiveStyles
+												: { '&:hover': { backgroundColor: 'input.background.primary', color: '#ffffff' } } ),
+										} }
+										onClick={ () => selectItem( item ) }
+										onMouseEnter={ () => setActiveIndex( index ) }
+										onMouseDown={ e => e.preventDefault() }
+									>
+										{ item.label }
+									</li>
+								);
+							} ) }
+
+							{ /* Sentinel — loading, searching, error, or invisible scroll trigger */ }
+							{ showSentinel && (
+								<li
+									role="none"
+									aria-hidden="true"
+									sx={ { px: 3, py: 2, fontSize: 'inherit', cursor: 'default' } }
+								>
+									{ isLoadingMore ? (
+										<Flex sx={ { alignItems: 'center', gap: 2, color: 'input.text.placeholder' } }>
+											<Spinner size={ 14 } />
+											Loading more results…
+										</Flex>
+									) : fetchError ? (
+										<Flex sx={ { alignItems: 'center', gap: 2, color: 'error' } }>
+											<MdWarning size={ 14 } aria-hidden="true" />
+											Error loading additional results.
+										</Flex>
+									) : isSearching ? (
+										<Flex sx={ { alignItems: 'center', gap: 2, color: 'input.text.placeholder' } }>
+											<Spinner size={ 14 } />
+											Searching for more results…
+										</Flex>
+									) : searchError ? (
+										<Flex sx={ { alignItems: 'center', gap: 2, color: 'error' } }>
+											<MdWarning size={ 14 } aria-hidden="true" />
+											Error — search failed. Please try again.
+										</Flex>
+									) : (
+										// Invisible scroll trigger when idle with more browse pages remaining
+										<span sx={ srOnly } aria-hidden="true" />
+									) }
+								</li>
+							) }
+						</ul>
+					) }
+				</div>
+
+				{ /* Helper text */ }
+				{ helperText && (
+					<p id={ helperTextId } sx={ { mt: 1, fontSize: 1, color: 'input.text.placeholder' } }>
+						{ helperText }
+					</p>
+				) }
+
+				{ /* Error + item count row */ }
+				<Flex sx={ { mt: 2, justifyContent: 'space-between' } }>
+					{ hasError && errorMessage && (
+						<Validation isValid={ false } describedId={ forLabel }>
+							{ errorMessage }
+						</Validation>
+					) }
+					<div sx={ { fontSize: 1 } }>
+						{ selectedItems.length } item{ selectedItems.length === 1 ? '' : 's' } selected
+					</div>
+				</Flex>
+
+				{ /* Assertive live region for add/remove announcements */ }
+				{ selectionAnnouncement && <SelectionStatus status={ selectionAnnouncement } /> }
+
+				{ /* Selected item chips */ }
+				<div sx={ { display: 'inline-flex', flexWrap: 'wrap', maxWidth: '100%' } }>
+					{ selectedItems.map( ( item, idx ) => (
+						<ListComponent
+							key={ item.id }
+							index={ idx }
+							option={ item.label }
+							unselectValue={ ( _label, index ) => {
+								const target = selectedItems[ index ];
+								if ( target ) removeItem( target );
+							} }
+						/>
+					) ) }
+				</div>
+			</div>
+		);
+	}
+);
+
+FormAutocompleteMultiselectSentinel.displayName = 'FormAutocompleteMultiselectSentinel';
+
+export { FormAutocompleteMultiselectSentinel };

--- a/src/system/NewForm/FormAutocompleteMultiselectSentinel.tsx
+++ b/src/system/NewForm/FormAutocompleteMultiselectSentinel.tsx
@@ -293,7 +293,7 @@ const FormAutocompleteMultiselectSentinel = React.forwardRef<
 		const isFirstRender = useRef( true );
 
 		// ── DOM refs ────────────────────────────────────────────────────────────
-		const inputRef = useRef< HTMLInputElement >( null );
+		const inputRef = useRef< HTMLInputElement | null >( null );
 		const listboxRef = useRef< HTMLUListElement >( null );
 		const containerRef = useRef< HTMLDivElement >( null );
 		const optionRefs = useRef< ( HTMLLIElement | null )[] >( [] );
@@ -308,7 +308,7 @@ const FormAutocompleteMultiselectSentinel = React.forwardRef<
 		// Access theme outline styles directly to avoid the problematic
 		// `{ '&': fn }` sx pattern which can cause rendering issues.
 		const { theme } = useThemeUI();
-		const outlineStyles = ( ( theme as any ).outline ?? {} ) as Record< string, string >;
+		const outlineStyles = ( theme as { outline?: Record< string, string > } ).outline ?? {};
 
 		// ── Derived flags ───────────────────────────────────────────────────────
 		const isAsync = Boolean( onFetchItems );
@@ -394,6 +394,8 @@ const FormAutocompleteMultiselectSentinel = React.forwardRef<
 		 */
 		const runTwoStageSearch = useCallback(
 			async ( query: string, gen: number ) => {
+				if ( ! onFetchLabels || ! onFetchByIds ) return;
+
 				setIsSearchMode( true );
 				setIsSearching( true );
 				setSearchError( false );
@@ -401,16 +403,20 @@ const FormAutocompleteMultiselectSentinel = React.forwardRef<
 				setLoadAnnouncement( 'Searching for more results.' );
 
 				try {
-					// Stage 1: Scan all remaining pages for labels
+					// Stage 1: Scan all remaining pages for labels sequentially
 					const allNewLabels: Array< { id: string | number; label: string } > = [];
 					let labelPage = pageRef.current;
+					let hasMoreLabels = true;
 
-					while ( true ) {
+					while ( hasMoreLabels ) {
 						if ( searchGenRef.current !== gen ) return;
-						const labels = await onFetchLabels!( labelPage );
+						// eslint-disable-next-line no-await-in-loop
+						const labels = await onFetchLabels( labelPage );
 						allNewLabels.push( ...labels );
 						labelPage++;
-						if ( labels.length < pageSize ) break;
+						if ( labels.length < pageSize ) {
+							hasMoreLabels = false;
+						}
 					}
 
 					if ( searchGenRef.current !== gen ) return;
@@ -427,7 +433,7 @@ const FormAutocompleteMultiselectSentinel = React.forwardRef<
 					let newItems: ComboboxItem[] = [];
 					if ( matchingIds.length > 0 ) {
 						if ( searchGenRef.current !== gen ) return;
-						newItems = await onFetchByIds!( matchingIds );
+						newItems = await onFetchByIds( matchingIds );
 					}
 
 					if ( searchGenRef.current !== gen ) return;
@@ -692,6 +698,41 @@ const FormAutocompleteMultiselectSentinel = React.forwardRef<
 
 		const inlineLabel = Boolean( isInline && label );
 
+		// ── Sentinel content ─────────────────────────────────────────────────────
+		let sentinelContent: React.ReactNode;
+		if ( isLoadingMore ) {
+			sentinelContent = (
+				<Flex sx={ { alignItems: 'center', gap: 2, color: 'input.text.placeholder' } }>
+					<Spinner size={ 14 } />
+					Loading more results…
+				</Flex>
+			);
+		} else if ( fetchError ) {
+			sentinelContent = (
+				<Flex sx={ { alignItems: 'center', gap: 2, color: 'error' } }>
+					<MdWarning size={ 14 } aria-hidden="true" />
+					Error loading additional results.
+				</Flex>
+			);
+		} else if ( isSearching ) {
+			sentinelContent = (
+				<Flex sx={ { alignItems: 'center', gap: 2, color: 'input.text.placeholder' } }>
+					<Spinner size={ 14 } />
+					Searching for more results…
+				</Flex>
+			);
+		} else if ( searchError ) {
+			sentinelContent = (
+				<Flex sx={ { alignItems: 'center', gap: 2, color: 'error' } }>
+					<MdWarning size={ 14 } aria-hidden="true" />
+					Error — search failed. Please try again.
+				</Flex>
+			);
+		} else {
+			// Invisible scroll trigger when idle with more browse pages remaining
+			sentinelContent = <span sx={ srOnly } aria-hidden="true" />;
+		}
+
 		// ── Render ───────────────────────────────────────────────────────────────
 		return (
 			<div
@@ -737,12 +778,11 @@ const FormAutocompleteMultiselectSentinel = React.forwardRef<
 
 						<input
 							ref={ node => {
-								( inputRef as React.MutableRefObject< HTMLInputElement | null > ).current = node;
+								inputRef.current = node;
 								if ( typeof forwardRef === 'function' ) {
 									forwardRef( node );
 								} else if ( forwardRef ) {
-									( forwardRef as React.MutableRefObject< HTMLInputElement | null > ).current =
-										node;
+									forwardRef.current = node;
 								}
 							} }
 							id={ forLabel }
@@ -795,7 +835,7 @@ const FormAutocompleteMultiselectSentinel = React.forwardRef<
 									cursor: 'pointer',
 									flexShrink: 0,
 									'&:hover': { color: 'text' },
-									'&:focus-visible': ( theme: any ) => theme.outline,
+									'&:focus-visible': outlineStyles,
 								} }
 							>
 								<MdClose size={ 14 } aria-hidden="true" />
@@ -880,7 +920,12 @@ const FormAutocompleteMultiselectSentinel = React.forwardRef<
 											...optionBaseStyles,
 											...( isActive
 												? optionActiveStyles
-												: { '&:hover': { backgroundColor: 'input.background.primary', color: '#ffffff' } } ),
+												: {
+														'&:hover': {
+															backgroundColor: 'input.background.primary',
+															color: '#ffffff',
+														},
+												  } ),
 										} }
 										onClick={ () => selectItem( item ) }
 										onMouseEnter={ () => setActiveIndex( index ) }
@@ -894,34 +939,10 @@ const FormAutocompleteMultiselectSentinel = React.forwardRef<
 							{ /* Sentinel — loading, searching, error, or invisible scroll trigger */ }
 							{ showSentinel && (
 								<li
-									role="none"
 									aria-hidden="true"
 									sx={ { px: 3, py: 2, fontSize: 'inherit', cursor: 'default' } }
 								>
-									{ isLoadingMore ? (
-										<Flex sx={ { alignItems: 'center', gap: 2, color: 'input.text.placeholder' } }>
-											<Spinner size={ 14 } />
-											Loading more results…
-										</Flex>
-									) : fetchError ? (
-										<Flex sx={ { alignItems: 'center', gap: 2, color: 'error' } }>
-											<MdWarning size={ 14 } aria-hidden="true" />
-											Error loading additional results.
-										</Flex>
-									) : isSearching ? (
-										<Flex sx={ { alignItems: 'center', gap: 2, color: 'input.text.placeholder' } }>
-											<Spinner size={ 14 } />
-											Searching for more results…
-										</Flex>
-									) : searchError ? (
-										<Flex sx={ { alignItems: 'center', gap: 2, color: 'error' } }>
-											<MdWarning size={ 14 } aria-hidden="true" />
-											Error — search failed. Please try again.
-										</Flex>
-									) : (
-										// Invisible scroll trigger when idle with more browse pages remaining
-										<span sx={ srOnly } aria-hidden="true" />
-									) }
+									{ sentinelContent }
 								</li>
 							) }
 						</ul>

--- a/src/system/NewForm/index.js
+++ b/src/system/NewForm/index.js
@@ -6,6 +6,7 @@ import { Fieldset } from './Fieldset';
 import { Form } from './Form';
 import { FormAutocomplete } from './FormAutocomplete';
 import { FormAutocompleteMultiselect } from './FormAutocompleteMultiselect';
+import { FormAutocompleteMultiselectSentinel } from './FormAutocompleteMultiselectSentinel';
 import { FormSelect } from './FormSelect';
 import { Legend } from './Legend';
 import { Input } from '../Form/Input';
@@ -16,6 +17,7 @@ import { Textarea } from '../Form/Textarea';
 const Select = FormSelect;
 const Autocomplete = FormAutocomplete;
 const AutocompleteMulti = FormAutocompleteMultiselect;
+const AutocompleteMultiSentinel = FormAutocompleteMultiselectSentinel;
 const Root = Form;
 
 export {
@@ -23,6 +25,7 @@ export {
 	Select,
 	Autocomplete,
 	AutocompleteMulti,
+	AutocompleteMultiSentinel,
 	Textarea,
 	Input,
 	InputWithCopyButton,


### PR DESCRIPTION
## Summary

- Adds a new `FormAutocompleteMultiselectSentinel` component to `src/system/NewForm/` — a fully custom autocomplete multiselect with scroll-triggered pagination, two-stage type-ahead search, and a sentinel element for loading/error states
- Exported from `NewForm/index.js` as `AutocompleteMultiSentinel`
- Matches the original `FormAutocompleteMultiselect` two-argument `onChange(selectedOptions, labels)` signature for compatibility

## New capabilities (beyond existing variants)

- **Scroll-triggered pagination** — `onFetchItems(page)` fetches the next page when the user scrolls near the bottom of the dropdown
- **Two-stage type-ahead search** — `onFetchLabels` + `onFetchByIds` scan all pages for matching labels then fetch only the matching full items
- **Sentinel element** — visible loading spinner, error state, and invisible scroll trigger at the bottom of the listbox
- **Keyboard-only focus ring** — outline only appears on keyboard focus, not mouse interaction
- **Configurable debounce** — `debounce` prop (default 300ms) controls type-ahead search delay

## Test plan

- [ ] 29 unit tests passing (`npm run test`)
- [ ] jest-axe accessibility tests passing for default, static options, and error states
- [ ] Storybook stories cover: Default, WithInitialValue, WithBadges, WithValidationError, Inline, AsyncPagination, AsyncTwoStageSearch, AsyncFetchError
- [ ] Dropdown hover state text color matches existing component variants (`#ffffff` on `input.background.primary`)
- [ ] Args table visible on Docs page in Storybook with all props categorised and described

🤖 Generated with [Claude Code](https://claude.com/claude-code)