### PR TITLE
Wizard semantic fix

### DIFF
--- a/src/system/Wizard/Wizard.stories.tsx
+++ b/src/system/Wizard/Wizard.stories.tsx
@@ -47,6 +47,36 @@ export const Primary: Story = {
 	},
 };
 
+/**
+ * `titleVariant` (visual style) and `titleAs` (semantic HTML element) can be set
+ * once at the Wizard level so they apply to every step, avoiding repetition. Here
+ * all titles render as `h2` elements while keeping `h3` styling, and the last step
+ * overrides `titleAs` to `h4` to demonstrate per-step precedence.
+ */
+export const WizardTitleLevels: Story = {
+	args: {
+		activeStep: 0,
+		completed: [],
+		titleVariant: 'h3',
+		titleAs: 'h2',
+		steps: [
+			{
+				title: 'Step One',
+				subTitle: 'Rendered as an h2 element with h3 styling.',
+				children: 'Step one content',
+			},
+			{
+				title: 'Step Two',
+				subTitle: 'Also an h2 element, inheriting the Wizard-level titleAs.',
+			},
+			{
+				title: 'Step Three (overrides titleAs)',
+				titleAs: 'h4',
+			},
+		],
+	},
+};
+
 export const Error: Story = {
 	render: () => {
 		const steps: WizardStepProps[] = [

--- a/src/system/Wizard/Wizard.test.tsx
+++ b/src/system/Wizard/Wizard.test.tsx
@@ -77,3 +77,55 @@ describe( '<Wizard /> error state', () => {
 		expect( screen.getByText( 'Step instructions' ) ).toBeInTheDocument();
 	} );
 } );
+
+describe( '<Wizard /> title element and style', () => {
+	it( 'renders step titles as h3 elements by default', () => {
+		const { container } = renderWithTheme( <Wizard activeStep={ 0 } steps={ steps } /> );
+
+		expect( container.querySelectorAll( 'h3' ) ).toHaveLength( steps.length );
+	} );
+
+	it( 'applies a Wizard-level titleAs element to every step', () => {
+		const { container } = renderWithTheme(
+			<Wizard activeStep={ 0 } steps={ steps } titleAs="h2" />
+		);
+
+		expect( container.querySelectorAll( 'h2' ) ).toHaveLength( steps.length );
+		expect( container.querySelectorAll( 'h3' ) ).toHaveLength( 0 );
+	} );
+
+	it( 'lets a step override the Wizard-level titleAs', () => {
+		const overrideSteps = [ { title: 'Step One' }, { title: 'Step Two', titleAs: 'h4' as const } ];
+		const { container } = renderWithTheme(
+			<Wizard activeStep={ 0 } steps={ overrideSteps } titleAs="h2" />
+		);
+
+		// One inherits the Wizard default (h2), the other overrides to h4.
+		expect( container.querySelectorAll( 'h2' ) ).toHaveLength( 1 );
+		expect( container.querySelectorAll( 'h4' ) ).toHaveLength( 1 );
+	} );
+
+	it( 'keeps titleVariant styling while titleAs changes the element', () => {
+		const { container } = renderWithTheme(
+			<Wizard
+				activeStep={ 0 }
+				steps={ [ { title: 'Only Step' } ] }
+				titleVariant="h3"
+				titleAs="h2"
+			/>
+		);
+
+		// The rendered element is an h2 that still carries the shared heading class
+		// (typographic variant is driven by titleVariant, not the element).
+		const heading = container.querySelector( 'h2.vip-heading-component' );
+		expect( heading ).toBeInTheDocument();
+	} );
+
+	it( 'has no accessibility violations when using a custom title element', async () => {
+		const { container } = renderWithTheme(
+			<Wizard activeStep={ 0 } steps={ steps } titleAs="h2" />
+		);
+
+		expect( await axe( container ) ).toHaveNoViolations();
+	} );
+} );

--- a/src/system/Wizard/Wizard.tsx
+++ b/src/system/Wizard/Wizard.tsx
@@ -11,6 +11,7 @@ import React, { useLayoutEffect, useState } from 'react';
  */
 import { WizardStepProps } from './WizardStep';
 import { Box, WizardStep } from '..';
+import { HeadingProps } from '../Heading/Heading';
 
 export interface WizardProps {
 	/** The array of step configurations to render. */
@@ -50,6 +51,18 @@ export interface WizardProps {
 	 * @default 'table'
 	 */
 	summaryAs?: 'table' | 'dl';
+	/**
+	 * The heading variant (typographic style) applied to every step title. A step
+	 * can override this with its own `titleVariant`.
+	 * @default 'h3'
+	 */
+	titleVariant?: HeadingProps[ 'variant' ];
+	/**
+	 * The HTML heading element used for every step title, independent of its
+	 * visual style — useful for keeping a correct document outline. A step can
+	 * override this with its own `titleAs`. Defaults to the value of `titleVariant`.
+	 */
+	titleAs?: HeadingProps[ 'variant' ];
 }
 
 /**
@@ -68,6 +81,8 @@ export const Wizard = React.forwardRef< HTMLDivElement, WizardProps >(
 			titleAutofocus = false,
 			showStepText = true,
 			summaryAs = 'table',
+			titleVariant,
+			titleAs,
 		},
 		forwardRef
 	) => {
@@ -88,7 +103,8 @@ export const Wizard = React.forwardRef< HTMLDivElement, WizardProps >(
 							title,
 							subTitle,
 							children,
-							titleVariant,
+							titleVariant: stepTitleVariant,
+							titleAs: stepTitleAs,
 							summary,
 							onChange,
 							actionLabel,
@@ -108,7 +124,8 @@ export const Wizard = React.forwardRef< HTMLDivElement, WizardProps >(
 							totalSteps={ steps.length }
 							subTitle={ subTitle }
 							title={ title }
-							titleVariant={ titleVariant }
+							titleVariant={ stepTitleVariant ?? titleVariant }
+							titleAs={ stepTitleAs ?? titleAs }
 							summary={ summary }
 							onChange={ onChange }
 							shouldFocusTitle={ titleAutofocus && didMount }

--- a/src/system/Wizard/WizardStep.tsx
+++ b/src/system/Wizard/WizardStep.tsx
@@ -35,10 +35,16 @@ export interface WizardStepProps {
 	/** The title content displayed in the step header. */
 	title: React.ReactNode;
 	/**
-	 * The heading variant used for the step title.
+	 * The heading variant used for the step title. Controls the typographic style.
 	 * @default 'h3'
 	 */
 	titleVariant?: HeadingProps[ 'variant' ];
+	/**
+	 * The HTML heading element used to render the step title, independent of its
+	 * visual style. Use this to keep a correct document outline (e.g. render an
+	 * `h2` while keeping `h3` styling). Defaults to the value of `titleVariant`.
+	 */
+	titleAs?: HeadingProps[ 'variant' ];
 	/** A subtitle displayed below the title when the step is active. */
 	subTitle?: React.ReactNode;
 	/** The content rendered inside the step when it is active. */
@@ -106,6 +112,7 @@ export const WizardStep = React.forwardRef< HTMLDivElement, WizardStepProps >(
 			totalSteps,
 			shouldFocusTitle,
 			titleVariant = 'h3',
+			titleAs,
 			summary,
 			summaryTitle,
 			summaryAs = 'table',
@@ -188,6 +195,7 @@ export const WizardStep = React.forwardRef< HTMLDivElement, WizardStepProps >(
 				<Flex sx={ { alignItems: 'center' } }>
 					<Heading
 						variant={ titleVariant }
+						as={ titleAs ?? titleVariant }
 						sx={ {
 							mb: 0,
 							color: headingColor,


### PR DESCRIPTION
## Description

### Before

<img width="451" height="457" alt="image" src="https://github.com/user-attachments/assets/a534322e-95b1-471d-84c0-c307def0d7b1" />

This pull request adds support for customizing the semantic HTML heading element (`titleAs`) and visual style (`titleVariant`) of step titles in the `Wizard` component. These options can be set at the Wizard level to apply to all steps, while still allowing individual steps to override them as needed. Comprehensive tests and storybook examples are included to demonstrate and verify this new flexibility.

**Wizard title element and style customization:**

* Added `titleVariant` (typographic style) and `titleAs` (HTML element) props to both `Wizard` and `WizardStep`, allowing the heading style and semantic element to be controlled globally or per-step. If not set, `titleAs` defaults to the value of `titleVariant`. [[1]](diffhunk://#diff-66b2b42d7fb8692a1a429ca71897bd82acde54d986f0f5e24875944903293a6fR54-R65) [[2]](diffhunk://#diff-cce273927df116a140dd9506262e45d87e52de8f3c5524433d5db3107709a1c4L38-R47)
* Updated the `Wizard` and `WizardStep` implementation to pass and honor these new props, ensuring that each step's title can be rendered with the correct HTML element and style. [[1]](diffhunk://#diff-66b2b42d7fb8692a1a429ca71897bd82acde54d986f0f5e24875944903293a6fL91-R107) [[2]](diffhunk://#diff-66b2b42d7fb8692a1a429ca71897bd82acde54d986f0f5e24875944903293a6fL111-R128) [[3]](diffhunk://#diff-cce273927df116a140dd9506262e45d87e52de8f3c5524433d5db3107709a1c4R115) [[4]](diffhunk://#diff-cce273927df116a140dd9506262e45d87e52de8f3c5524433d5db3107709a1c4R198)

**Documentation and examples:**

* Added a new story, `WizardTitleLevels`, to `Wizard.stories.tsx` to demonstrate setting `titleVariant` and `titleAs` at the Wizard level and overriding them per-step.

**Testing:**

* Added tests to `Wizard.test.tsx` to verify default and custom heading elements, per-step overrides, typographic styling, and accessibility compliance when using custom heading elements.

**Internal typing:**

* Imported `HeadingProps` for correct typing of the new props.

## Steps to Test

Outline the steps to test and verify the PR here.

Example:

1. Pull down PR.
1. `npm run dev`.
1. Open Storybook.
1. Eat cookies.
1. Verify cookies are delicious.
