### PR TITLE
Show accordion header focus ring only on keyboard focus

### DIFF
--- a/src/system/Accordion/Accordion.tsx
+++ b/src/system/Accordion/Accordion.tsx
@@ -92,7 +92,6 @@ export const Item = ( { children, ...props }: AccordionItemProps ) => (
 				borderBottomLeftRadius: 1,
 				borderBottomRightRadius: 1,
 			},
-			'&:focus-within': ( theme: AccordionTheme ) => theme.outline,
 		} }
 	>
 		{ children }
@@ -136,6 +135,21 @@ export const Trigger = React.forwardRef< HTMLButtonElement, TriggerProps >(
 						'.vip-accordion-trigger-indicator': { transform: 'rotate(270deg)' },
 					},
 					'&:hover': { backgroundColor: 'accordion.background.hover' },
+					// Keyboard-only focus ring on the header (the trigger button
+					// fills the header). Rendered inset, reusing the shared
+					// focus-ring colors, because the parent Item has overflow:hidden
+					// for its rounded corners which would clip an outset ring.
+					'&:focus-visible': ( theme: AccordionTheme ) => {
+						const ring = theme.outline?.boxShadow;
+						return ring
+							? {
+									boxShadow: ring
+										.split( /,(?![^(]*\))/ )
+										.map( layer => `inset ${ layer.trim() }` )
+										.join( ', ' ),
+							  }
+							: {};
+					},
 					...sx,
 				} }
 				{ ...props }


### PR DESCRIPTION
## Summary

`Accordion.Item` drew its focus ring via `:focus-within`, which is modality-blind — it showed on **mouse** click as well as keyboard focus, and because it sat on the Item wrapper it also fired when focusable content inside an expanded panel was focused (a second, wrapping ring).

This moves the ring onto the **trigger button** and gates it behind `:focus-visible`:

- Keyboard focus on a header → ring; mouse click → no ring.
- Ring is on the header only, never the expanded content → no double ring.
- The trigger button fills the header, so styling it directly avoids needing `:has()` on the Item.

### Why inset, and why not `:has()`

- An outset ring on the inner trigger is clipped by the Item's `overflow: hidden` (which it needs for its rounded corners). So the ring is rendered **inset**, reusing the shared `theme.outline` colors (white + blue) flipped to `inset` box-shadows.
- Putting an outset ring on the Item via `:has(:focus-visible)` was the alternative, but `:has()` cannot be parsed by jsdom's `nwsapi` selector engine (it throws on Radix's colon-containing element IDs), which breaks this suite's tests and any consumer's jsdom tests that render an accordion. Styling the button directly avoids `:has()` entirely.

## Testing

- ESLint ✓
- `tsc` type-check ✓
- Jest — Accordion suite passes (4/4)
- Verified on a consuming app (vip-dashboard, Help Center accordion) on localhost: mouse click shows no ring; keyboard focus shows the blue inset ring on the header; open/close/tab focus behaviour unchanged.

## Follow-up (separate, in the dashboard)

`SecurityModuleAccordionItem` in vip-dashboard hand-rolls its own focus override (`:has(button…:focus)`) to compensate for the old `:focus-within` behaviour. With this change that override becomes redundant and should be removed — that's a coordinated dashboard PR to land alongside the dependency bump, tracked separately.

## Versioning

No version bump here — handled by the automated dev-release/release process per `docs/RELEASING.md`.

🤖 Generated with [Claude Code](https://claude.com/claude-code)