### PR TITLE
Add ServiceHeader and a dismissible Notice

### DIFF
--- a/src/system/Notice/Notice.stories.tsx
+++ b/src/system/Notice/Notice.stories.tsx
@@ -126,3 +126,22 @@ export const Default: Story = {
 		</React.Fragment>
 	),
 };
+
+/**
+ * A notice either closes or collapses, never both: one icon in the header keeps it
+ * obvious what that icon does. Passing `dismissible` with `collapsible` is a type error.
+ */
+export const Dismissible: Story = {
+	render: () => (
+		<React.Fragment>
+			<Notice variant="info" sx={ { mb: 4 } } title="You can close this one" dismissible>
+				Dismissing removes the notice and calls <code>onDismiss</code>, so the page can remember the
+				choice.
+			</Notice>
+
+			<Notice variant="success" sx={ { mb: 4 } } title="This one collapses instead" collapsible>
+				Bucket names in Amazon S3 are globally unique.
+			</Notice>
+		</React.Fragment>
+	),
+};

--- a/src/system/Notice/Notice.test.tsx
+++ b/src/system/Notice/Notice.test.tsx
@@ -2,6 +2,7 @@
  * External dependencies
  */
 import { render, screen } from '@testing-library/react';
+import userEvent from '@testing-library/user-event';
 import { axe } from 'jest-axe';
 
 /**
@@ -28,5 +29,39 @@ describe( '<Notice />', () => {
 		expect( screen.getByText( 'notice title' ) ).toBeInTheDocument();
 		expect( screen.getByTestId( 'notice' ) ).toHaveAttribute( 'role', 'status' );
 		expect( await axe( container ) ).toHaveNoViolations();
+	} );
+
+	it( 'has no close button unless it is dismissible', () => {
+		render( <Notice title="Heads up">Notice content</Notice> );
+
+		expect( screen.queryByRole( 'button', { name: 'Close notice' } ) ).not.toBeInTheDocument();
+	} );
+
+	it( 'hides itself and reports the dismissal when closed', async () => {
+		const onDismiss = jest.fn();
+		render(
+			<Notice title="Heads up" dismissible onDismiss={ onDismiss }>
+				Notice content
+			</Notice>
+		);
+
+		await userEvent.click( screen.getByRole( 'button', { name: 'Close notice' } ) );
+
+		expect( screen.queryByText( 'Notice content' ) ).not.toBeInTheDocument();
+		expect( onDismiss ).toHaveBeenCalledTimes( 1 );
+	} );
+
+	it( 'gives a collapsible notice one icon, the toggle', async () => {
+		render(
+			<Notice title="Heads up" collapsible>
+				Notice content
+			</Notice>
+		);
+
+		// Only the chevron, so there is no second icon to mistake it for.
+		expect( screen.queryByRole( 'button', { name: 'Close notice' } ) ).not.toBeInTheDocument();
+
+		await userEvent.click( screen.getByRole( 'button', { name: 'Heads up' } ) );
+		expect( screen.getByText( 'Notice content' ) ).toBeInTheDocument();
 	} );
 } );

--- a/src/system/Notice/Notice.tsx
+++ b/src/system/Notice/Notice.tsx
@@ -5,9 +5,10 @@
  */
 import * as Collapsible from '@radix-ui/react-collapsible';
 import classNames from 'classnames';
+import { useTranslate } from 'i18n-calypso';
 import React, { useState, useId } from 'react';
 import { BiChevronDown, BiChevronUp } from 'react-icons/bi';
-import { MdError, MdWarning, MdCheckCircle, MdInfo } from 'react-icons/md';
+import { MdError, MdWarning, MdCheckCircle, MdInfo, MdClose } from 'react-icons/md';
 import { ThemeUIStyleObject } from 'theme-ui';
 
 /**
@@ -45,6 +46,14 @@ export type NoticeProps = Omit< React.HTMLAttributes< HTMLDivElement >, 'title' 
 	headingVariant?: React.ElementType;
 	/** Additional CSS class name(s) appended to the root element. */
 	className?: string;
+	/**
+	 * When true, renders a close button that hides the notice. Ignored on a
+	 * collapsible notice, which shows only its toggle: two icons in one header
+	 * leave the chevron ambiguous. @default false
+	 */
+	dismissible?: boolean;
+	/** Called when the notice is dismissed through the close button. */
+	onDismiss?: () => void;
 	/** Ref forwarded to the root element. */
 	ref?: React.Ref< HTMLDivElement >;
 } & CollapsibleProps;
