### PR TITLE
Show form-control focus ring only on keyboard focus

### DIFF
--- a/src/system/Form/Input.styles.ts
+++ b/src/system/Form/Input.styles.ts
@@ -14,7 +14,6 @@ export const inputBaseText = 'input.text.default';
 export const inputBaseBackground = 'input.background.default';
 export const baseControlFocusStyle = {
 	'&:focus-visible': ( theme: InputTheme ) => theme.outline,
-	'&:focus-within': ( theme: InputTheme ) => theme.outline,
 };
 
 export const baseControlStyle = {

--- a/src/system/Form/Radio/styles.ts
+++ b/src/system/Form/Radio/styles.ts
@@ -13,7 +13,7 @@ export const inputStyle = ( variant: string ): ThemeUIStyleObject => ( {
 	clipPath: 'inset(50%)',
 	width: RADIO_SIZE,
 	height: RADIO_SIZE,
-	'&:focus ~ label:before': {
+	'&:focus-visible ~ label:before': {
 		variant: 'outline',
 		content: '""',
 		border: '1px solid',


### PR DESCRIPTION
## Summary

Checkbox and Radio painted their focus ring on **mouse** interaction, not just keyboard focus. This gates those rings behind `:focus-visible` so they only appear for keyboard navigation — matching how `Button` already behaves.

### Changes

- **`Form/Input.styles.ts`** — remove the redundant `'&:focus-within'` from `baseControlFocusStyle`. It flows into `Input`, `InputWithCopyButton`, `FormSelect`, and `Checkbox`, and in every one it lands on the **focusable element itself**, where `:focus-within` is equivalent to `:focus` and is modality-blind (fires on mouse). Removing it leaves `:focus-visible`:
  - **Checkbox** — ring no longer shows on mouse click (checkboxes don't match `:focus-visible` on click); keyboard focus still shows it.
  - **Text Input / InputWithCopyButton / FormSelect** — no visible change: browsers deliberately match `:focus-visible` on text fields/selects on click, which is standard, expected behavior and is intentionally left alone.
- **`Form/Radio/styles.ts`** — `'&:focus ~ label:before'` → `'&:focus-visible ~ label:before'`, so the visually-hidden radio input only rings its label's circle on keyboard focus.

## Testing

- ESLint ✓
- `tsc` type-check ✓
- Jest — Radio, Checkbox, Input suites pass (no test asserted on the old selectors)
- Verified on a consuming app (vip-dashboard) on localhost: mouse click no longer shows the ring on checkbox/radio; keyboard focus still does

## Not included

The **Accordion** has a related but distinct issue (`Accordion.Item` uses `:focus-within` on a *wrapper*, where `:focus-visible` doesn't apply and naively swapping risks double rings when panel content is focused). It also interacts with consumer-side overrides. It's being handled as a separate, coordinated follow-up rather than rushed in here.

## Note on versioning

No version bump in this PR — handled by the automated dev-release/release process per `docs/RELEASING.md`. After this releases, consuming apps bump their `@automattic/vip-design-system` dependency to pick it up.

🤖 Generated with [Claude Code](https://claude.com/claude-code)