### PR TITLE
PLTFRM-2675 Fix Avatar 404 error

### DIFF
--- a/src/system/Avatar/Avatar.stories.tsx
+++ b/src/system/Avatar/Avatar.stories.tsx
@@ -18,6 +18,9 @@ type Story = StoryObj< typeof Avatar >;
 
 const COMMON_SIZES = [ 128, 64, 48, 32, 24, 16 ];
 
+// A URL that is guaranteed to 404, to demonstrate the fallback chain.
+const BROKEN_SRC = 'https://github.com/github-actions%5Bbot%5D.png?size=200';
+
 export const Default: Story = {
 	args: {
 		src: 'https://i.pravatar.cc/100',
@@ -48,4 +51,85 @@ export const WithAbbreviation: Story = {
 			backgroundColor: '#D8A45F',
 		},
 	},
+};
+
+/**
+ * When the image fails to load, the avatar falls back to the initial from `name`
+ * rather than leaving the browser's broken-image glyph on screen.
+ */
+export const BrokenImage: Story = {
+	args: {
+		name: 'Taylor Swift',
+		src: BROKEN_SRC,
+		sx: {
+			backgroundColor: '#D8A45F',
+		},
+	},
+	render: args => (
+		<>
+			{ COMMON_SIZES.map( size => (
+				<Avatar { ...args } size={ size } key={ size } />
+			) ) }
+		</>
+	),
+};
+
+/**
+ * With no `name` or `abbr` to fall back to, a broken image degrades to a generic
+ * user icon.
+ */
+export const IconFallback: Story = {
+	args: {
+		src: BROKEN_SRC,
+		sx: {
+			backgroundColor: '#D8A45F',
+		},
+	},
+	render: args => (
+		<>
+			{ COMMON_SIZES.map( size => (
+				<Avatar { ...args } size={ size } key={ size } />
+			) ) }
+		</>
+	),
+};
+
+/**
+ * Set `fallback="icon"` to always render the generic user icon, even when a `name`
+ * or `abbr` is available. Useful for non-human actors such as bots and integrations,
+ * where an initial would be misleading.
+ */
+export const ForcedIconFallback: Story = {
+	args: {
+		name: 'Platform Bot',
+		fallback: 'icon',
+		sx: {
+			backgroundColor: '#D8A45F',
+		},
+	},
+	render: args => (
+		<>
+			{ COMMON_SIZES.map( size => (
+				<Avatar { ...args } size={ size } key={ size } />
+			) ) }
+		</>
+	),
+};
+
+/**
+ * The same icon fallback is used when no `src` is provided at all.
+ */
+export const NoImageOrName: Story = {
+	args: {
+		sx: {
+			backgroundColor: '#D8A45F',
+		},
+	},
+	render: args => (
+		<>
+			{ COMMON_SIZES.map( size => (
+				<Avatar { ...args } size={ size } key={ size } />
+			) ) }
+		</>
+	),
 };

--- a/src/system/Avatar/Avatar.test.tsx
+++ b/src/system/Avatar/Avatar.test.tsx
@@ -1,7 +1,7 @@
 /**
  * External dependencies
  */