@@ -77,16 +86,45 @@ export const Notice = ( {
 	variant = 'warning',
 	collapsible = false,
 	defaultOpen = false,
+	dismissible = false,
+	onDismiss,
 	ref,
 	...props
 }: NoticeProps ) => {
+	const translate = useTranslate();
 	const [ isExpanded, setIsExpanded ] = useState( defaultOpen );
+	const [ isDismissed, setIsDismissed ] = useState( false );
 	const handleExpand = ( openValue: boolean ) => setIsExpanded( openValue );
 	const ChevronIcon = isExpanded ? BiChevronUp : BiChevronDown;
 	const contentId = useId();
 
 	const iconColor = `notice.icon.${ variant }`;
 	const textColor = `notice.text.${ variant }`;
+
+	if ( isDismissed ) {
+		return null;
+	}
+
+	const dismissButton = dismissible && (
+		<Button
+			variant="icon"
+			type="button"
+			aria-label={ translate( 'Close notice' ) }
+			onClick={ () => {
+				setIsDismissed( true );
+				onDismiss?.();
+			} }
+			sx={ {
+				// The body can run several lines tall, so the button sits beside the first.
+				alignSelf: 'flex-start',
+				color: textColor,
+				flex: '0 0 auto',
+				ml: 'auto',
+			} }
+		>
+			<MdClose size={ 20 } aria-hidden="true" />
+		</Button>
+	);
 
 	const baseCardSx: ThemeUIStyleObject = {
 		boxShadow: 'none',
@@ -253,6 +291,7 @@ export const Notice = ( {
 				) }
 				{ children }
 			</Box>
+			{ dismissButton }
 		</Card>
 	);
 };

--- a/src/system/Notice/Notice.types.test.tsx
+++ b/src/system/Notice/Notice.types.test.tsx
@@ -1,0 +1,35 @@
+/**
+ * External dependencies
+ */
+import React from 'react';
+
+/**
+ * Internal dependencies
+ */
+import { Notice } from './Notice';
+
+/**
+ * Wrappers commonly re-expose the whole prop surface and spread it through, so
+ * the props have to stay forwardable as one object. Splitting them into a union
+ * of collapsible-or-dismissible reads well but breaks exactly this pattern.
+ */
+type WrapperProps = Omit< React.ComponentProps< typeof Notice >, 'title' | 'children' >;
+
+const Wrapper = ( { ...noticeProps }: WrapperProps ) => (
+	<Notice variant="warning" title="Wrapped" { ...noticeProps }>
+		Content
+	</Notice>
+);
+
+describe( '<Notice /> types', () => {
+	it( 'stays forwardable through a wrapper that spreads its props', () => {
+		const examples = {
+			dismissible: <Wrapper dismissible onDismiss={ () => undefined } />,
+			collapsible: <Wrapper collapsible defaultOpen />,
+			// A wrapper only knows these at runtime, so they have to type-check as booleans.
+			dynamic: <Wrapper collapsible={ Boolean( 1 ) } />,
+		};
+
+		expect( Object.keys( examples ) ).toHaveLength( 3 );
+	} );
+} );

--- a/src/system/ServiceHeader/ServiceHeader.stories.tsx
+++ b/src/system/ServiceHeader/ServiceHeader.stories.tsx
@@ -1,0 +1,84 @@
+/**
+ * External dependencies
+ */
+import React from 'react';
+import { BiDotsVerticalRounded } from 'react-icons/bi';
+
+/**
+ * Internal dependencies
+ */
+import { ServiceHeader, Button, Dropdown } from '..';
+
+import type { ServiceStatus } from './ServiceHeader';
+import type { StoryObj } from '@storybook/react-vite';
+
+export default {
+	title: 'ServiceHeader',
+	component: ServiceHeader,
+};
+
+type Story = StoryObj< typeof ServiceHeader >;
+
+const title = 'Performance Monitoring';
+const description = 'This service monitors your application environment and reports on it.';
+
+export const Primary: Story = {
+	args: {
+		title,
+		description,
+		status: 'enabled',
+		message: 'Available on non-production environments only.',
+		actions: <Button variant="secondary">Disable</Button>,
+	},
+};
+
+/** The actions slot takes any number of controls, so a menu can sit beside the primary action. */
+export const WithActionsMenu: Story = {
+	args: {
+		title,
+		description,
+		status: 'enabled',
+		actions: (
+			<React.Fragment>
+				<Button variant="primary">Open ↗</Button>
+				<Dropdown.Root
+					contentProps={ { align: 'end', sx: { minWidth: 'auto' } } }
+					trigger={
+						<Button variant="secondary" sx={ { px: 2 } } aria-label="More actions">
+							<BiDotsVerticalRounded aria-hidden="true" size={ 20 } />
+						</Button>
+					}
+				>
+					<Dropdown.Item>Disable service</Dropdown.Item>
+				</Dropdown.Root>
+			</React.Fragment>
+		),
+	},
+};
+
+const statuses: ServiceStatus[] = [
+	'loading',
+	'unavailable',
+	'disabled',
+	'enabling',
+	'enabled',
+	'disabling',
+	'error',
+];
+
+export const Statuses: Story = {
+	render: () => (
+		<React.Fragment>
+			{ statuses.map( status => (
+				<ServiceHeader
+					key={ status }
+					title={ title }
+					description={ description }
+					status={ status }
+					sx={ { mb: 5 } }
+					actions={ <Button variant="secondary">Enable</Button> }
+				/>
+			) ) }
+		</React.Fragment>
+	),
+};

