### PR TITLE
Avatar fallback contrast

### DIFF
--- a/src/system/Avatar/Avatar.stories.tsx
+++ b/src/system/Avatar/Avatar.stories.tsx
@@ -37,9 +37,6 @@ export const WithName: Story = {
 	args: {
 		name: 'Kitty',
 		size: 30,
-		sx: {
-			backgroundColor: '#D8A45F',
-		},
 	},
 };
 export const WithAbbreviation: Story = {
@@ -47,9 +44,6 @@ export const WithAbbreviation: Story = {
 		name: 'Taylor Swift',
 		abbr: 'TS',
 		size: 64,
-		sx: {
-			backgroundColor: '#D8A45F',
-		},
 	},
 };
 
@@ -61,9 +55,6 @@ export const BrokenImage: Story = {
 	args: {
 		name: 'Taylor Swift',
 		src: BROKEN_SRC,
-		sx: {
-			backgroundColor: '#D8A45F',
-		},
 	},
 	render: args => (
 		<>
@@ -81,9 +72,6 @@ export const BrokenImage: Story = {
 export const IconFallback: Story = {
 	args: {
 		src: BROKEN_SRC,
-		sx: {
-			backgroundColor: '#D8A45F',
-		},
 	},
 	render: args => (
 		<>
@@ -103,9 +91,6 @@ export const ForcedIconFallback: Story = {
 	args: {
 		name: 'Platform Bot',
 		fallback: 'icon',
-		sx: {
-			backgroundColor: '#D8A45F',
-		},
 	},
 	render: args => (
 		<>
@@ -120,11 +105,7 @@ export const ForcedIconFallback: Story = {
  * The same icon fallback is used when no `src` is provided at all.
  */
 export const NoImageOrName: Story = {
-	args: {
-		sx: {
-			backgroundColor: '#D8A45F',
-		},
-	},
+	args: {},
 	render: args => (
 		<>
 			{ COMMON_SIZES.map( size => (

--- a/src/system/Avatar/Avatar.test.tsx
+++ b/src/system/Avatar/Avatar.test.tsx
@@ -3,11 +3,36 @@
  */
 import { fireEvent, render, screen } from '@testing-library/react';
 import { axe } from 'jest-axe';
+import { ThemeUIProvider, type Theme } from 'theme-ui';
 
 /**
  * Internal dependencies
  */
 import { Avatar } from './Avatar';
+import { theme } from '../';
+
+const renderWithTheme = ( children: React.ReactNode ) =>
+	render( <ThemeUIProvider theme={ theme as Theme }>{ children }</ThemeUIProvider> );
+
+// jsdom here does not resolve class-based rules through getComputedStyle, so
+// read the CSS that Emotion emitted for the element's own class instead.
+const cssFor = ( el: HTMLElement ) => {
+	const emotionClass = Array.from( el.classList ).find( c => c.startsWith( 'css-' ) );
+	let css = '';
+
+	for ( const sheet of Array.from( document.styleSheets ) ) {
+		for ( const rule of Array.from( sheet.cssRules ) ) {
+			if ( ( rule as CSSStyleRule ).selectorText === `.${ emotionClass }` ) {
+				css += ( rule as CSSStyleRule ).cssText;
+			}
+		}
+	}
+
+	return css;
+};
+
+// Theme UI emits custom properties rather than rgb values.
+const AVATAR_FALLBACK_BG = 'background-color: var(--theme-ui-colors-gray-65)';
 
 describe( '<Avatar />', () => {
 	it( 'renders the Avatar without an image', async () => {
@@ -38,6 +63,55 @@ describe( '<Avatar />', () => {
 
 		// Check for accessibility issues
 		expect( await axe( container ) ).toHaveNoViolations();
+	} );
+
+	describe( 'fallback contrast', () => {
+		it( 'gives the initial fallback a background so it is not white on white', () => {
+			// The fallback renders in `icon.inverse` (#ffffff light, #ebe9e8 dark), so
+			// without a background of its own it is invisible on a light surface.
+			renderWithTheme( <Avatar name="John Doe" /> );
+
+			const circle = screen.getByText( 'J' ).parentElement as HTMLElement;
+
+			expect( cssFor( circle ) ).toContain( AVATAR_FALLBACK_BG );
+		} );
+
+		it( 'gives the icon fallback the same background', () => {
+			renderWithTheme( <Avatar /> );
+
+			const circle = screen.getByTestId( 'avatar-fallback-icon' ).parentElement as HTMLElement;
+
+			expect( cssFor( circle ) ).toContain( AVATAR_FALLBACK_BG );
+		} );
+
+		it( 'applies the background once an image fails to load', () => {
+			renderWithTheme( <Avatar name="John Doe" src="path/to/broken/image" /> );
+
+			fireEvent.error( screen.getByAltText( 'Avatar image from John Doe' ) );
+
+			const circle = screen.getByText( 'J' ).parentElement as HTMLElement;
+
+			expect( cssFor( circle ) ).toContain( AVATAR_FALLBACK_BG );
+		} );
+
+		it( 'leaves the background alone while a working image is showing', () => {
+			// Consumers pass transparent marks as `src`; a filled circle behind them
+			// would show through.
+			renderWithTheme( <Avatar name="John Doe" src="path/to/image" /> );
+
+			const circle = screen.getByAltText( 'Avatar image from John Doe' )
+				.parentElement as HTMLElement;
+
+			expect( cssFor( circle ) ).not.toContain( AVATAR_FALLBACK_BG );
+		} );
+
+		it( 'still lets a consumer override the background', () => {
+			renderWithTheme( <Avatar name="John Doe" sx={ { backgroundColor: '#ff0000' } } /> );
+
+			const circle = screen.getByText( 'J' ).parentElement as HTMLElement;
+
+			expect( cssFor( circle ) ).toContain( 'background-color: #ff0000' );
+		} );
 	} );
 
 	it( 'falls back to the abbreviation when the image fails to load', () => {

--- a/src/system/Avatar/Avatar.tsx
+++ b/src/system/Avatar/Avatar.tsx
@@ -113,6 +113,7 @@ export const Avatar = ( {
 				justifyContent: 'center',
 				color: 'inverse',
 				textAlign: 'center',
+				...( showImage ? {} : { backgroundColor: 'gray.65' } ),
 				...sx,
 			} }
 			className={ classNames( 'vip-avatar-component', className ) }


### PR DESCRIPTION
## Description

This pull request updates the `Avatar` component to ensure a consistent fallback background color for improved accessibility and visual clarity, and refactors related stories and tests. Inline `sx` overrides for the fallback background are removed from stories, and the fallback background is now handled directly in the component and tested thoroughly.

**Avatar Fallback Background Improvements:**

* [`src/system/Avatar/Avatar.tsx`](diffhunk://#diff-a40cf48abb3017501cd8f6a3132ffa40ec654930d56c0b1558b31d1be3c96f19R116): Adds a default fallback background color (`gray.65`) when no image is shown, ensuring the avatar content is always visible and accessible.
* [`src/system/Avatar/Avatar.test.tsx`](diffhunk://#diff-ca35367f91b6a7a1981dc308d9c380d04267082e4b06891f7a88991fa39bb30aR6-R35): Adds tests to verify the fallback background is applied correctly in various scenarios (initials fallback, icon fallback, image load failure), and that consumers can still override the background color. [[1]](diffhunk://#diff-ca35367f91b6a7a1981dc308d9c380d04267082e4b06891f7a88991fa39bb30aR6-R35) [[2]](diffhunk://#diff-ca35367f91b6a7a1981dc308d9c380d04267082e4b06891f7a88991fa39bb30aR68-R116)

**Storybook Cleanup:**

* [`src/system/Avatar/Avatar.stories.tsx`](diffhunk://#diff-4121b205261c2e9eb35016c0d6fbdd31c650e48bc7b7a3545f911a90ed0dff6dL40-L52): Removes inline `sx: { backgroundColor: '#D8A45F' }` overrides from all stories, relying on the component's default fallback background instead. [[1]](diffhunk://#diff-4121b205261c2e9eb35016c0d6fbdd31c650e48bc7b7a3545f911a90ed0dff6dL40-L52) [[2]](diffhunk://#diff-4121b205261c2e9eb35016c0d6fbdd31c650e48bc7b7a3545f911a90ed0dff6dL64-L66) [[3]](diffhunk://#diff-4121b205261c2e9eb35016c0d6fbdd31c650e48bc7b7a3545f911a90ed0dff6dL84-L86) [[4]](diffhunk://#diff-4121b205261c2e9eb35016c0d6fbdd31c650e48bc7b7a3545f911a90ed0dff6dL106-L108) [[5]](diffhunk://#diff-4121b205261c2e9eb35016c0d6fbdd31c650e48bc7b7a3545f911a90ed0dff6dL123-R108)

## Checklist

- [ ] This PR has good automated test coverage
- [ ] The storybook for the component has been updated

## Steps to Test

Outline the steps to test and verify the PR here.

Example:

1. Pull down PR.
1. `npm run dev`.
1. Open Storybook.
1. Eat cookies.
1. Verify cookies are delicious.
