### PR TITLE
AutocompleteMulti design polish

### DIFF
--- a/src/system/NewForm/FormAutocompleteMultiselect.jsx
+++ b/src/system/NewForm/FormAutocompleteMultiselect.jsx
@@ -111,7 +111,7 @@ const inlineChipsContainerStyles = {
 	flexWrap: 'wrap',
 	alignItems: 'center',
 	p: 1,
-	pr: 0,
+	pr: 5,
 	position: 'relative',
 	'& .autocomplete__input': {
 		...defaultStyles[ '& .autocomplete__input' ],
@@ -448,7 +448,7 @@ const FormAutocompleteMultiselect = React.forwardRef(
 								unselectValue={ unselectValue }
 							/>
 						) ) }
-						<div sx={ { flex: '1 1 120px', minWidth: '120px' } }>
+						<div sx={ { flex: '1 1 120px', minWidth: '120px', mr: -5 } }>
 							<Autocomplete
 								id={ forLabel }
 								aria-busy={ loading }

--- a/src/system/NewForm/FormAutocompleteMultiselect.jsx
+++ b/src/system/NewForm/FormAutocompleteMultiselect.jsx
@@ -131,7 +131,9 @@ const inlineChipsContainerStyles = {
 	},
 };
 
-const DefaultArrow = config => <FormSelectArrow className={ config.className } />;
+const DefaultArrow = config => (
+	<FormSelectArrow className={ config.className } separator={ false } />
+);
 
 const AddSelectionStatus = ( { status } ) => {
 	return (

--- a/src/system/NewForm/FormAutocompleteMultiselect.jsx
+++ b/src/system/NewForm/FormAutocompleteMultiselect.jsx
@@ -125,8 +125,8 @@ const inlineChipsContainerStyles = {
 		lineHeight: '24px',
 		minHeight: '24px',
 		'& .autocomplete__dropdown-arrow-down': {
-			top: 'unset',
-			bottom: '6px',
+			top: '6px',
+			bottom: 'unset',
 		},
 	},
 };


### PR DESCRIPTION
## Summary

We are making two changes here:

1. Remove the rule next to the chevron
2. Align the chevron with the top badge row on wrap

## Changes

Before | After
--- | ---
<img width="544" height="111" alt="Screenshot 2026-06-04 at 1 15 41 PM" src="https://github.com/user-attachments/assets/d944ba0e-2ffd-404e-8ea1-6d11856d0a15" /> | <img width="544" height="111" alt="Screenshot 2026-06-04 at 1 15 45 PM" src="https://github.com/user-attachments/assets/a4cfbbe3-46ef-41a1-ba3b-248058abb75e" />


## Testing

1. Run the PR with `npm run dev`
2. Go to http://localhost:6006/?path=/story/form-autocompletemulti--inline-chips and test out