### PR TITLE
Drive NewDialog title font size from the h3 heading token

### DIFF
--- a/src/system/NewDialog/DialogTitle.tsx
+++ b/src/system/NewDialog/DialogTitle.tsx
@@ -35,7 +35,7 @@ export const DialogTitle: React.FC< DialogTitleProps > = ( { title, hidden = fal
 
 	return (
 		<DialogPrimitive.Title
-			sx={ { margin: 0, fontSize: 3, fontWeight: 'medium', color: 'heading' } }
+			sx={ { margin: 0, variant: 'text.h3', color: 'heading' } }
 		>
 			{ titleNode }
 		</DialogPrimitive.Title>

--- a/src/system/NewDialog/DialogTitle.tsx
+++ b/src/system/NewDialog/DialogTitle.tsx
@@ -34,9 +34,7 @@ export const DialogTitle: React.FC< DialogTitleProps > = ( { title, hidden = fal
 	}
 
 	return (
-		<DialogPrimitive.Title
-			sx={ { margin: 0, variant: 'text.h3', color: 'heading' } }
-		>
+		<DialogPrimitive.Title sx={ { margin: 0, variant: 'text.h3', color: 'heading' } }>
 			{ titleNode }
 		</DialogPrimitive.Title>
 	);


### PR DESCRIPTION
## What

Change `NewDialog`'s `DialogTitle` to inherit the `text.h3` variant instead of the hardcoded `fontSize: 3` / `fontWeight: 'medium'`.

```diff
- sx={ { margin: 0, fontSize: 3, fontWeight: 'medium', color: 'heading' } }
+ sx={ { margin: 0, variant: 'text.h3', color: 'heading' } }
```

## Why

`DialogTitle` rendered at `fontSize: 3` (**16px**), smaller than the design intent and disconnected from the heading scale. Because of this, several consumers hide the real title (`showHeading={false}`) and inject their own `<Heading variant="h3">` into the dialog content, which produces **inconsistent dialog title sizes** across the app (title-prop dialogs at 16px vs. custom-heading dialogs at h3/18px).

Pointing the title at the `text.h3` variant:

- Resolves to **18px** today (the `heading.3` token), matching the Figma spec for dialog headings.
- Stays **token-driven** — future Figma/token changes to h3 flow through automatically instead of needing a hardcoded value bump.
- **Converges** title-prop dialogs with the dialogs already rendering their heading at h3.

The title weight now comes from the h3 token (`heading`) rather than the previous `medium`, which is intentional — it matches the Figma h3.

## Scope / impact

- Affects all `NewDialog` consumers that use the `title` prop.
- No API change; purely the rendered style of the existing title element.
- No consumer changes required — downstreams pick this up on their next version bump.

## Testing

- CI: lint, format, type check, unit tests (incl. jest-axe).
- `DialogTitle.test.js` has no font-size assertions, so no test updates needed.

🤖 Generated with [Claude Code](https://claude.com/claude-code)