-import { render, screen } from '@testing-library/react';
+import { fireEvent, render, screen } from '@testing-library/react';
 import { axe } from 'jest-axe';
 
 /**
@@ -26,5 +26,123 @@ describe( '<Avatar />', () => {
 
 		// Check for accessibility issues
 		expect( await axe( container ) ).toHaveNoViolations();
+	} );
+
+	it( 'falls back to the initial when the image fails to load', async () => {
+		const { container } = render( <Avatar name="John Doe" src="path/to/broken/image" /> );
+
+		fireEvent.error( screen.getByAltText( 'Avatar image from John Doe' ) );
+
+		expect( screen.getByText( 'J' ) ).toBeInTheDocument();
+		expect( container.querySelector( 'img' ) ).not.toBeInTheDocument();
+
+		// Check for accessibility issues
+		expect( await axe( container ) ).toHaveNoViolations();
+	} );
+
+	it( 'falls back to the abbreviation when the image fails to load', () => {
+		render( <Avatar name="Taylor Swift" abbr="TS" src="path/to/broken/image" /> );
+
+		fireEvent.error( screen.getByAltText( 'Avatar image from Taylor Swift' ) );
+
+		expect( screen.getByText( 'TS' ) ).toBeInTheDocument();
+	} );
+
+	it( 'falls back to the user icon when the image fails and there is no name', async () => {
+		const { container } = render( <Avatar src="path/to/broken/image" /> );
+
+		fireEvent.error( container.querySelector( 'img' ) as HTMLImageElement );
+
+		expect( screen.getByTestId( 'avatar-fallback-icon' ) ).toBeInTheDocument();
+		expect( container.querySelector( 'img' ) ).not.toBeInTheDocument();
+
+		// Check for accessibility issues
+		expect( await axe( container ) ).toHaveNoViolations();
+	} );
+
+	it( 'renders the user icon when there is no image, name, or abbreviation', async () => {
+		const { container } = render( <Avatar /> );
+
+		expect( screen.getByTestId( 'avatar-fallback-icon' ) ).toBeInTheDocument();
+
+		// Check for accessibility issues
+		expect( await axe( container ) ).toHaveNoViolations();
+	} );
+
+	it( 'renders the icon instead of initials when fallback is "icon"', async () => {
+		const { container } = render( <Avatar name="John Doe" fallback="icon" /> );
+
+		expect( screen.getByTestId( 'avatar-fallback-icon' ) ).toBeInTheDocument();
+		expect( screen.queryByText( 'J' ) ).not.toBeInTheDocument();
+
+		// Check for accessibility issues
+		expect( await axe( container ) ).toHaveNoViolations();
+	} );
+
+	it( 'renders the icon when fallback is "icon" and the image fails to load', () => {
+		render( <Avatar name="John Doe" fallback="icon" src="path/to/broken/image" /> );
+
+		fireEvent.error( screen.getByAltText( 'Avatar image from John Doe' ) );
+
+		expect( screen.getByTestId( 'avatar-fallback-icon' ) ).toBeInTheDocument();
+		expect( screen.queryByText( 'J' ) ).not.toBeInTheDocument();
+	} );
+
+	it( 'still shows a working image when fallback is "icon"', () => {
+		render( <Avatar name="John Doe" fallback="icon" src="path/to/image" /> );
+
+		expect( screen.getByAltText( 'Avatar image from John Doe' ) ).toBeInTheDocument();
+		expect( screen.queryByTestId( 'avatar-fallback-icon' ) ).not.toBeInTheDocument();
+	} );
+
+	it( 'renders initials by default when fallback is not set', () => {
+		render( <Avatar name="John Doe" abbr="JD" /> );
+
+		expect( screen.getByText( 'JD' ) ).toBeInTheDocument();
+		expect( screen.queryByTestId( 'avatar-fallback-icon' ) ).not.toBeInTheDocument();
+	} );
+
+	it( 'scales the fallback icon with the size prop', () => {
+		render( <Avatar size={ 64 } /> );
+
+		expect( screen.getByTestId( 'avatar-fallback-icon' ).querySelector( 'svg' ) ).toHaveAttribute(
+			'height',
+			'40'
+		);
+	} );
+
+	it( 'retries when the src changes after a failure', () => {
+		const { container, rerender } = render( <Avatar name="John Doe" src="path/to/broken/image" /> );
+
+		fireEvent.error( screen.getByAltText( 'Avatar image from John Doe' ) );
+		expect( container.querySelector( 'img' ) ).not.toBeInTheDocument();
+
+		rerender( <Avatar name="John Doe" src="path/to/working/image" /> );
+
+		expect( container.querySelector( 'img' ) ).toHaveAttribute( 'src', 'path/to/working/image' );
+	} );
+
+	it( 'falls back when a server-rendered image failed before hydration', () => {
+		const completeSpy = jest
+			.spyOn( HTMLImageElement.prototype, 'complete', 'get' )
+			.mockReturnValue( true );
+		const naturalWidthSpy = jest
+			.spyOn( HTMLImageElement.prototype, 'naturalWidth', 'get' )
+			.mockReturnValue( 0 );
+
+		const { container } = render( <Avatar name="John Doe" src="path/to/broken/image" /> );
+
+		expect( screen.getByText( 'J' ) ).toBeInTheDocument();
+		expect( container.querySelector( 'img' ) ).not.toBeInTheDocument();
+
+		completeSpy.mockRestore();
+		naturalWidthSpy.mockRestore();
+	} );
+
+	it( 'does not render a placeholder alt text when there is no name', () => {
+		const { container } = render( <Avatar src="path/to/image" /> );
+
+		expect( container.querySelector( 'img' ) ).toHaveAttribute( 'alt', '' );
+		expect( screen.queryByAltText( /undefined/ ) ).not.toBeInTheDocument();
 	} );
 } );

--- a/src/system/Avatar/Avatar.tsx
+++ b/src/system/Avatar/Avatar.tsx
@@ -2,7 +2,8 @@
  * External dependencies
  */
 import classNames, { Argument } from 'classnames';
