### PR TITLE
Add Wizard summaryFontWeight/overflow props and AutocompleteMulti inline chips variant

### DIFF
--- a/src/system/DescriptionList/DescriptionList.tsx
+++ b/src/system/DescriptionList/DescriptionList.tsx
@@ -1,7 +1,7 @@
 /**
  * External dependencies
  */
-import { forwardRef } from 'react';
+import { type CSSProperties, forwardRef } from 'react';
 import { ThemeUIStyleObject } from 'theme-ui';
 
 /**
@@ -35,7 +35,7 @@ export interface DescriptionListProps {
 	 * The font weight applied to values in the list.
 	 * @default 'bold'
 	 */
-	fontWeight?: string;
+	fontWeight?: CSSProperties[ 'fontWeight' ];
 }
 
 const TableComponent = ( {
@@ -81,6 +81,7 @@ const DescriptionListComponent = ( {
 	sx,
 	title,
 	labelWidth = '100px',
+	fontWeight,
 }: DescriptionListProps ) => (
 	<Box className={ className } sx={ sx }>
 		{ title && <Text sx={ { fontSize: 2 } }>{ title }</Text> }
@@ -94,6 +95,7 @@ const DescriptionListComponent = ( {
 					gap: 2,
 					alignItems: 'flex-start',
 					color: 'texts.helper',
+					...( fontWeight ? { '& > dd': { fontWeight } } : {} ),
 				} }
 			>
 				<dt>{ item.label }:</dt>

--- a/src/system/DescriptionList/DescriptionList.tsx
+++ b/src/system/DescriptionList/DescriptionList.tsx
@@ -31,9 +31,20 @@ export interface DescriptionListProps {
 	 * @default 'dl'
 	 */
 	as?: 'table' | 'dl';
+	/**
+	 * The font weight applied to values in the list.
+	 * @default 'bold'
+	 */
+	fontWeight?: string;
 }
 
-const TableComponent = ( { list, className, sx, title }: DescriptionListProps ) => (
+const TableComponent = ( {
+	list,
+	className,
+	sx,
+	title,
+	fontWeight = 'bold',
+}: DescriptionListProps ) => (
 	<Table
 		caption={ `Summary of ${ title?.toString() }` }
 		className={ className }
@@ -57,9 +68,7 @@ const TableComponent = ( { list, className, sx, title }: DescriptionListProps ) 
 						{ item.label }
 						{ item.value ? ':' : '' }
 					</TableCell>
-					<TableCell sx={ { color: 'text' } }>
-						<strong>{ item.value }</strong>
-					</TableCell>
+					<TableCell sx={ { color: 'text', fontWeight } }>{ item.value }</TableCell>
 				</TableRow>
 			) ) }
 		</tbody>
@@ -99,7 +108,15 @@ const DescriptionListComponent = ( {
  */
 const DescriptionList = forwardRef< HTMLDivElement, DescriptionListProps >(
 	(
-		{ sx, className, list, labelWidth = '100px', as = 'dl', title }: DescriptionListProps,
+		{
+			sx,
+			className,
+			list,
+			labelWidth = '100px',
+			as = 'dl',
+			title,
+			fontWeight,
+		}: DescriptionListProps,
 		ref
 	) => {
 		const Component = as === 'table' ? TableComponent : DescriptionListComponent;
@@ -112,6 +129,7 @@ const DescriptionList = forwardRef< HTMLDivElement, DescriptionListProps >(
 					sx={ sx }
 					labelWidth={ labelWidth }
 					title={ title }
+					fontWeight={ fontWeight }
 				/>
 			</Box>
 		);

--- a/src/system/NewForm/FormAutocompleteMultiselect.jsx
+++ b/src/system/NewForm/FormAutocompleteMultiselect.jsx
@@ -13,6 +13,7 @@ import React, { useCallback, useEffect, useMemo, useState } from 'react';
  */
 import { FormAutocompleteMultiselectBadge } from './FormAutocompleteMultiselectBadge';
 import { FormAutocompleteMultiselectButton } from './FormAutocompleteMultiselectButton';
+import { FormAutocompleteMultiselectChip } from './FormAutocompleteMultiselectChip';
 import { FormSelectArrow } from './FormSelectArrow';
 import { FormSelectContent } from './FormSelectContent';
 import { FormSelectLoading } from './FormSelectLoading';
@@ -96,6 +97,24 @@ const searchIconStyles = {
 	},
 };
 
+const inlineChipsStyles = {
+	display: 'flex',
+	flexWrap: 'wrap',
+	alignItems: 'center',
+	gap: '2px',
+	py: '4px',
+	px: 2,
+	'& .autocomplete__wrapper': {
+		flex: '1 1 80px',
+		minWidth: '80px',
+	},
+	'& .autocomplete__input': {
+		paddingLeft: '4px',
+		minHeight: '28px',
+		lineHeight: '28px',
+	},
+};
+
 const DefaultArrow = config => <FormSelectArrow classNames={ config.className } />;
 
 const AddSelectionStatus = ( { status } ) => {
@@ -156,6 +175,7 @@ const FormAutocompleteMultiselect = React.forwardRef(
 			listType = 'button',
 			initialValue = [],
 			allowCustom = false,
+			variant = 'default',
 			...props
 		},
 		forwardRef
@@ -165,8 +185,10 @@ const FormAutocompleteMultiselect = React.forwardRef(
 			REMOVE: 'remove',
 			NONE: 'none',
 		};
-		const ListComponent =
+		const isInlineVariant = variant === 'inline';
+		const defaultListComponent =
 			listType === 'button' ? FormAutocompleteMultiselectButton : FormAutocompleteMultiselectBadge;
+		const ListComponent = isInlineVariant ? FormAutocompleteMultiselectChip : defaultListComponent;
 		const [ isDirty, setIsDirty ] = useState( false );
 		const [ selectedOptions, setSelectedOptions ] = useState( initialValue );
 		const [ addStatus, setAddStatus ] = useState( '' );
@@ -357,8 +379,18 @@ const FormAutocompleteMultiselect = React.forwardRef(
 						...defaultStyles,
 						...( isInline && inlineStyles ),
 						...( searchIcon && searchIconStyles ),
+						...( isInlineVariant && inlineChipsStyles ),
 					} }
 				>
+					{ isInlineVariant &&
+						selectedOptions.map( ( option, idx ) => (
+							<ListComponent
+								key={ idx }
+								index={ idx }
+								option={ option }
+								unselectValue={ unselectValue }
+							/>
+						) ) }
 					<FormSelectContent
 						isInline={ inlineLabel }
 						label={ inlineLabel ? <SelectLabel /> : null }
@@ -367,7 +399,7 @@ const FormAutocompleteMultiselect = React.forwardRef(
 						<Autocomplete
 							id={ forLabel }
 							aria-busy={ loading }
-							showAllValues={ showAllValues }
+							showAllValues={ isInlineVariant || showAllValues }
 							ref={ forwardRef }
 							source={ source || suggest }
 							defaultValue={ value }
@@ -375,7 +407,7 @@ const FormAutocompleteMultiselect = React.forwardRef(
 							onConfirm={ onValueChange }
 							tNoResults={ noOptionsMessage }
 							required={ required }
-							dropdownArrow={ showAllValues ? dropdownArrow : () => '' }
+							dropdownArrow={ isInlineVariant || showAllValues ? dropdownArrow : () => '' }
 							confirmOnBlur={ false }
 							{ ...props }
 						/>
@@ -393,17 +425,19 @@ const FormAutocompleteMultiselect = React.forwardRef(
 						{ selectedOptions.length } item{ selectedOptions.length === 1 ? '' : 's' } selected
 					</div>
 				</Flex>
-				<div sx={ { display: 'inline-flex', flexWrap: 'wrap', maxWidth: '100%' } }>
-					{ selectedOptions &&
-						selectedOptions.map( ( option, idx ) => (
-							<ListComponent
-								key={ idx }
-								index={ idx }
-								option={ option }
-								unselectValue={ unselectValue }
-							/>
-						) ) }
-				</div>
+				{ ! isInlineVariant && (
+					<div sx={ { display: 'inline-flex', flexWrap: 'wrap', maxWidth: '100%' } }>
+						{ selectedOptions &&
+							selectedOptions.map( ( option, idx ) => (
+								<ListComponent
+									key={ idx }
+									index={ idx }
+									option={ option }
+									unselectValue={ unselectValue }
+								/>
+							) ) }
+					</div>
+				) }
 			</div>
 		);
 	}
@@ -435,6 +469,7 @@ FormAutocompleteMultiselect.propTypes = {
 	dropdownArrow: PropTypes.node,
 	initialValue: PropTypes.array,
 	allowCustom: PropTypes.bool,
+	variant: PropTypes.oneOf( [ 'default', 'inline' ] ),
 };
 
 FormAutocompleteMultiselect.displayName = 'FormAutocompleteMultiselect';

--- a/src/system/NewForm/FormAutocompleteMultiselect.stories.jsx
+++ b/src/system/NewForm/FormAutocompleteMultiselect.stories.jsx
@@ -120,6 +120,27 @@ export const Inline = {
 	},
 };
 
+export const InlineChips = {
+	render: props => <DefaultComponent { ...props } />,
+	args: {
+		...args,
+		variant: 'inline',
+		showAllValues: true,
+		placeholder: 'Type to filter...',
+	},
+};
+
+export const InlineChipsWithInitialValue = {
+	render: props => <DefaultComponent { ...props } />,
+	args: {
+		...args,
+		variant: 'inline',
+		showAllValues: true,
+		placeholder: 'Type to filter...',
+		initialValue: shortOptions.slice( 0, 3 ).map( option => option.label ),
+	},
+};
+
 export const WithStaticData = {
 	render: props => <DefaultComponent { ...props } />,
 	args: {

--- a/src/system/NewForm/FormAutocompleteMultiselectChip.tsx
+++ b/src/system/NewForm/FormAutocompleteMultiselectChip.tsx
@@ -1,0 +1,68 @@
+/** @jsxImportSource theme-ui */
+
+/**
+ * External dependencies
+ */
+import { MdClose } from 'react-icons/md';
+
+const FormAutocompleteMultiselectChip = ( {
+	index,
+	option,
+	unselectValue,
+}: {
+	index: number;
+	option: string;
+	unselectValue: ( option: string, index: number ) => void;
+} ) => {
+	return (
+		<span
+			key={ index }
+			sx={ {
+				display: 'inline-flex',
+				alignItems: 'center',
+				backgroundColor: 'input.background.secondary',
+				borderRadius: '12px',
+				px: 2,
+				py: '2px',
+				m: '2px',
+				fontSize: 1,
+				lineHeight: 'normal',
+				maxWidth: '100%',
+				whiteSpace: 'nowrap',
+			} }
+		>
+			<span
+				sx={ {
+					overflow: 'hidden',
+					textOverflow: 'ellipsis',
+				} }
+			>
+				{ option }
+			</span>
+			<button
+				type="button"
+				aria-label={ `Remove ${ option }` }
+				onClick={ e => {
+					e.preventDefault();
+					e.stopPropagation();
+					unselectValue( option, index );
+				} }
+				sx={ {
+					display: 'inline-flex',
+					alignItems: 'center',
+					background: 'none',
+					border: 'none',
+					cursor: 'pointer',
+					p: 0,
+					ml: 1,
+					color: 'inherit',
+					'&:hover': { opacity: 0.7 },
+				} }
+			>
+				<MdClose size={ 14 } />
+			</button>
+		</span>
+	);
+};
+
+export { FormAutocompleteMultiselectChip };

--- a/src/system/Wizard/Wizard.stories.tsx
+++ b/src/system/Wizard/Wizard.stories.tsx
@@ -185,6 +185,68 @@ export const WithTitleAutoFocus: Story = {
 	},
 };
 
+export const WithSummaryFontWeight: Story = {
+	render: () => {
+		const steps: WizardStepProps[] = [
+			{
+				title: 'Choose Domain',
+				titleVariant: 'h3',
+				summary: [
+					{
+						label: 'Domain',
+						value: 'example.com',
+					},
+				],
+				onChange: () => {},
+			},
+			{
+				title: 'Configure DNS',
+				titleVariant: 'h3',
+				summary: [
+					{
+						label: 'Status',
+						value: 'Configured',
+					},
+				],
+				onChange: () => {},
+			},
+		];
+		return (
+			<Box mt={ 4 }>
+				<Wizard
+					activeStep={ undefined }
+					steps={ steps }
+					completed={ [ 0, 1 ] }
+					summaryAs="table"
+					summaryFontWeight="normal"
+				/>
+			</Box>
+		);
+	},
+};
+
+export const WithOverflow: Story = {
+	render: () => {
+		const steps: WizardStepProps[] = [
+			{
+				title: 'Step with tooltip',
+				titleVariant: 'h3',
+				subTitle: 'Hover over the text below to see the tooltip.',
+				children: (
+					<Box sx={ { position: 'relative' } }>
+						<Text>Content with a tooltip that needs visible overflow</Text>
+					</Box>
+				),
+			},
+		];
+		return (
+			<Box mt={ 4 }>
+				<Wizard activeStep={ 0 } steps={ steps } overflow="visible" />
+			</Box>
+		);
+	},
+};
+
 export const HideStepText: Story = {
 	render: () => {
 		const [ activeStep, setActiveStep ] = React.useState< number | undefined >( undefined );

--- a/src/system/Wizard/Wizard.tsx
+++ b/src/system/Wizard/Wizard.tsx
@@ -44,6 +44,16 @@ export interface WizardProps {
 	 * @default 'table'
 	 */
 	summaryAs?: 'table' | 'dl';
+	/**
+	 * The font weight applied to summary values in all steps.
+	 * @default 'bold'
+	 */
+	summaryFontWeight?: string;
+	/**
+	 * The CSS overflow property for each step container.
+	 * @default 'inherit'
+	 */
+	overflow?: string;
 }
 
 /**
@@ -61,6 +71,8 @@ export const Wizard = React.forwardRef< HTMLDivElement, WizardProps >(
 			titleAutofocus = false,
 			showStepText = true,
 			summaryAs = 'table',
+			summaryFontWeight,
+			overflow,
 		},
 		forwardRef
 	) => {
@@ -88,6 +100,8 @@ export const Wizard = React.forwardRef< HTMLDivElement, WizardProps >(
 							actionIcon,
 							actionDisabled,
 							summaryTitle,
+							summaryFontWeight: stepSummaryFontWeight,
+							overflow: stepOverflow,
 						},
 						index
 					) => (
@@ -110,6 +124,8 @@ export const Wizard = React.forwardRef< HTMLDivElement, WizardProps >(
 							summaryAs={ summaryAs }
 							summaryTitle={ summaryTitle }
 							actionDisabled={ actionDisabled }
+							summaryFontWeight={ stepSummaryFontWeight || summaryFontWeight }
+							overflow={ stepOverflow || overflow }
 						>
 							{ children }
 						</WizardStep>

--- a/src/system/Wizard/Wizard.tsx
+++ b/src/system/Wizard/Wizard.tsx
@@ -48,12 +48,12 @@ export interface WizardProps {
 	 * The font weight applied to summary values in all steps.
 	 * @default 'bold'
 	 */
-	summaryFontWeight?: string;
+	summaryFontWeight?: React.CSSProperties[ 'fontWeight' ];
 	/**
 	 * The CSS overflow property for each step container.
 	 * @default 'inherit'
 	 */
-	overflow?: string;
+	overflow?: React.CSSProperties[ 'overflow' ];
 }
 
 /**

--- a/src/system/Wizard/WizardStep.tsx
+++ b/src/system/Wizard/WizardStep.tsx
@@ -78,6 +78,16 @@ export interface WizardStepProps {
 	 * @default true
 	 */
 	showStepText?: boolean;
+	/**
+	 * The font weight applied to summary values.
+	 * @default 'bold'
+	 */
+	summaryFontWeight?: string;
+	/**
+	 * The CSS overflow property for the step container.
+	 * @default 'inherit'
+	 */
+	overflow?: string;
 }
 
 /**
@@ -105,6 +115,8 @@ export const WizardStep = React.forwardRef< HTMLDivElement, WizardStepProps >(
 			actionIcon,
 			actionDisabled = false,
 			showStepText = true,
+			summaryFontWeight,
+			overflow = 'inherit',
 		},
 		forwardRef
 	) => {
@@ -157,7 +169,7 @@ export const WizardStep = React.forwardRef< HTMLDivElement, WizardStepProps >(
 					},
 					borderColor: 'wizard.step.border.default',
 					borderLeftColor,
-					overflow: 'inherit',
+					overflow,
 					py: 1,
 				} }
 				data-step={ order }
@@ -223,6 +235,7 @@ export const WizardStep = React.forwardRef< HTMLDivElement, WizardStepProps >(
 						list={ summary || [] }
 						title={ summaryTitle }
 						sx={ { mt: 2 } }
+						fontWeight={ summaryFontWeight }
 					/>
 				) }
 

--- a/src/system/Wizard/WizardStep.tsx
+++ b/src/system/Wizard/WizardStep.tsx
@@ -82,12 +82,12 @@ export interface WizardStepProps {
 	 * The font weight applied to summary values.
 	 * @default 'bold'
 	 */
-	summaryFontWeight?: string;
+	summaryFontWeight?: React.CSSProperties[ 'fontWeight' ];
 	/**
 	 * The CSS overflow property for the step container.
 	 * @default 'inherit'
 	 */
-	overflow?: string;
+	overflow?: React.CSSProperties[ 'overflow' ];
 }
 
 /**


### PR DESCRIPTION
## Summary

Addresses [VIP-2782](https://linear.app/a8c/issue/VIP-2782) — design system updates needed for the Wizard and AutocompleteMulti components.

### Changes

**Wizard / WizardStep:**
- `summaryFontWeight` prop — controls the font weight of summary values (defaults to `'bold'` for backward compatibility). Pass `'normal'` to remove bold styling.
- `overflow` prop — controls CSS overflow on each step container (defaults to `'inherit'`). Pass `'visible'` to prevent tooltip clipping inside wizard steps.
- Both props can be set at the `Wizard` level (applies to all steps) or per-step (overrides Wizard-level).

**DescriptionList:**
- `fontWeight` prop — replaces the hardcoded `<strong>` tag with a configurable `fontWeight` CSS property on values.

**FormAutocompleteMultiselect:**
- `variant="inline"` — new variant that renders selected items as inline removable chips inside the input container instead of below it. The full option list loads in the dropdown, supporting both typing-to-filter and scrolling.
- New `FormAutocompleteMultiselectChip` component for the inline chip rendering.

### Storybook stories added
- `WithSummaryFontWeight` — Wizard with non-bold summary values
- `WithOverflow` — Wizard with visible overflow
- `InlineChips` — AutocompleteMulti with inline chip variant
- `InlineChipsWithInitialValue` — same, pre-populated

## Test plan

- [ ] Verify existing Wizard stories still render correctly (no visual regression)
- [ ] Verify `WithSummaryFontWeight` story shows non-bold summary text
- [ ] Verify `WithOverflow` story doesn't clip child content
- [ ] Verify `InlineChips` story: select items → chips appear inside input, deselect via chip X button
- [ ] Verify `InlineChipsWithInitialValue` renders pre-selected chips
- [ ] Verify keyboard navigation works in inline chips variant
- [ ] Run `npm run check-types` — no new type errors

🤖 Generated with [Claude Code](https://claude.com/claude-code)