### PR TITLE
Fix spinner position in AutocompleteMulti inline-chip variant

### DIFF
--- a/src/system/NewForm/FormAutocompleteMultiselect.jsx
+++ b/src/system/NewForm/FormAutocompleteMultiselect.jsx
@@ -466,7 +466,7 @@ const FormAutocompleteMultiselect = React.forwardRef(
 							/>
 						</div>
 						{ addStatus && <AddSelectionStatus status={ addStatus } /> }
-						{ loading && <FormSelectLoading sx={ { right: 7, top: '9px' } } /> }
+						{ loading && <FormSelectLoading sx={ { right: 7 } } /> }
 					</div>
 					{ hasError && errorMessage && (
 						<Flex sx={ { mt: 2 } }>

--- a/src/system/NewForm/FormAutocompleteMultiselect.jsx
+++ b/src/system/NewForm/FormAutocompleteMultiselect.jsx
@@ -466,7 +466,7 @@ const FormAutocompleteMultiselect = React.forwardRef(
 							/>
 						</div>
 						{ addStatus && <AddSelectionStatus status={ addStatus } /> }
-						{ loading && <FormSelectLoading sx={ { right: 7 } } /> }
+						{ loading && <FormSelectLoading sx={ { right: 7, top: '9px' } } /> }
 					</div>
 					{ hasError && errorMessage && (
 						<Flex sx={ { mt: 2 } }>

--- a/src/system/NewForm/FormSelectLoading.tsx
+++ b/src/system/NewForm/FormSelectLoading.tsx
@@ -25,6 +25,7 @@ interface FormSelectLoadingProps {
 const loadingStyles: ThemeUIStyleObject = {
 	position: 'absolute',
 	right: 3,
+	top: '9px',
 	pointerEvents: 'none',
 	animation: `${ kf } 1s infinite linear`,
 	opacity: 0.5,


### PR DESCRIPTION
## Summary

- Fixed the misplaced spinner in the `FormSelectLoading` component used across all autocomplete variants (`AutocompleteMulti` inline-chips, non-inline, and single-select `Autocomplete`)
- The spinner SVG had `position: absolute` with `right` but no `top` value — without explicit vertical positioning, the spinner fell to wherever the browser's static position fallback placed it, which varied by variant layout
- Added `top: '9px'` to the shared `loadingStyles` in `FormSelectLoading.tsx` to vertically center the 18px spinner within the standard 36px container height

## Before / After

| Before | After |
|--------|-------|
| <img width="543" height="154" alt="Screenshot 2026-06-02 at 12 52 32 PM" src="https://github.com/user-attachments/assets/992b047d-4f74-4807-93fe-9fb9e3658f9e" /> | <img width="543" height="154" alt="Screenshot 2026-06-02 at 12 52 55 PM" src="https://github.com/user-attachments/assets/2d7cc0a9-515a-47d5-a629-b21b2b874a62" /> |

## Test plan

- [x] All 8 existing unit tests pass (2 single-select + 6 multiselect including 4 inline-chips)
- [x] ESLint clean
- [ ] Visual verification in Storybook for all variants with `loading: true`:
  - `Form/AutocompleteMulti` → `InlineChips`
  - `Form/AutocompleteMulti` → `WithStaticData`
  - `Form/AutocompleteMulti` → `WithDynamicData`

🤖 Generated with [Claude Code](https://claude.com/claude-code)