### PR TITLE
Fix Card sx merge and Accordion surface

### DIFF
--- a/AGENTS.md
+++ b/AGENTS.md
@@ -62,6 +62,7 @@ build/                   # Compiled output (generated, do not edit)
 - Use Prettier formatting (`wp-prettier`). Run `npm run format` before committing.
 - Use TypeScript for all new code. Define prop interfaces with explicit types.
 - Accept `ref` as a regular prop when wrapping HTML elements or Theme UI components (React 19 pattern). Add `ref?: React.Ref<T>` to the component's props type. Do not use `forwardRef` — it is no longer used in this codebase. **Note:** this pattern requires React 19; React 18 consumers cannot use forwarded refs on these components.
+- A component that sets a literal `sx` must destructure `sx` (and `className`) from its props and merge them explicitly — `sx={ { ...ownStyles, ...sx } }`, or `sx={ { variant: 'foo.bar', ...sx } }` for variant-based components, and `className={ classNames( 'vip-x-component', className ) }`. Never let either ride along in `...rest`: spread after the component's own value, they replace it silently instead of merging.
 
 ### Styling
 

--- a/src/system/Accordion/Accordion.test.tsx
+++ b/src/system/Accordion/Accordion.test.tsx
@@ -121,3 +121,28 @@ describe.each( [
 		expect( await axe( container ) ).toHaveNoViolations();
 	} );
 } );
+
+describe( '<Accordion />, surface', () => {
+	// Theme UI emits colours as CSS custom properties by default, which jsdom
+	// cannot resolve. Turning them off makes the theme emit literal values.
+	const testTheme = { ...theme, config: { ...theme.config, useCustomProperties: false } };
+
+	it( 'paints its own background on a closed item', () => {
+		const { container } = render(
+			<ThemeUIProvider theme={ testTheme }>
+				<Accordion.Root>
+					<Accordion.Item className="test-item" value="one">
+						<Accordion.Trigger>trigger one</Accordion.Trigger>
+						<Accordion.Content>content one</Accordion.Content>
+					</Accordion.Item>
+				</Accordion.Root>
+			</ThemeUIProvider>
+		);
+
+		const item = container.querySelector( '.test-item' );
+
+		expect( item ).toHaveAttribute( 'data-state', 'closed' );
+		// A closed accordion must not fall through to whatever the page sits on.
+		expect( item ).toHaveStyle( { backgroundColor: theme.colors.layer[ '2' ] } );
+	} );
+} );