--- a/src/system/ServiceHeader/ServiceHeader.test.tsx
+++ b/src/system/ServiceHeader/ServiceHeader.test.tsx
@@ -1,0 +1,120 @@
+/**
+ * External dependencies
+ */
+import { render, screen } from '@testing-library/react';
+import userEvent from '@testing-library/user-event';
+import { axe } from 'jest-axe';
+
+/**
+ * Internal dependencies
+ */
+import { ServiceHeader } from './ServiceHeader';
+import { Button } from '../Button/Button';
+import * as Dropdown from '../Dropdown';
+
+beforeAll( () => {
+	if ( ! global.ResizeObserver ) {
+		global.ResizeObserver = class ResizeObserver {
+			observe() {}
+			unobserve() {}
+			disconnect() {}
+		} as typeof ResizeObserver;
+	}
+} );
+
+describe( '<ServiceHeader />', () => {
+	it( 'renders the service, its status badge, and the actions', async () => {
+		const { container } = render(
+			<ServiceHeader
+				title="Performance Monitoring"
+				description="This service monitors your application environment."
+				status="enabled"
+				actions={ <button>Enable</button> }
+			/>
+		);
+
+		expect( screen.getByRole( 'heading', { name: 'Performance Monitoring' } ) ).toBeInTheDocument();
+		expect(
+			screen.getByText( 'This service monitors your application environment.' )
+		).toBeInTheDocument();
+		// Every service reads the same way: a running service is "Enabled".
+		expect( screen.getByText( 'Enabled' ) ).toBeInTheDocument();
+		expect( screen.getByRole( 'button', { name: 'Enable' } ) ).toBeInTheDocument();
+		expect( await axe( container ) ).toHaveNoViolations();
+	} );
+
+	it( 'labels the section with the service name', () => {
+		render(
+			<ServiceHeader title="Performance Monitoring" description="Monitoring." status="disabled" />
+		);
+
+		expect( screen.getByRole( 'region', { name: 'Performance Monitoring' } ) ).toBeInTheDocument();
+		expect( screen.getByText( 'Disabled' ) ).toBeInTheDocument();
+	} );
+
+	it( 'spins the badge itself while the service is in transition', () => {
+		const { container, rerender } = render(
+			<ServiceHeader title="Performance Monitoring" description="Monitoring." status="enabled" />
+		);
+
+		expect( container.querySelector( '.vip-spinner-component' ) ).toBeNull();
+
+		rerender(
+			<ServiceHeader title="Performance Monitoring" description="Monitoring." status="enabling" />
+		);
+
+		const badge = container.querySelector( '.vip-badge-component' );
+		expect( badge ).toHaveTextContent( 'Enabling' );
+		expect( badge?.querySelector( '.vip-spinner-component' ) ).not.toBeNull();
+	} );
+
+	it( 'shows the helper message only when there is one', () => {
+		const { rerender } = render(
+			<ServiceHeader title="Performance Monitoring" description="Monitoring." status="disabled" />
+		);
+
+		expect( screen.queryByText( 'Non-production environments only.' ) ).not.toBeInTheDocument();
+
+		rerender(
+			<ServiceHeader
+				title="Performance Monitoring"
+				description="Monitoring."
+				status="disabled"
+				message="Non-production environments only."
+			/>
+		);
+
+		expect( screen.getByText( 'Non-production environments only.' ) ).toBeInTheDocument();
+	} );
+
+	it( 'opens a menu placed alongside the lifecycle button in the actions slot', async () => {
+		render(
+			<ServiceHeader
+				title="Performance Monitoring"
+				description="Monitoring."
+				status="enabled"
+				actions={
+					<>
+						<Button variant="primary">Open</Button>
+						<Dropdown.Root
+							modal={ false }
+							trigger={ <Button variant="secondary" aria-label="More actions" /> }
+						>
+							<Dropdown.Item>Disable service</Dropdown.Item>
+						</Dropdown.Root>
+					</>
+				}
+			/>
+		);
+
+		expect( screen.getByRole( 'button', { name: 'Open' } ) ).toBeInTheDocument();
+		expect( screen.queryByRole( 'menuitem' ) ).not.toBeInTheDocument();
+
+		await userEvent.click( screen.getByRole( 'button', { name: 'More actions' } ) );
+
+		// The menu is portaled, so the header's `overflow: hidden` never clips it.
+		expect(
+			await screen.findByRole( 'menuitem', { name: 'Disable service' } )
+		).toBeInTheDocument();
+	} );
+} );