-import { Ref } from 'react';
+import { Ref, useState } from 'react';
+import { MdPerson } from 'react-icons/md';
 import { Image, ImageProps, ThemeUIStyleObject } from 'theme-ui';
 
 /**
@@ -17,12 +18,22 @@ export interface AvatarProps {
 	 * @default 32
 	 */
 	size?: number;
-	/** Image URL for the avatar. When provided, renders an image instead of initials. */
+	/**
+	 * Image URL for the avatar. When it is omitted or fails to load, the avatar
+	 * falls back to the initial from `name`/`abbr`, and then to a generic user icon.
+	 */
 	src?: string;
 	/** The full name of the user; the first character is used as the fallback initial. */
 	name?: string;
-	/** Custom abbreviation text displayed when no image is provided, overrides the initial from `name`. */
+	/** Custom abbreviation text displayed when no image is available, overrides the initial from `name`. */
 	abbr?: string;
+	/**
+	 * What to render when no image is available. `initials` uses `abbr` or the first
+	 * character of `name`, falling back to the icon when neither is set. `icon` always
+	 * renders the generic user icon, even when a `name` is provided.
+	 * @default 'initials'
+	 */
+	fallback?: 'initials' | 'icon';
 	/** Additional CSS class names. */
 	className?: Argument;
 	/** Additional Theme UI styles applied to the avatar container. */