--- a/src/system/Accordion/Accordion.tsx
+++ b/src/system/Accordion/Accordion.tsx
@@ -87,6 +87,9 @@ export const Item = ( { children, className, sx = {}, ref, ...props }: Accordion
 		className={ classNames( className ) }
 		ref={ ref }
 		sx={ {
+			// The item owns the surface so a closed accordion is self-contained
+			// rather than showing whatever the page sits on.
+			backgroundColor: 'accordion.item.background',
 			overflow: 'hidden',
 			borderWidth: '0 1px 1px 1px',
 			borderStyle: 'solid',

--- a/src/system/Card/Card.stories.tsx
+++ b/src/system/Card/Card.stories.tsx
@@ -73,3 +73,15 @@ export const StyledBody: Story = {
 		children: 'Hello styled body.',
 	},
 };
+
+/**
+ * `sx` is merged over the variant rather than replacing it, so the card keeps its
+ * background, radius and shadow while the custom styles are applied on top.
+ */
+export const WithCustomStyles: Story = {
+	args: {
+		title: 'Header',
+		sx: { maxWidth: 400, mb: 4 },
+		children: 'This card sets maxWidth and margin, and keeps the primary variant surface.',
+	},
+};

--- a/src/system/Card/Card.test.tsx
+++ b/src/system/Card/Card.test.tsx
@@ -3,13 +3,33 @@
  */
 import { render, screen } from '@testing-library/react';
 import { axe } from 'jest-axe';
+import { createElement } from 'react';
+import { ThemeUIProvider } from 'theme-ui';
 
 /**
  * Internal dependencies
  */
 import { Card } from './Card';
+import { theme } from '../';
+
+import type { Theme } from 'theme-ui';
 
 const defaultProps = {};
+
+// Theme UI emits colours as CSS custom properties by default, which jsdom cannot
+// resolve, so `toHaveStyle` would see an empty background. Turning them off makes
+// the theme emit literal values and keeps these assertions readable.
+const testTheme = {
+	...theme,
+	config: { ...theme.config, useCustomProperties: false },
+} as unknown as Theme;
+
+const renderWithTheme = ( children: React.ReactNode ) =>
+	render( <ThemeUIProvider theme={ testTheme }>{ children }</ThemeUIProvider> );
+
+const layerTwo = ( theme.colors as unknown as Record< string, Record< string, string > > ).layer[
+	'2'
+];
 
 describe( '<Card />', () => {
 	it( 'renders the Card component', async () => {
@@ -39,5 +59,38 @@ describe( '<Card />', () => {
 
 		// Check for accessibility issues
 		expect( await axe( container ) ).toHaveNoViolations();
+	} );
+
+	it( 'keeps the variant styles when the consumer passes an unrelated sx', () => {
+		// `createElement` deliberately bypasses the theme-ui JSX pragma so that `sx`
+		// reaches Card as a runtime prop, which is what a consumer that does not
+		// compile with `importSource: 'theme-ui'` produces. Written as JSX, Babel
+		// would compile `sx` away at the call site and never exercise this path.
+		const { container } = renderWithTheme(
+			createElement( Card, { sx: { marginTop: '8px' } }, 'Card text' )
+		);
+
+		const card = container.querySelector( '.vip-card-component' );
+
+		// `cards.primary` supplies the surface; the consumer sx must add to it,
+		// not replace it.
+		expect( card ).toHaveStyle( { backgroundColor: layerTwo } );
+		expect( card ).toHaveStyle( { marginTop: '8px' } );
+	} );
+
+	it( 'lets the consumer sx override a property the variant sets', () => {
+		const { container } = renderWithTheme(
+			createElement( Card, { sx: { backgroundColor: 'rgb(255, 0, 0)' } }, 'Card text' )
+		);
+
+		expect( container.querySelector( '.vip-card-component' ) ).toHaveStyle( {
+			backgroundColor: 'rgb(255, 0, 0)',
+		} );
+	} );
+
+	it( 'keeps its own class name when the consumer passes one', () => {
+		const { container } = renderWithTheme( <Card className="custom-card">Card text</Card> );
+
+		expect( container.querySelector( '.vip-card-component' ) ).toHaveClass( 'custom-card' );
 	} );
 } );

--- a/src/system/Card/Card.tsx
+++ b/src/system/Card/Card.tsx
@@ -3,6 +3,7 @@
 /**
  * External dependencies
  */
+import classNames from 'classnames';
 import React, { Ref } from 'react';
 import { ThemeUIStyleObject } from 'theme-ui';
 
@@ -37,6 +38,11 @@ export interface CardProps {
 	/** Additional Theme UI styles applied to the card header. */
 	headerStyles?: ThemeUIStyleObject;
 	/**
+	 * Additional Theme UI styles applied to the card container. Merged over the
+	 * `variant` styles, so it overrides only the properties it sets.
+	 */
+	sx?: ThemeUIStyleObject;
+	/**
 	 * Hides the card body when true.
 	 * @default false
 	 */
@@ -58,16 +64,22 @@ export const Card = ( {
 	headerStyles,
 	children,
 	hideBody = false,
+	className,
+	sx,
 	ref,
 	...rest
 }: CardBoxProps ) => {
 	return (
 		<Box
 			ref={ ref }
+			// `variant` is listed first so the consumer `sx` merges over it rather
+			// than replacing it: Theme UI expands `variant` in place as it walks the
+			// object, so later keys win.
 			sx={ {
 				variant: `cards.${ variant }`,
+				...sx,
 			} }
-			className="vip-card-component"
+			className={ classNames( 'vip-card-component', className ) }
 			{ ...rest }
 		>
 			{ renderHeader ? renderHeader( title ) : '' }

--- a/src/system/NewForm/FormSelectSearch.tsx
+++ b/src/system/NewForm/FormSelectSearch.tsx
@@ -27,9 +27,9 @@ const searchStyles: ThemeUIStyleObject = {
 	pointerEvents: 'none',
 };
 
-export const FormSelectSearch = ( { ref, ...props }: FormSelectSearchProps ) => (
+export const FormSelectSearch = ( { ref, sx, ...props }: FormSelectSearchProps ) => (
 	<Box ref={ ref } sx={ wrapperStyles }>
-		<MdSearch aria-hidden="true" size={ 24 } sx={ searchStyles } { ...props } />
+		<MdSearch aria-hidden="true" size={ 24 } sx={ { ...searchStyles, ...sx } } { ...props } />
 	</Box>
 );
 

--- a/src/system/Notice/Notice.tsx
+++ b/src/system/Notice/Notice.tsx
@@ -126,12 +126,10 @@ export const Notice = ( {
 		</Button>
 	);
 
+	// `boxShadow`, `borderRadius` and `fontSize` come from the `cards.notice` variant.
 	const baseCardSx: ThemeUIStyleObject = {
-		boxShadow: 'none',
-		borderRadius: 2,
 		bg: inline || collapsible ? 'transparent' : `notice.background.${ variant }`,
 		color: textColor,
-		fontSize: 2,
 		p: {
 			color: textColor,
 			fontSize: 2,

--- a/src/system/ServiceHeader/ServiceHeader.tsx
+++ b/src/system/ServiceHeader/ServiceHeader.tsx
@@ -91,9 +91,10 @@ export const ServiceHeader = ( {
 			className={ classNames( 'vip-service-header-component', className ) }
 			bodyStyles={ { p: 0 } }
 			sx={ {
-				backgroundColor: 'layer.2',
+				// Background and shadow come from the `cards.primary` variant. The
+				// radius is a deliberate departure: the header sits tighter than a
+				// standalone card, so it keeps the 4px step rather than the card's 8px.
 				borderRadius: 1,
-				boxShadow: 'low',
 				overflow: 'hidden',
 				...sx,
 			} }
@@ -149,7 +150,7 @@ export const ServiceHeader = ( {
 					} }
 				>
 					<BiInfoCircle size={ 14 } sx={ { fill: 'texts.helper' } } />
-					<Text sx={ { m: 0, fontSize: 'small', color: 'texts.helper' } }>{ message }</Text>
+					<Text sx={ { m: 0, fontSize: 1, color: 'texts.helper' } }>{ message }</Text>
 				</Flex>
 			) }
 		</Card>

--- a/src/system/theme/index.ts
+++ b/src/system/theme/index.ts
@@ -169,8 +169,13 @@ const getComponentColors = ( theme, gColor, gVariants ) => ( {
 		},
 		background: {
 			open: gColor( 'layer', '3' ),
+			// Transparent so the closed header shows the item surface below, which
+			// leaves this token free to express open/hover contrast against it.
 			closed: 'transparent',
 			hover: gColor( 'layer', '3' ),
+		},
+		item: {
+			background: gColor( 'layer', '2' ),
 		},
 	},
 


### PR DESCRIPTION
## Description

This pull request introduces improvements to styling consistency, prop merging, and test coverage for the `Card`, `Accordion`, and related components. The main focus is on ensuring that custom `sx` and `className` props are merged correctly with component defaults and variant styles, preventing silent overrides and maintaining intended visual hierarchies. Additionally, new tests are added to verify these behaviors, and documentation is updated to reflect the new patterns.

**Prop merging and styling improvements:**

* `Card.tsx`, `ServiceHeader.tsx`, `FormSelectSearch.tsx`: Updated to merge incoming `sx` and `className` props over default and variant styles, ensuring that custom styles add to or override only specific properties without replacing the base styles. (`[[1]](diffhunk://#diff-e3364cd26bccb948f0c44fc34396b80a3c0546d77f300a9b114b80b633387f68R40-R44)`, `[[2]](diffhunk://#diff-e3364cd26bccb948f0c44fc34396b80a3c0546d77f300a9b114b80b633387f68R67-R82)`, `[[3]](diffhunk://#diff-27e10455b5c40b0fff2f995c3705b8e240c99848ad5d205b417e0333971bc6d2L94-L96)`, `[[4]](diffhunk://#diff-3fb7443f758344dffade95ca7def09a1268f21fa8c9cefd980f7294c7c55c0efL30-R32)`, `[[5]](diffhunk://#diff-a54ff182c7e8acf56acfd6e4b9c3ff41e2c41a31c9b211b2deb9df75d9a478f9R65)`)
* `Accordion.tsx`, `theme/index.ts`: The `Accordion.Item` now always paints its own background when closed, using a new theme token, to prevent background leakage and ensure visual containment. (`[[1]](diffhunk://#diff-bd4cd529dfdd6a2f82a02a29bf026856ff9c9f846d65ed37168150e7ac2feb27R90-R92)`, `[[2]](diffhunk://#diff-58fcf6b7cf2c2f4faf2fc08149633c8079285072f2905ad4713c9a8c5e7b33d9R172-R179)`)

**Test coverage:**

* `Card.test.tsx`, `Accordion.test.tsx`: Added tests to confirm that custom `sx` and `className` props are merged correctly and that variant styles are preserved unless explicitly overridden. Tests also verify that `Accordion.Item` backgrounds behave as expected. (`[[1]](diffhunk://#diff-1a4490cc79df0ee5060aa88745d33fe06a32fdf1a52d513969daa78d6d5149b3R6-R33)`, `[[2]](diffhunk://#diff-1a4490cc79df0ee5060aa88745d33fe06a32fdf1a52d513969daa78d6d5149b3R63-R95)`, `[[3]](diffhunk://#diff-41881608b44846652f15c7d944c4c05b90bb410da1e0367900f7f584a19d6735R124-R148)`)

**Documentation:**

* [`AGENTS.md`](diffhunk://#diff-a54ff182c7e8acf56acfd6e4b9c3ff41e2c41a31c9b211b2deb9df75d9a478f9R65): Updated with guidance on destructuring and merging `sx` and `className` props, clarifying the new pattern for all components setting literal `sx`. (`[AGENTS.mdR65](diffhunk://#diff-a54ff182c7e8acf56acfd6e4b9c3ff41e2c41a31c9b211b2deb9df75d9a478f9R65)`)

**Other styling refinements:**

* `Notice.tsx`, `ServiceHeader.tsx`: Adjusted to rely on variant-based styles for background, shadow, and radius, reducing redundancy and improving maintainability. (`[[1]](diffhunk://#diff-4e192a829f2799d44d5927d3f1b3c2f1e2999818c80d0d6f8b6c23997f6571e8R129-L134)`, `[[2]](diffhunk://#diff-27e10455b5c40b0fff2f995c3705b8e240c99848ad5d205b417e0333971bc6d2L94-L96)`, `[[3]](diffhunk://#diff-27e10455b5c40b0fff2f995c3705b8e240c99848ad5d205b417e0333971bc6d2L152-R153)`)

**Storybook examples:**

* [`Card.stories.tsx`](diffhunk://#diff-af06d7e0524a851fa9c6f117ac83fd85111ecdeabaa3546c4ed4c51be6d24625R76-R87): Added an example showing how custom `sx` props are merged over variant styles in the `Card` component. (`[src/system/Card/Card.stories.tsxR76-R87](diffhunk://#diff-af06d7e0524a851fa9c6f117ac83fd85111ecdeabaa3546c4ed4c51be6d24625R76-R87)`)

## Steps to Test

Outline the steps to test and verify the PR here.

Example:

1. Pull down PR.
1. `npm run dev`.
1. Open Storybook.
1. Eat cookies.
1. Verify cookies are delicious.
