### PR TITLE
[VIP-2897] Add inline-chips variant for AutocompleteMulti

### DIFF
--- a/src/system/NewForm/FormAutocompleteMultiselect.jsx
+++ b/src/system/NewForm/FormAutocompleteMultiselect.jsx
@@ -106,73 +106,32 @@ const searchIconStyles = {
 };
 
 const inlineChipsContainerStyles = {
-	...baseBorderTextColors,
-	width: '100%',
+	...defaultStyles,
 	display: 'flex',
 	flexWrap: 'wrap',
 	alignItems: 'center',
 	p: 1,
-	pr: 7,
+	pr: 0,
 	position: 'relative',
-	minHeight: '36px',
+	'& .autocomplete__input': {
+		...defaultStyles[ '& .autocomplete__input' ],
+		lineHeight: '24px',
+		minHeight: '24px',
+	},
 	'&:focus-within': theme => theme.outline,
 	'& .autocomplete__wrapper': {
 		position: 'static',
 		width: '100%',
-	},
-	'& .autocomplete__input': {
-		width: '100%',
-		paddingLeft: 2,
-		py: 0,
-		borderWidth: 0,
-		color: 'text',
-		bg: 'transparent',
-		minHeight: '28px',
-		lineHeight: '28px',
-		'&:focus-visible': { outlineWidth: 0, boxShadow: 'none' },
-		'&:focus-within': { outlineWidth: 0, boxShadow: 'none' },
-		'&.autocomplete__input--focused': { outlineWidth: 0, boxShadow: 'none' },
-		'&.autocomplete__input--show-all-values': { paddingRight: 7 },
-		'&::placeholder': {
-			color: 'input.text.placeholder',
-			opacity: 1,
+		lineHeight: '24px',
+		minHeight: '24px',
+		'& .autocomplete__dropdown-arrow-down': {
+			top: 'unset',
+			bottom: '6px',
 		},
-	},
-	'& .autocomplete__menu': {
-		...baseBorderTextColors,
-		position: 'absolute',
-		left: '-1px',
-		right: '-1px',
-		top: '100%',
-		width: 'auto',
-		zIndex: 100,
-		boxShadow: 'rgba(0, 0, 0, 0.257) 0px 2px 6px',
-	},
-	'& .autocomplete__hint, & .autocomplete__input, & .autocomplete__option': {
-		fontSize: 'inherit',
-	},
-	'& .autocomplete__option': {
-		borderColor: baseControlBorderStyle.borderColor,
-	},
-	'& .autocomplete__option--odd': {
-		bg: 'layer.1',
-	},
-	'& .autocomplete__option:hover, & .autocomplete__option--focused': {
-		bg: 'input.background.primary',
-		borderColor: 'input.background.primary',
-	},
-	'& .autocomplete__hint': {
-		border: 'none',
-		paddingLeft: 2,
-		minHeight: '27px',
-		lineHeight: '27px',
-	},
-	'& .autocomplete__input--show-all-values': {
-		paddingRight: 0,
 	},
 };
 
-const DefaultArrow = config => <FormSelectArrow classNames={ config.className } />;
+const DefaultArrow = config => <FormSelectArrow className={ config.className } />;
 
 const AddSelectionStatus = ( { status } ) => {
 	return (

--- a/src/system/NewForm/FormAutocompleteMultiselect.jsx
+++ b/src/system/NewForm/FormAutocompleteMultiselect.jsx
@@ -104,6 +104,7 @@ const inlineChipsContainerStyles = {
 	flexWrap: 'wrap',
 	alignItems: 'center',
 	p: 1,
+	pr: 7,
 	position: 'relative',
 	minHeight: '36px',
 	'&:focus-within': theme => theme.outline,
@@ -481,6 +482,7 @@ const FormAutocompleteMultiselect = React.forwardRef(
 								confirmOnBlur={ false }
 								templates={ inlineChipsTemplates }
 								{ ...props }
+								placeholder={ selectedOptions.length > 0 ? '' : props.placeholder || '' }
 							/>
 						</div>
 						{ addStatus && <AddSelectionStatus status={ addStatus } /> }

--- a/src/system/NewForm/FormAutocompleteMultiselect.jsx
+++ b/src/system/NewForm/FormAutocompleteMultiselect.jsx
@@ -245,6 +245,7 @@ const FormAutocompleteMultiselect = React.forwardRef(
 			option: null,
 			index: -1,
 		} );
+		const justSelectedRef = React.useRef( false );
 		let debounceTimeout;
 		forwardRef = forwardRef || React.createRef();
 
@@ -369,6 +370,7 @@ const FormAutocompleteMultiselect = React.forwardRef(
 				if ( ! inputValue ) {
 					return;
 				}
+				justSelectedRef.current = true;
 				if ( selectedOptions.includes( inputValue ) ) {
 					unselectValue( inputValue, selectedOptions.indexOf( inputValue ) );
 				} else {
@@ -432,7 +434,16 @@ const FormAutocompleteMultiselect = React.forwardRef(
 				selectedOptions,
 				selectedOptions.map( option => option?.label || option )
 			);
-			resetInputState();
+			if ( isInlineChips && justSelectedRef.current && forwardRef?.current ) {
+				justSelectedRef.current = false;
+				forwardRef.current.setState( {
+					...forwardRef.current.state,
+					query: '',
+					menuOpen: true,
+				} );
+			} else {
+				resetInputState();
+			}
 		}, [ selectedOptions ] );
 
 		// Update the select status for screen readers

--- a/src/system/NewForm/FormAutocompleteMultiselect.jsx
+++ b/src/system/NewForm/FormAutocompleteMultiselect.jsx
@@ -439,12 +439,16 @@ const FormAutocompleteMultiselect = React.forwardRef(
 			if ( currentOption.action === OPTION_ACTION.ADD ) {
 				setAddStatus( `${ currentOption.option } added to the list.` );
 				setCurrentOption( { action: OPTION_ACTION.NONE, option: null } );
-			} else if ( currentOption.index === selectedOptions.length && selectedOptions.length > 0 ) {
-				// Move focus to the first selected item, if the last element is removed and there are other elements in the list
-				global.document.querySelector( '.vip-button-component' )?.focus();
-			} else if ( selectedOptions.length === 0 ) {
-				// Move focus to the input field if the last element is removed and there are no other elements in the list
-				global.document.querySelector( '.autocomplete__input' )?.focus();
+			} else if ( currentOption.action === OPTION_ACTION.REMOVE ) {
+				setAddStatus( `${ currentOption.option } removed from the list.` );
+				if ( isInlineChips ) {
+					global.document.querySelector( `#${ forLabel }` )?.focus();
+				} else if ( currentOption.index === selectedOptions.length && selectedOptions.length > 0 ) {
+					global.document.querySelector( '.vip-button-component' )?.focus();
+				} else if ( selectedOptions.length === 0 ) {
+					global.document.querySelector( '.autocomplete__input' )?.focus();
+				}
+				setCurrentOption( { action: OPTION_ACTION.NONE, option: null } );
 			}
 		}, [ currentOption ] );
 
@@ -455,7 +459,7 @@ const FormAutocompleteMultiselect = React.forwardRef(
 					<div sx={ inlineChipsContainerStyles }>
 						{ selectedOptions.map( ( option, idx ) => (
 							<FormAutocompleteMultiselectInlineChip
-								key={ idx }
+								key={ option }
 								index={ idx }
 								option={ option }
 								unselectValue={ unselectValue }

--- a/src/system/NewForm/FormAutocompleteMultiselect.jsx
+++ b/src/system/NewForm/FormAutocompleteMultiselect.jsx
@@ -23,6 +23,14 @@ import { Validation } from '../Form';
 import { baseControlBorderStyle, inputBaseText } from '../Form/Input.styles';
 import { Label } from '../Form/Label';
 
+const escapeHtml = str =>
+	String( str )
+		.replace( /&/g, '&amp;' )
+		.replace( /</g, '&lt;' )
+		.replace( />/g, '&gt;' )
+		.replace( /"/g, '&quot;' )
+		.replace( /'/g, '&#039;' );
+
 const baseBorderTextColors = {
 	...baseControlBorderStyle,
 	backgroundColor: 'layer.2',
@@ -386,7 +394,9 @@ const FormAutocompleteMultiselect = React.forwardRef(
 				suggestion: suggestion => {
 					const isSelected = selectedOptions.includes( suggestion );
 					const check = isSelected ? '&#10003;' : '';
-					return `<span style="display:flex;align-items:center;gap:8px"><span style="width:16px;flex-shrink:0">${ check }</span>${ suggestion }</span>`;
+					return `<span style="display:flex;align-items:center;gap:8px"><span style="width:16px;flex-shrink:0">${ check }</span>${ escapeHtml(
+						suggestion
+					) }</span>`;
 				},
 			} ),
 			[ selectedOptions ]

--- a/src/system/NewForm/FormAutocompleteMultiselect.jsx
+++ b/src/system/NewForm/FormAutocompleteMultiselect.jsx
@@ -13,6 +13,7 @@ import React, { useCallback, useEffect, useMemo, useState } from 'react';
  */
 import { FormAutocompleteMultiselectBadge } from './FormAutocompleteMultiselectBadge';
 import { FormAutocompleteMultiselectButton } from './FormAutocompleteMultiselectButton';
+import { FormAutocompleteMultiselectInlineChip } from './FormAutocompleteMultiselectInlineChip';
 import { FormSelectArrow } from './FormSelectArrow';
 import { FormSelectContent } from './FormSelectContent';
 import { FormSelectLoading } from './FormSelectLoading';
@@ -96,6 +97,72 @@ const searchIconStyles = {
 	},
 };
 
+const inlineChipsContainerStyles = {
+	...baseBorderTextColors,
+	width: '100%',
+	display: 'flex',
+	flexWrap: 'wrap',
+	alignItems: 'center',
+	p: 1,
+	position: 'relative',
+	minHeight: '36px',
+	'&:focus-within': theme => theme.outline,
+	'& .autocomplete__wrapper': {
+		position: 'static',
+		width: '100%',
+	},
+	'& .autocomplete__input': {
+		width: '100%',
+		paddingLeft: 2,
+		py: 0,
+		borderWidth: 0,
+		color: 'text',
+		bg: 'transparent',
+		minHeight: '28px',
+		lineHeight: '28px',
+		'&:focus-visible': { outlineWidth: 0, boxShadow: 'none' },
+		'&:focus-within': { outlineWidth: 0, boxShadow: 'none' },
+		'&.autocomplete__input--focused': { outlineWidth: 0, boxShadow: 'none' },
+		'&.autocomplete__input--show-all-values': { paddingRight: 7 },
+		'&::placeholder': {
+			color: 'input.text.placeholder',
+			opacity: 1,
+		},
+	},
+	'& .autocomplete__menu': {
+		...baseBorderTextColors,
+		position: 'absolute',
+		left: '-1px',
+		right: '-1px',
+		top: '100%',
+		width: 'auto',
+		zIndex: 100,
+		boxShadow: 'rgba(0, 0, 0, 0.257) 0px 2px 6px',
+	},
+	'& .autocomplete__hint, & .autocomplete__input, & .autocomplete__option': {
+		fontSize: 'inherit',
+	},
+	'& .autocomplete__option': {
+		borderColor: baseControlBorderStyle.borderColor,
+	},
+	'& .autocomplete__option--odd': {
+		bg: 'layer.1',
+	},
+	'& .autocomplete__option:hover, & .autocomplete__option--focused': {
+		bg: 'input.background.primary',
+		borderColor: 'input.background.primary',
+	},
+	'& .autocomplete__hint': {
+		border: 'none',
+		paddingLeft: 2,
+		minHeight: '27px',
+		lineHeight: '27px',
+	},
+	'& .autocomplete__input--show-all-values': {
+		paddingRight: 0,
+	},
+};
+
 const DefaultArrow = config => <FormSelectArrow classNames={ config.className } />;
 
 const AddSelectionStatus = ( { status } ) => {
@@ -156,10 +223,12 @@ const FormAutocompleteMultiselect = React.forwardRef(
 			listType = 'button',
 			initialValue = [],
 			allowCustom = false,
+			variant,
 			...props
 		},
 		forwardRef
 	) => {
+		const isInlineChips = variant === 'inline-chips';
 		const OPTION_ACTION = {
 			ADD: 'add',
 			REMOVE: 'remove',
@@ -283,11 +352,41 @@ const FormAutocompleteMultiselect = React.forwardRef(
 					data = handleTypeChange( query );
 				}
 				const optionForDisplay = data?.map( option => optionLabel( option ) );
-				populateResults(
-					optionForDisplay.filter( option => ! selectedOptions.includes( option ) )
-				);
+				if ( isInlineChips ) {
+					populateResults( optionForDisplay );
+				} else {
+					populateResults(
+						optionForDisplay.filter( option => ! selectedOptions.includes( option ) )
+					);
+				}
 			},
-			[ autoFilter, isDirty, onInputChange, options, selectedOptions ]
+			[ autoFilter, isDirty, isInlineChips, onInputChange, options, selectedOptions ]
+		);
+
+		const onValueChangeInlineChips = useCallback(
+			inputValue => {
+				if ( ! inputValue ) {
+					return;
+				}
+				if ( selectedOptions.includes( inputValue ) ) {
+					unselectValue( inputValue, selectedOptions.indexOf( inputValue ) );
+				} else {
+					setCurrentOption( { action: OPTION_ACTION.ADD, option: inputValue } );
+					setSelectedOptions( [ ...selectedOptions, inputValue ] );
+				}
+			},
+			[ selectedOptions, unselectValue ]
+		);
+
+		const inlineChipsTemplates = useMemo(
+			() => ( {
+				suggestion: suggestion => {
+					const isSelected = selectedOptions.includes( suggestion );
+					const check = isSelected ? '&#10003;' : '';
+					return `<span style="display:flex;align-items:center;gap:8px"><span style="width:16px;flex-shrink:0">${ check }</span>${ suggestion }</span>`;
+				},
+			} ),
+			[ selectedOptions ]
 		);
 
 		useEffect( () => {
@@ -348,6 +447,51 @@ const FormAutocompleteMultiselect = React.forwardRef(
 				global.document.querySelector( '.autocomplete__input' )?.focus();
 			}
 		}, [ currentOption ] );
+
+		if ( isInlineChips ) {
+			return (
+				<div className={ classNames( 'vip-form-autocomplete-component', className ) }>
+					{ label && <SelectLabel /> }
+					<div sx={ inlineChipsContainerStyles }>
+						{ selectedOptions.map( ( option, idx ) => (
+							<FormAutocompleteMultiselectInlineChip
+								key={ idx }
+								index={ idx }
+								option={ option }
+								unselectValue={ unselectValue }
+							/>
+						) ) }
+						<div sx={ { flex: '1 1 120px', minWidth: '120px' } }>
+							<Autocomplete
+								id={ forLabel }
+								aria-busy={ loading }
+								showAllValues={ true }
+								ref={ forwardRef }
+								source={ source || suggest }
+								defaultValue={ value }
+								displayMenu={ displayMenu }
+								onConfirm={ onValueChangeInlineChips }
+								tNoResults={ noOptionsMessage }
+								required={ required }
+								dropdownArrow={ dropdownArrow }
+								confirmOnBlur={ false }
+								templates={ inlineChipsTemplates }
+								{ ...props }
+							/>
+						</div>
+						{ addStatus && <AddSelectionStatus status={ addStatus } /> }
+						{ loading && <FormSelectLoading sx={ { right: 7 } } /> }
+					</div>
+					{ hasError && errorMessage && (
+						<Flex sx={ { mt: 2 } }>
+							<Validation isValid={ false } describedId={ forLabel }>
+								{ errorMessage }
+							</Validation>
+						</Flex>
+					) }
+				</div>
+			);
+		}
 
 		return (
 			<div className={ classNames( 'vip-form-autocomplete-component', className ) }>
@@ -435,6 +579,7 @@ FormAutocompleteMultiselect.propTypes = {
 	dropdownArrow: PropTypes.node,
 	initialValue: PropTypes.array,
 	allowCustom: PropTypes.bool,
+	variant: PropTypes.string,
 };
 
 FormAutocompleteMultiselect.displayName = 'FormAutocompleteMultiselect';

--- a/src/system/NewForm/FormAutocompleteMultiselect.stories.jsx
+++ b/src/system/NewForm/FormAutocompleteMultiselect.stories.jsx
@@ -161,17 +161,6 @@ export const InlineChips = {
 	},
 };
 
-export const InlineChipsEmpty = {
-	render: props => <DefaultComponent { ...props } width={ 500 } />,
-	args: {
-		label: 'Tags',
-		options: shortOptions,
-		variant: 'inline-chips',
-		showAllValues: true,
-		placeholder: 'Select tags...',
-	},
-};
-
 export const WithDynamicData = {
 	render: () => {
 		const [ selectedValues, setSelectedValues ] = useState( [] );

--- a/src/system/NewForm/FormAutocompleteMultiselect.stories.jsx
+++ b/src/system/NewForm/FormAutocompleteMultiselect.stories.jsx
@@ -134,6 +134,44 @@ export const WithStaticData = {
 	},
 };
 
+export const InlineChips = {
+	render: props => <DefaultComponent { ...props } width={ 500 } />,
+	args: {
+		label: 'Post Categories',
+		options: [
+			{ value: 'breaking-news', label: 'Breaking News' },
+			{ value: 'world-news', label: 'World News' },
+			{ value: 'us-news', label: 'U.S. News' },
+			{ value: 'climate-environment', label: 'Climate & Environment' },
+			{ value: 'obituaries', label: 'Obituaries' },
+			{ value: 'technology', label: 'Technology' },
+			{ value: 'entertainment', label: 'Entertainment' },
+			{ value: 'real-estate', label: 'Real Estate' },
+		],
+		variant: 'inline-chips',
+		showAllValues: true,
+		placeholder: 'Search categories...',
+		initialValue: [
+			'Breaking News',
+			'World News',
+			'U.S. News',
+			'Climate & Environment',
+			'Obituaries',
+		],
+	},
+};
+
+export const InlineChipsEmpty = {
+	render: props => <DefaultComponent { ...props } width={ 500 } />,
+	args: {
+		label: 'Tags',
+		options: shortOptions,
+		variant: 'inline-chips',
+		showAllValues: true,
+		placeholder: 'Select tags...',
+	},
+};
+
 export const WithDynamicData = {
 	render: () => {
 		const [ selectedValues, setSelectedValues ] = useState( [] );

--- a/src/system/NewForm/FormAutocompleteMultiselect.stories.jsx
+++ b/src/system/NewForm/FormAutocompleteMultiselect.stories.jsx
@@ -151,13 +151,7 @@ export const InlineChips = {
 		variant: 'inline-chips',
 		showAllValues: true,
 		placeholder: 'Search categories...',
-		initialValue: [
-			'Breaking News',
-			'World News',
-			'U.S. News',
-			'Climate & Environment',
-			'Obituaries',
-		],
+		initialValue: [ 'Breaking News' ],
 	},
 };
 

--- a/src/system/NewForm/FormAutocompleteMultiselect.test.jsx
+++ b/src/system/NewForm/FormAutocompleteMultiselect.test.jsx
@@ -37,3 +37,36 @@ describe( '<FormAutocompleteMultiselect />', () => {
 		await expect( await axe( container ) ).toHaveNoViolations();
 	} );
 } );
+
+describe( '<FormAutocompleteMultiselect variant="inline-chips" />', () => {
+	it( 'renders the inline-chips variant', async () => {
+		const { container } = render(
+			<FormAutocompleteMultiselect
+				forLabel="my_inline_chips"
+				label="Categories"
+				options={ options }
+				variant="inline-chips"
+				showAllValues
+			/>
+		);
+		expect( screen.getByLabelText( 'Categories' ) ).toBeInTheDocument();
+		await expect( await axe( container ) ).toHaveNoViolations();
+	} );
+
+	it( 'renders initial values as inline chips', () => {
+		render(
+			<FormAutocompleteMultiselect
+				forLabel="my_inline_chips_init"
+				label="Categories"
+				options={ options }
+				variant="inline-chips"
+				showAllValues
+				initialValue={ [ 'Chocolate', 'Vanilla' ] }
+			/>
+		);
+		expect( screen.getByText( 'Chocolate' ) ).toBeInTheDocument();
+		expect( screen.getByText( 'Vanilla' ) ).toBeInTheDocument();
+		expect( screen.getByRole( 'button', { name: 'Remove Chocolate' } ) ).toBeInTheDocument();
+		expect( screen.getByRole( 'button', { name: 'Remove Vanilla' } ) ).toBeInTheDocument();
+	} );
+} );

--- a/src/system/NewForm/FormAutocompleteMultiselect.test.jsx
+++ b/src/system/NewForm/FormAutocompleteMultiselect.test.jsx
@@ -1,7 +1,7 @@
 /**
  * External dependencies
  */
-import { render, screen } from '@testing-library/react';
+import { fireEvent, render, screen } from '@testing-library/react';
 import { axe } from 'jest-axe';
 
 /**
@@ -68,5 +68,38 @@ describe( '<FormAutocompleteMultiselect variant="inline-chips" />', () => {
 		expect( screen.getByText( 'Vanilla' ) ).toBeInTheDocument();
 		expect( screen.getByRole( 'button', { name: 'Remove Chocolate' } ) ).toBeInTheDocument();
 		expect( screen.getByRole( 'button', { name: 'Remove Vanilla' } ) ).toBeInTheDocument();
+	} );
+
+	it( 'removes a chip when the close button is clicked', () => {
+		render(
+			<FormAutocompleteMultiselect
+				forLabel="my_inline_chips_remove"
+				label="Categories"
+				options={ options }
+				variant="inline-chips"
+				showAllValues
+				initialValue={ [ 'Chocolate', 'Vanilla' ] }
+			/>
+		);
+		expect( screen.getByText( 'Chocolate' ) ).toBeInTheDocument();
+		fireEvent.click( screen.getByRole( 'button', { name: 'Remove Chocolate' } ) );
+		expect( screen.queryByText( 'Chocolate' ) ).not.toBeInTheDocument();
+		expect( screen.getByText( 'Vanilla' ) ).toBeInTheDocument();
+	} );
+
+	it( 'announces removal to screen readers', () => {
+		const { container } = render(
+			<FormAutocompleteMultiselect
+				forLabel="my_inline_chips_a11y"
+				label="Categories"
+				options={ options }
+				variant="inline-chips"
+				showAllValues
+				initialValue={ [ 'Chocolate', 'Vanilla' ] }
+			/>
+		);
+		fireEvent.click( screen.getByRole( 'button', { name: 'Remove Chocolate' } ) );
+		const statusEl = container.querySelector( '#vip-autocompletemultiselect-status' );
+		expect( statusEl ).toHaveTextContent( 'Chocolate removed from the list.' );
 	} );
 } );

--- a/src/system/NewForm/FormAutocompleteMultiselectInlineChip.tsx
+++ b/src/system/NewForm/FormAutocompleteMultiselectInlineChip.tsx
@@ -24,7 +24,7 @@ const FormAutocompleteMultiselectInlineChip = ( {
 				py: '2px',
 				m: '2px',
 				bg: 'layer.1',
-				borderRadius: '12px',
+				borderRadius: 1,
 				fontSize: 1,
 				lineHeight: '20px',
 				whiteSpace: 'nowrap',

--- a/src/system/NewForm/FormAutocompleteMultiselectInlineChip.tsx
+++ b/src/system/NewForm/FormAutocompleteMultiselectInlineChip.tsx
@@ -22,11 +22,11 @@ const FormAutocompleteMultiselectInlineChip = ( {
 				gap: 1,
 				px: 2,
 				py: '2px',
-				m: '2px',
+				m: 1,
 				bg: 'layer.1',
 				borderRadius: 1,
 				fontSize: 1,
-				lineHeight: '20px',
+				lineHeight: '16px',
 				whiteSpace: 'nowrap',
 				maxWidth: '100%',
 			} }

--- a/src/system/NewForm/FormAutocompleteMultiselectInlineChip.tsx
+++ b/src/system/NewForm/FormAutocompleteMultiselectInlineChip.tsx
@@ -1,0 +1,72 @@
+/** @jsxImportSource theme-ui */
+
+/**
+ * External dependencies
+ */
+import { MdClose } from 'react-icons/md';
+
+const FormAutocompleteMultiselectInlineChip = ( {
+	index,
+	option,
+	unselectValue,
+}: {
+	index: number;
+	option: string;
+	unselectValue: ( option: string, index: number ) => void;
+} ) => {
+	return (
+		<span
+			sx={ {
+				display: 'inline-flex',
+				alignItems: 'center',
+				gap: 1,
+				px: 2,
+				py: '2px',
+				m: '2px',
+				bg: 'layer.1',
+				borderRadius: '12px',
+				fontSize: 1,
+				lineHeight: '20px',
+				whiteSpace: 'nowrap',
+				maxWidth: '100%',
+			} }
+		>
+			<span
+				sx={ {
+					overflow: 'hidden',
+					textOverflow: 'ellipsis',
+					whiteSpace: 'nowrap',
+				} }
+			>
+				{ option }
+			</span>
+			<button
+				type="button"
+				aria-label={ `Remove ${ option }` }
+				onClick={ e => {
+					e.preventDefault();
+					e.stopPropagation();
+					unselectValue( option, index );
+				} }
+				sx={ {
+					display: 'inline-flex',
+					alignItems: 'center',
+					justifyContent: 'center',
+					p: 0,
+					border: 'none',
+					bg: 'transparent',
+					cursor: 'pointer',
+					color: 'text',
+					lineHeight: 0,
+					'&:hover': {
+						opacity: 0.7,
+					},
+				} }
+			>
+				<MdClose size={ 14 } />
+			</button>
+		</span>
+	);
+};
+
+export { FormAutocompleteMultiselectInlineChip };


### PR DESCRIPTION
## Summary
https://linear.app/a8c/issue/VIP-2897/add-variant-to-autocompletemulti

Adds a new `variant="inline-chips"` for the `AutocompleteMulti` component. Selected items render as removable chips inside the input container instead of below it, matching the design spec from Emily's P2 post.

### Key behaviors
- Chips display inline inside the bordered input area with the text field
- Dropdown shows all options with ✓ checkmarks for selected items
- Clicking a selected option toggles it off (deselects)
- Dropdown stays open after each selection for rapid multi-select
- Placeholder hidden when items are selected
- Full keyboard navigation and screen reader support

### Usage

```jsx
<Form.AutocompleteMulti
  variant="inline-chips"
  label="Post Categories"
  options={categories}
  showAllValues
  placeholder="Search categories..."
/>
```

## Screenshot

<img width="724" height="420" alt="Screenshot 2026-05-26 at 7 47 29 PM" src="https://github.com/user-attachments/assets/64285c06-930f-45e5-8c34-744888dbf3d4" />


## Changes

- **New**: `FormAutocompleteMultiselectInlineChip.tsx` — chip component (pill + close button)
- **Modified**: `FormAutocompleteMultiselect.jsx` — `variant` prop, inline-chips layout, toggle selection, keep-menu-open behavior, removal announcements, focus management
- **Stories**: `InlineChips` story with pre-populated categories
- **Tests**: 6 tests total (2 existing + 4 new for inline-chips rendering, chip removal, and a11y announcements)

## Accessibility

- Chips have `aria-label="Remove {option}"` on close buttons
- Screen reader announces both additions and removals via `aria-live="assertive"`
- Focus moves to input after chip removal
- `jest-axe` accessibility test passes

## Checklist

- [x] This PR has good automated test coverage
- [x] The storybook for the component has been updated

## Steps to Test

1. Pull down PR
2. `npm run dev`
3. Open Storybook → Form/AutocompleteMulti → InlineChips story
4. Verify chips render inside the input container
5. Click dropdown arrow → verify all options visible with checkmarks on selected
6. Select an option → verify chip added, dropdown stays open
7. Click selected option → verify chip removed (toggle), dropdown stays open
8. Click × on chip → verify chip removed
9. Type to filter → verify dropdown filters options
10. Verify existing stories (Default, WithBadges, WithStaticData) still work
11. `npm run jest` — all 6 tests pass