### PR TITLE
More type fixes

### DIFF
--- a/src/system/Accordion/Accordion.tsx
+++ b/src/system/Accordion/Accordion.tsx
@@ -29,13 +29,18 @@ const slideUp = keyframes( {
 interface AccordionTheme extends Theme {
 	outline?: Record< string, string >;
 }
-export interface AccordionItemProps {
+export interface AccordionItemProps
+	extends Omit< AccordionPrimitive.AccordionItemProps, 'children' | 'className' > {
 	/** Content to render inside the accordion item. */
 	children: ReactNode;
-	/** Unique value that identifies this item within the accordion. */
-	value: string;
+	/** Additional CSS class names. */
+	className?: Argument;
+	/** Theme UI style overrides for the accordion item. */
+	sx?: ThemeUIStyleObject;
+	/** Ref forwarded to the item element. */
+	ref?: React.Ref< HTMLDivElement >;
 }
-export interface TriggerProps {
+export interface TriggerProps extends Omit< AccordionPrimitive.AccordionTriggerProps, 'children' > {
 	/** Label content for the trigger button. */
 	children: ReactNode;
 	/** Heading level used to wrap the trigger. @default 'h3' */
@@ -45,16 +50,14 @@ export interface TriggerProps {
 	/** Ref forwarded to the trigger button. */
 	ref?: React.Ref< HTMLButtonElement >;
 }
-export interface TriggerWithIconProps {
+export interface TriggerWithIconProps extends Omit< TriggerProps, 'children' > {
 	/** Label content displayed next to the icon. */
 	children: ReactNode;
 	/** Icon element rendered before the label. */
 	icon: ReactNode;
-	/** Ref forwarded to the trigger button. */
-	ref?: React.Ref< HTMLButtonElement >;
 }
 
-export interface ContentProps {
+export interface ContentProps extends Omit< AccordionPrimitive.AccordionContentProps, 'children' > {
 	/** Content revealed when the accordion item is expanded. */
 	children: ReactNode;
 	/** Theme UI style overrides for the content area. */
@@ -79,9 +82,10 @@ export interface RootProps
 	ref?: React.Ref< HTMLDivElement >;
 }
 /** A single collapsible section within the Accordion. */
-export const Item = ( { children, ...props }: AccordionItemProps ) => (
+export const Item = ( { children, className, sx = {}, ref, ...props }: AccordionItemProps ) => (
 	<AccordionPrimitive.Item
-		{ ...props }
+		className={ classNames( className ) }
+		ref={ ref }
 		sx={ {
 			overflow: 'hidden',
 			borderWidth: '0 1px 1px 1px',
@@ -97,7 +101,9 @@ export const Item = ( { children, ...props }: AccordionItemProps ) => (
 				borderBottomLeftRadius: 1,
 				borderBottomRightRadius: 1,
 			},
+			...sx,
 		} }
+		{ ...props }
 	>
 		{ children }
 	</AccordionPrimitive.Item>

--- a/src/system/Accordion/Accordion.types.test.tsx
+++ b/src/system/Accordion/Accordion.types.test.tsx
@@ -9,15 +9,36 @@ import React from 'react';
 import * as Accordion from './Accordion';
 
 describe( '<Accordion.Root /> types', () => {
-	it( 'type-checks Radix root props forwarded by VDS', () => {
+	it( 'type-checks forwarded VDS and Radix props', () => {
 		const ref = React.createRef< HTMLDivElement >();
+		const triggerRef = React.createRef< HTMLButtonElement >();
 
 		const examples = {
 			root: (
 				<Accordion.Root aria-label="Example accordion" defaultValue="one" disabled ref={ ref }>
-					<Accordion.Item value="one">
-						<Accordion.Trigger>One</Accordion.Trigger>
-						<Accordion.Content>Content one</Accordion.Content>
+					<Accordion.Item
+						id="accordion-item-one"
+						className={ [ 'accordion-item', { 'is-open': true } ] }
+						sx={ { borderColor: 'borders.2' } }
+						value="one"
+					>
+						<Accordion.Trigger id="accordion-trigger-one" ref={ triggerRef }>
+							One
+						</Accordion.Trigger>
+						<Accordion.Content id="accordion-content-one" aria-labelledby="accordion-trigger-one">
+							Content one
+						</Accordion.Content>
+					</Accordion.Item>
+					<Accordion.Item value="two">
+						<Accordion.TriggerWithIcon
+							disabled
+							headingVariant="h4"
+							icon={ <span aria-hidden>Icon</span> }
+							sx={ { color: 'texts.primary' } }
+						>
+							Two
+						</Accordion.TriggerWithIcon>
+						<Accordion.Content>Content two</Accordion.Content>
 					</Accordion.Item>
 				</Accordion.Root>
 			),

--- a/src/system/NewForm/FormSelect.test.jsx
+++ b/src/system/NewForm/FormSelect.test.jsx
@@ -91,6 +91,12 @@ describe( '<FormSelect />', () => {
 		await expect( await axe( container ) ).toHaveNoViolations();
 	} );
 
+	it( 'forwards select attributes', () => {
+		render( <FormSelect id="dessert" name="dessert" { ...defaultProps } /> );
+
+		expect( screen.getByRole( 'combobox' ) ).toHaveAttribute( 'name', 'dessert' );
+	} );
+
 	it( 'renders the FormSelect with nullish options', async () => {
 		const nullishOptions = [ ...options, { value: null, label: 'Empty' } ];
 

--- a/src/system/NewForm/FormSelect.tsx
+++ b/src/system/NewForm/FormSelect.tsx
@@ -58,6 +58,7 @@ interface FormSelectProps {
 	'aria-describedby'?: string;
 	'aria-required'?: boolean;
 	id?: string;
+	name?: string;
 	ref?: React.Ref< HTMLSelectElement >;
 }
 

--- a/src/system/NewForm/FormSelect.types.test.tsx
+++ b/src/system/NewForm/FormSelect.types.test.tsx
@@ -1,0 +1,34 @@
+/**
+ * External dependencies
+ */
+import React from 'react';
+
+/**
+ * Internal dependencies
+ */
+import { FormSelect } from './FormSelect';
+
+describe( '<FormSelect /> types', () => {
+	it( 'type-checks forwarded select props used by consumers', () => {
+		const ref = React.createRef< HTMLSelectElement >();
+
+		const examples = {
+			name: (
+				<FormSelect
+					ref={ ref }
+					id="dessert"
+					name="dessert"
+					label="Dessert"
+					options={ [
+						{
+							label: 'Chocolate',
+							value: 'chocolate',
+						},
+					] }
+				/>
+			),
+		};
+
+		expect( Object.keys( examples ) ).toHaveLength( 1 );
+	} );
+} );


### PR DESCRIPTION
## Description

This pull request enhances the type safety and flexibility of the Accordion and FormSelect components by improving prop forwarding and extending their prop interfaces. It also adds and updates tests to ensure correct typing and attribute forwarding for these components.

### Accordion component improvements

* Updated `AccordionItemProps`, `TriggerProps`, `TriggerWithIconProps`, and `ContentProps` to extend and omit appropriate primitive props, allowing for better prop forwarding and more flexible usage [[1]](diffhunk://#diff-bd4cd529dfdd6a2f82a02a29bf026856ff9c9f846d65ed37168150e7ac2feb27L32-R43) [[2]](diffhunk://#diff-bd4cd529dfdd6a2f82a02a29bf026856ff9c9f846d65ed37168150e7ac2feb27L48-R60).
* Added support for forwarding `className`, `sx`, and `ref` props to `Accordion.Item`, and ensured these are applied correctly in the render function [[1]](diffhunk://#diff-bd4cd529dfdd6a2f82a02a29bf026856ff9c9f846d65ed37168150e7ac2feb27L82-R88) [[2]](diffhunk://#diff-bd4cd529dfdd6a2f82a02a29bf026856ff9c9f846d65ed37168150e7ac2feb27R104-R106).
* Improved type tests to verify that both VDS and Radix props are properly forwarded and type-checked for all Accordion components, including support for additional props like `id`, `className`, `sx`, and `ref`.

### FormSelect component improvements

* Added support for forwarding the `name` attribute to the underlying `<select>` element by including it in `FormSelectProps`.
* Added a test to confirm that select attributes such as `name` are forwarded and rendered as expected.
* Introduced a new type test to verify that consumers can forward select props (like `id`, `name`, and `ref`) to `FormSelect` without type errors.