--- a/src/system/ServiceHeader/ServiceHeader.tsx
+++ b/src/system/ServiceHeader/ServiceHeader.tsx
@@ -1,0 +1,159 @@
+/** @jsxImportSource theme-ui */
+
+/**
+ * External dependencies
+ */
+import classNames from 'classnames';
+import { useTranslate } from 'i18n-calypso';
+import React, { useId } from 'react';
+import { BiInfoCircle } from 'react-icons/bi';
+import { FaCircle } from 'react-icons/fa6';
+import { ThemeUIStyleObject } from 'theme-ui';
+
+/**
+ * Internal dependencies
+ */
+import { Badge } from '../Badge/Badge';
+import { Box } from '../Box/Box';
+import { Card } from '../Card/Card';
+import { Flex } from '../Flex/Flex';
+import { Heading } from '../Heading/Heading';
+import { Spinner } from '../Spinner/Spinner';
+import { Text } from '../Text/Text';
+
+/**
+ * The statuses every service shares. Keeping the vocabulary here is the point of
+ * the pattern: closely related services read the same way instead of each one
+ * inventing its own wording.
+ */
+export type ServiceStatus =
+	| 'loading'
+	| 'unavailable'
+	| 'disabled'
+	| 'enabling'
+	| 'enabled'
+	| 'disabling'
+	| 'error';
+
+export type ServiceHeaderProps = {
+	/** Lifecycle controls for the service, rendered on the right of the header. */
+	actions?: React.ReactNode;
+	/** Additional CSS class name(s) appended to the root element. */
+	className?: string;
+	/** What the service does, in plain language. */
+	description: React.ReactNode;
+	/** Instruction or notice qualifying the status, shown in the bar below the header. */
+	message?: React.ReactNode;
+	/** The lifecycle state of the service, shown as a badge next to the title. */
+	status: ServiceStatus;
+	/** Theme UI style overrides applied to the root element. */
+	sx?: ThemeUIStyleObject;
+	/** The name of the service. */
+	title: React.ReactNode;
+};
+
+/**
+ * The standard header for a service a customer can enable, check the status of,
+ * and control: title and status badge, description, lifecycle actions, and a
+ * helper message bar for anything that qualifies the status.
+ */
+export const ServiceHeader = ( {
+	actions,
+	className,
+	description,
+	message,
+	status,
+	sx = {},
+	title,
+}: ServiceHeaderProps ) => {
+	const translate = useTranslate();
+	const headingId = useId();
+
+	const badgeByStatus: Record<
+		ServiceStatus,
+		{ label: string; variant: React.ComponentProps< typeof Badge >[ 'variant' ] }
+	> = {
+		loading: { label: translate( 'Loading' ), variant: 'gray' },
+		unavailable: { label: translate( 'Unavailable' ), variant: 'orange' },
+		disabled: { label: translate( 'Disabled' ), variant: 'gray' },
+		enabling: { label: translate( 'Enabling' ), variant: 'blue' },
+		enabled: { label: translate( 'Enabled' ), variant: 'green' },
+		disabling: { label: translate( 'Disabling' ), variant: 'blue' },
+		error: { label: translate( 'Error' ), variant: 'red' },
+	};
+	const badge = badgeByStatus[ status ];
+	const isInTransition = status === 'loading' || status === 'enabling' || status === 'disabling';
+
+	return (
+		<Card
+			as="section"
+			aria-labelledby={ headingId }
+			className={ classNames( 'vip-service-header-component', className ) }
+			bodyStyles={ { p: 0 } }
+			sx={ {
+				backgroundColor: 'layer.2',
+				borderRadius: 1,
+				boxShadow: 'low',
+				overflow: 'hidden',
+				...sx,
+			} }
+		>
+			<Flex
+				sx={ {
+					alignItems: [ 'stretch', 'stretch', 'center' ],
+					flexDirection: [ 'column', 'column', 'row' ],
+					gap: 4,
+					justifyContent: 'space-between',
+					py: 4,
+					px: 5,
+				} }
+			>
+				<Box aria-live="polite">
+					<Flex sx={ { alignItems: 'center', flexWrap: 'wrap', gap: 2, mb: 1 } }>
+						<Heading id={ headingId } variant="h5" sx={ { mb: 0 } }>
+							{ title }
+						</Heading>
+						<Badge
+							variant={ badge.variant }
+							sx={ { alignItems: 'center', display: 'flex', gap: 1, mb: 0 } }
+						>
+							{ /* The badge carries the progress, so a service in
+							     transition has one spinner and not two. */ }
+							{ isInTransition && <Spinner size={ 12 } color="inherit" aria-hidden="true" /> }
+							{ status === 'enabled' && (
+								<FaCircle
+									aria-hidden="true"
+									size={ 8 }
+									sx={ { color: 'tag.green.icon', mr: 0.5 } }
+								/>
+							) }
+							{ badge.label }
+						</Badge>
+					</Flex>
+					<Text sx={ { mb: 0 } }>{ description }</Text>
+				</Box>
+
+				{ actions && (
+					<Flex sx={ { alignItems: 'center', flexShrink: 0, gap: 2 } }>{ actions }</Flex>
+				) }
+			</Flex>
+
+			{ message && (
+				<Flex
+					sx={ {
+						px: 5,
+						py: 3,
+						background: 'layer.1',
+						gap: 2,
+						alignItems: 'center',
+					} }
+				>
+					<BiInfoCircle size={ 14 } sx={ { fill: 'texts.helper' } } />
+					<Text sx={ { m: 0, fontSize: 'small', color: 'texts.helper' } }>{ message }</Text>
+				</Flex>
+			) }
+		</Card>
+	);
+};
+
+ServiceHeader.displayName = 'ServiceHeader';