@@ -34,7 +45,8 @@ export interface AvatarProps {
 type AvatarImageProps = AvatarProps & ImageProps;
 
 /**
- * A circular avatar component that displays a user image or falls back to an initial/abbreviation.
+ * A circular avatar component that displays a user image, falling back to an
+ * initial or abbreviation, and finally to a generic user icon.
  */
 export const Avatar = ( {
 	name,
@@ -43,10 +55,50 @@ export const Avatar = ( {
 	className,
 	sx = {},
 	abbr,
+	fallback = 'initials',
 	ref,
 	...props
 }: AvatarImageProps ) => {
+	// Track the URL that failed rather than a boolean, so the state resets on its
+	// own as soon as `src` changes and a recycled avatar is never stuck broken.
+	const [ failedSrc, setFailedSrc ] = useState< string | null >( null );
+
 	const displayName = name && ! abbr ? name.charAt( 0 ) : abbr;
+	const showImage = Boolean( src ) && failedSrc !== src;
+
+	const handleImageRef = ( image: HTMLImageElement | null ) => {
+		// A server-rendered image can finish failing before hydration attaches
+		// `onError`, which would leave the broken image on screen. Catch it on mount.
+		if ( image?.complete && image.naturalWidth === 0 ) {
+			setFailedSrc( image.getAttribute( 'src' ) );
+		}
+	};
+
+	const showInitials = fallback === 'initials' && Boolean( displayName );
+
+	const renderFallback = () =>
+		showInitials ? (
+			<Text
+				as="span"
+				sx={ {
+					color: 'icon.inverse',
+					mb: 0,
+					fontWeight: 'bold',
+					fontSize: 2,
+					textTransform: 'uppercase',
+				} }
+			>
+				{ displayName }
+			</Text>
+		) : (
+			<Box
+				as="span"
+				sx={ { color: 'icon.inverse', display: 'inline-flex' } }
+				data-testid="avatar-fallback-icon"
+			>
+				<MdPerson size={ Math.round( size * 0.625 ) } aria-hidden="true" />
+			</Box>
+		);
 
 	return (
 		<Box
@@ -68,29 +120,22 @@ export const Avatar = ( {
 			ref={ ref }
 			{ ...props }
 		>
-			{ src ? (
+			{ showImage ? (
 				<Image
 					src={ src }
-					alt={ `Avatar image from ${ name }` }
+					alt={ name ? `Avatar image from ${ name }` : '' }
+					ref={ handleImageRef }
+					onError={ () => setFailedSrc( src ?? null ) }
 					sx={ {
 						borderRadius: '100%',
 						width: '100%',
+						height: '100%',
+						objectFit: 'cover',
 						display: 'block',
 					} }
 				/>
 			) : (
-				<Text
-					as="span"
-					sx={ {
-						color: 'icon.inverse',
-						mb: 0,
-						fontWeight: 'bold',
-						fontSize: 2,
-						textTransform: 'uppercase',
-					} }
-				>
-					{ displayName }
-				</Text>
+				renderFallback()
 			) }
 		</Box>
 	);


### PR DESCRIPTION
## Description

https://linear.app/a8c/issue/PLTFRM-2675/broken-avatar-and-icon-images-404-in-the-dashboard

This pull request enhances the `Avatar` component by introducing a more robust and flexible fallback mechanism for avatar images, improving both user experience and accessibility. The changes include new fallback options (initials or icon), improved handling of image load failures, expanded Storybook stories, and comprehensive test coverage for various fallback scenarios.

**Avatar fallback improvements:**

* Added a `fallback` prop to the `Avatar` component, allowing control over whether to display initials/abbreviation or a generic user icon when the image is unavailable (`initials` by default, or `icon` for always showing the icon). [[1]](diffhunk://#diff-a40cf48abb3017501cd8f6a3132ffa40ec654930d56c0b1558b31d1be3c96f19L20-R36) [[2]](diffhunk://#diff-a40cf48abb3017501cd8f6a3132ffa40ec654930d56c0b1558b31d1be3c96f19R58-R101)
* Improved image failure handling: the component now detects and responds to failed image loads, including server-rendered images that fail before hydration, and resets state when the `src` changes. [[1]](diffhunk://#diff-a40cf48abb3017501cd8f6a3132ffa40ec654930d56c0b1558b31d1be3c96f19R58-R101) [[2]](diffhunk://#diff-a40cf48abb3017501cd8f6a3132ffa40ec654930d56c0b1558b31d1be3c96f19L71-R138)
* Updated the fallback rendering logic to prioritize `abbr`, then the initial from `name`, and finally the icon if neither is provided. [[1]](diffhunk://#diff-a40cf48abb3017501cd8f6a3132ffa40ec654930d56c0b1558b31d1be3c96f19R58-R101) [[2]](diffhunk://#diff-a40cf48abb3017501cd8f6a3132ffa40ec654930d56c0b1558b31d1be3c96f19L71-R138)

**Storybook and documentation:**

* Added several new stories to `Avatar.stories.tsx` demonstrating all fallback behaviors, including image failures, forced icon fallback, and scenarios with missing props. [[1]](diffhunk://#diff-4121b205261c2e9eb35016c0d6fbdd31c650e48bc7b7a3545f911a90ed0dff6dR21-R23) [[2]](diffhunk://#diff-4121b205261c2e9eb35016c0d6fbdd31c650e48bc7b7a3545f911a90ed0dff6dR55-R135)

**Testing improvements:**

* Significantly expanded the test suite for the `Avatar` component to cover all fallback scenarios, including image load failures, fallback switching, accessibility checks, and state resets when `src` changes. [[1]](diffhunk://#diff-ca35367f91b6a7a1981dc308d9c380d04267082e4b06891f7a88991fa39bb30aL4-R4) [[2]](diffhunk://#diff-ca35367f91b6a7a1981dc308d9c380d04267082e4b06891f7a88991fa39bb30aR30-R147)

These changes make the `Avatar` component more resilient, accessible, and customizable for a variety of use cases.