--- a/src/system/ServiceHeader/index.ts
+++ b/src/system/ServiceHeader/index.ts
@@ -1,0 +1,7 @@
+/**
+ * Internal dependencies
+ */
+import { ServiceHeader } from './ServiceHeader';
+
+export { ServiceHeader };
+export type { ServiceHeaderProps, ServiceStatus } from './ServiceHeader';

--- a/src/system/index.ts
+++ b/src/system/index.ts
@@ -53,6 +53,7 @@ import { OptionRow } from './OptionRow';
 import { SimplePagination, Pagination } from './Pagination';
 import { Progress } from './Progress';
 import { ScreenReaderText } from './ScreenReaderText';
+import { ServiceHeader } from './ServiceHeader';
 import { Skeleton } from './Skeleton';
 import { Snackbar } from './Snackbar';
 import { Spinner } from './Spinner';
@@ -130,6 +131,7 @@ export {
 	ToggleRow,
 	Toolbar,
 	Snackbar,
+	ServiceHeader,
 	Validation,
 	Wizard,
 	WizardStep,


### PR DESCRIPTION
## Description

We are making two additions:

- `ServiceHeader` component:
This is the [standard header component](https://pixelsandpointsp2.wordpress.com/2026/08/11/vip-dashboard-service-header-design-pattern-i1/) that is used in the VIP APM and Defensive Mode pages. We are porting it out to VIP Design Systems. 

<img width="1019" height="163" alt="Screenshot 2026-08-17 at 6 09 45 PM" src="https://github.com/user-attachments/assets/94743671-bebf-4d1c-b03f-ff7701f8076a" />
<img width="1019" height="113" alt="Screenshot 2026-08-17 at 6 09 57 PM" src="https://github.com/user-attachments/assets/702dad16-2b10-475a-bc16-4551b204c68a" />

- Dismiss button in `Notice` component:
We are making the `Notice` component dismissible by adding a `dismissible` prop and cross icon.

<img width="1019" height="167" alt="Screenshot 2026-08-17 at 6 10 09 PM" src="https://github.com/user-attachments/assets/54b3077e-7d57-423d-b0dc-08125a78a076" />


## How to test

1. Pull the PR and run `pnpm dev`
2. Go to http://localhost:6006/?path=/story/notice--dismissible&args=dismissible:!true and observe the dismissible button on the Notice component.
3. Go to http://localhost:6006/?path=/docs/serviceheader--docs and observe the new ServiceHeader component.

