### PR TITLE
PLTFRM-2753 - Fix Tabs navigation on smaller screens

### DIFF
--- a/src/system/Tabs/Tabs.stories.jsx
+++ b/src/system/Tabs/Tabs.stories.jsx
@@ -8,7 +8,7 @@ import React from 'react';
 /**
  * Internal dependencies
  */
-import { Tabs, TabsTrigger, TabsList, TabsContent, Text, Link, Button } from '..';
+import { Tabs, TabsTrigger, TabsList, TabsContent, Text, Link, Button, Box } from '..';
 
 export default {
 	title: 'Navigation/Tabs',
@@ -75,4 +75,37 @@ export const SetActiveTab = {
 			</Tabs>
 		);
 	},
+};
+
+/**
+ * When the triggers no longer fit, the list scrolls sideways and fades whichever
+ * edge still has tabs beyond it. The active tab is scrolled into view on mount,
+ * which is why this story opens on a tab near the end.
+ */
+export const Scrollable = {
+	render: () => (
+		<Box sx={ { maxWidth: 380 } }>
+			<Tabs defaultValue="cache">
+				<TabsList title="Insights">
+					<TabsTrigger value="overview">Overview</TabsTrigger>
+					<TabsTrigger value="requests">Requests (1.2M)</TabsTrigger>
+					<TabsTrigger value="bandwidth">Bandwidth</TabsTrigger>
+					<TabsTrigger value="cache">Cache Hit Ratio</TabsTrigger>
+					<TabsTrigger value="errors">Errors (12)</TabsTrigger>
+					<TabsTrigger value="edge">Edge Locations</TabsTrigger>
+					<TabsTrigger value="firewall">Firewall</TabsTrigger>
+					<TabsTrigger value="uptime" disabled>
+						Uptime
+					</TabsTrigger>
+				</TabsList>
+				<TabsContent value="overview">Overview content</TabsContent>
+				<TabsContent value="requests">Requests content</TabsContent>
+				<TabsContent value="bandwidth">Bandwidth content</TabsContent>
+				<TabsContent value="cache">Cache hit ratio content</TabsContent>
+				<TabsContent value="errors">Errors content</TabsContent>
+				<TabsContent value="edge">Edge locations content</TabsContent>
+				<TabsContent value="firewall">Firewall content</TabsContent>
+			</Tabs>
+		</Box>
+	),
 };

--- a/src/system/Tabs/Tabs.test.tsx
+++ b/src/system/Tabs/Tabs.test.tsx
@@ -1,0 +1,213 @@
+/**
+ * External dependencies
+ */
+import { fireEvent, render, screen } from '@testing-library/react';
+import userEvent from '@testing-library/user-event';
+import { axe } from 'jest-axe';
+import React from 'react';
+import { ThemeUIProvider } from 'theme-ui';
+
+/**
+ * Internal dependencies
+ */
+import { Tabs, TabsContent, TabsList, TabsTrigger } from '.';
+import { theme } from '../';
+
+import type { Theme } from 'theme-ui';
+
+// Theme UI emits theme values as CSS custom properties by default, which jsdom
+// cannot resolve. Turning them off makes the theme emit literal values so
+// `toHaveStyle` can see them.
+const testTheme = {
+	...theme,
+	config: { ...theme.config, useCustomProperties: false },
+} as unknown as Theme;
+
+const renderWithTheme = ( children: React.ReactNode ) =>
+	render( <ThemeUIProvider theme={ testTheme }>{ children }</ThemeUIProvider> );
+
+const space = theme.space as unknown as Record< string, number >;
+
+const scrollIntoView = jest.fn();
+
+beforeAll( () => {
+	if ( ! global.ResizeObserver ) {
+		global.ResizeObserver = class ResizeObserver {
+			observe() {}
+			unobserve() {}
+			disconnect() {}
+		} as typeof ResizeObserver;
+	}
+
+	// jsdom does not implement scrollIntoView.
+	Element.prototype.scrollIntoView = scrollIntoView;
+} );
+
+beforeEach( () => {
+	jest.clearAllMocks();
+} );
+
+const renderTabs = ( { defaultValue = 'all' } = {} ) =>
+	renderWithTheme(
+		<Tabs defaultValue={ defaultValue }>
+			<TabsList title="See all the content">
+				<TabsTrigger value="all">All (5)</TabsTrigger>
+				<TabsTrigger value="live">Live (2)</TabsTrigger>
+				<TabsTrigger value="dev">In Development (3)</TabsTrigger>
+			</TabsList>
+			<TabsContent value="all">All content</TabsContent>
+			<TabsContent value="live">Live content</TabsContent>
+			<TabsContent value="dev">In Development content</TabsContent>
+		</Tabs>
+	);
+
+const getScroller = ( container: HTMLElement ) =>
+	container.querySelector< HTMLElement >( '.vip-tabs-list-scroller' ) as HTMLElement;
+
+/** Fakes the layout metrics jsdom never computes, then fires a scroll event. */
+const setScrollMetrics = (
+	node: HTMLElement,
+	{ scrollLeft, clientWidth, scrollWidth }: Record< string, number >
+) => {
+	Object.defineProperty( node, 'clientWidth', { value: clientWidth, configurable: true } );
+	Object.defineProperty( node, 'scrollWidth', { value: scrollWidth, configurable: true } );
+	Object.defineProperty( node, 'scrollLeft', { value: scrollLeft, configurable: true } );
+
+	fireEvent.scroll( node );
+};
+
+describe( '<Tabs />', () => {
+	it( 'has no accessibility violations', async () => {
+		const { container } = renderTabs();
+
+		expect( await axe( container ) ).toHaveNoViolations();
+	} );
+
+	it( 'labels the tab list and keeps the triggers inside it', () => {
+		renderTabs();
+
+		const tablist = screen.getByRole( 'tablist', { name: 'See all the content' } );
+
+		expect( tablist ).toBeInTheDocument();
+		expect( screen.getAllByRole( 'tab' ) ).toHaveLength( 3 );
+		screen.getAllByRole( 'tab' ).forEach( tab => expect( tab.parentElement ).toBe( tablist ) );
+	} );
+
+	it( 'does not make the scroll container focusable', () => {
+		const { container } = renderTabs();
+
+		// The triggers carry a roving tabindex, so a focusable scroller would only add
+		// a redundant tab stop ahead of the tabs.
+		expect( getScroller( container ) ).not.toHaveAttribute( 'tabindex' );
+	} );
+
+	it( 'moves between tabs with the arrow keys', async () => {
+		const user = userEvent.setup();
+
+		renderTabs();
+
+		await user.tab();
+		expect( screen.getByRole( 'tab', { name: 'All (5)' } ) ).toHaveFocus();
+
+		await user.keyboard( '{ArrowRight}' );
+
+		const live = screen.getByRole( 'tab', { name: 'Live (2)' } );
+
+		expect( live ).toHaveFocus();
+		expect( live ).toHaveAttribute( 'aria-selected', 'true' );
+		expect( screen.getByText( 'Live content' ) ).toBeInTheDocument();
+	} );
+
+	it( 'flags the scrollable edges as the list is scrolled', () => {
+		const { container } = renderTabs();
+		const scroller = getScroller( container );
+
+		// Not scrolled yet: only the trailing edge has more tabs beyond it.
+		setScrollMetrics( scroller, { scrollLeft: 0, clientWidth: 200, scrollWidth: 600 } );
+		expect( scroller ).not.toHaveAttribute( 'data-scroll-start' );
+		expect( scroller ).toHaveAttribute( 'data-scroll-end' );
+
+		// Mid-scroll: tabs beyond both edges.
+		setScrollMetrics( scroller, { scrollLeft: 150, clientWidth: 200, scrollWidth: 600 } );
+		expect( scroller ).toHaveAttribute( 'data-scroll-start' );
+		expect( scroller ).toHaveAttribute( 'data-scroll-end' );
+
+		// Scrolled to the end.
+		setScrollMetrics( scroller, { scrollLeft: 400, clientWidth: 200, scrollWidth: 600 } );
+		expect( scroller ).toHaveAttribute( 'data-scroll-start' );
+		expect( scroller ).not.toHaveAttribute( 'data-scroll-end' );
+	} );
+
+	it( 'flags no edges when every tab fits', () => {
+		const { container } = renderTabs();
+		const scroller = getScroller( container );
+
+		setScrollMetrics( scroller, { scrollLeft: 0, clientWidth: 600, scrollWidth: 600 } );
+
+		expect( scroller ).not.toHaveAttribute( 'data-scroll-start' );
+		expect( scroller ).not.toHaveAttribute( 'data-scroll-end' );
+	} );
+
+	it( 'scrolls the active tab into view on mount', () => {
+		renderTabs( { defaultValue: 'dev' } );
+
+		expect( scrollIntoView ).toHaveBeenCalled();
+		expect( screen.getByRole( 'tab', { name: 'In Development (3)' } ) ).toHaveAttribute(
+			'aria-selected',
+			'true'
+		);
+	} );
+
+	it( 'scrolls a newly active tab into view when the value is controlled', async () => {
+		const user = userEvent.setup();
+
+		const Controlled = () => {
+			const [ value, setValue ] = React.useState( 'all' );
+
+			return (
+				<>
+					<button type="button" onClick={ () => setValue( 'dev' ) }>
+						Go to dev
+					</button>
+					<Tabs value={ value } onValueChange={ setValue }>
+						<TabsList title="See all the content">
+							<TabsTrigger value="all">All (5)</TabsTrigger>
+							<TabsTrigger value="dev">In Development (3)</TabsTrigger>
+						</TabsList>
+						<TabsContent value="all">All content</TabsContent>
+						<TabsContent value="dev">In Development content</TabsContent>
+					</Tabs>
+				</>
+			);
+		};
+
+		renderWithTheme( <Controlled /> );
+		// Ignore the scroll-into-view that every mount performs.
+		scrollIntoView.mockClear();
+
+		await user.click( screen.getByRole( 'button', { name: 'Go to dev' } ) );
+
+		expect( scrollIntoView ).toHaveBeenCalled();
+	} );
+
+	it( 'merges a consumer sx and className into the tab list', () => {
+		renderWithTheme(
+			<Tabs defaultValue="all">
+				<TabsList title="See all the content" className="custom-list" sx={ { pt: 4 } }>
+					<TabsTrigger value="all">All (5)</TabsTrigger>
+				</TabsList>
+				<TabsContent value="all">All content</TabsContent>
+			</Tabs>
+		);
+
+		const tablist = screen.getByRole( 'tablist', { name: 'See all the content' } );
+
+		expect( tablist ).toHaveClass( 'vip-tabs-list', 'custom-list' );
+		// The consumer override resolves against the token scale, and the component's
+		// own display style survives it.
+		expect( tablist ).toHaveStyle( {
+			display: 'flex',
+			paddingTop: `${ space[ '4' ] }px`,
+		} );
+	} );
+} );

--- a/src/system/Tabs/TabsList.tsx
+++ b/src/system/Tabs/TabsList.tsx
@@ -4,34 +4,197 @@
  * External dependencies
  */
 import * as TabsPrimitive from '@radix-ui/react-tabs';
-import React from 'react';
+import classNames, { Argument } from 'classnames';
+import React, { useCallback, useEffect, useRef, useState } from 'react';
 
 /**
  * Internal dependencies
  */
+import { Box } from '../Box/Box';
 
-export interface TabsListProps extends React.ComponentPropsWithoutRef< typeof TabsPrimitive.List > {
+import type { ThemeUIStyleObject } from 'theme-ui';
+
+export interface TabsListProps
+	extends Omit< React.ComponentPropsWithoutRef< typeof TabsPrimitive.List >, 'className' > {
 	/** Accessible label for the tab list, used as the `aria-label` attribute. */
 	title: string;
 	/** The TabsTrigger elements to render inside the list. */
 	children: React.ReactNode;
+	/** Additional CSS class name(s) applied to the tab list element. */
+	className?: Argument;
+	/** Theme UI style overrides applied to the tab list element. */
+	sx?: ThemeUIStyleObject;
+	/** Forwarded ref to the underlying tab list element. */
+	ref?: React.Ref< HTMLDivElement >;
 }
 
+interface ScrollEdges {
+	start: boolean;
+	end: boolean;
+}
+
+/** Width of the gradient that fades out tabs running past a scrollable edge. */
+const FADE_WIDTH = '2rem';
+
 /**
- * TabsList — Container for TabsTrigger elements. Renders as a horizontal list with a bottom border.
+ * Builds a mask that fades whichever edge has more tabs beyond it. A mask is used
+ * instead of a gradient painted in a background colour so the fade works on any
+ * surface, in both the light and dark themes, without knowing what sits behind it.
  */
-const TabsList = ( { children, title, ...props }: TabsListProps ) => (
-	<TabsPrimitive.List
-		sx={ {
-			borderBottom: '1px solid',
-			borderColor: 'borders.2',
-			display: 'flex',
-		} }
-		aria-label={ title }
-		{ ...props }
-	>
-		{ children }
-	</TabsPrimitive.List>
-);
+const getFadeStyles = ( { start, end }: ScrollEdges ): ThemeUIStyleObject => {
+	if ( ! start && ! end ) {
+		return {};
+	}
+
+	const from = start ? `transparent 0, black ${ FADE_WIDTH }` : 'black 0';
+	const to = end ? `black calc(100% - ${ FADE_WIDTH }), transparent 100%` : 'black 100%';
+	const image = `linear-gradient(to right, ${ from }, ${ to })`;
+
+	return { maskImage: image, WebkitMaskImage: image };
+};
+
+/**
+ * TabsList — Container for TabsTrigger elements. Renders as a horizontal list with a
+ * bottom border that scrolls sideways when the triggers no longer fit, fading the
+ * edge that has more tabs beyond it.
+ *
+ * The scroll container deliberately has no `tabIndex`: Radix gives the triggers a
+ * roving tabindex, so the list always holds a focusable button and arrow keys already
+ * reach every tab. Making the container focusable would only add a redundant tab stop.
+ */
+const TabsList = ( { children, title, className, sx, ref, ...props }: TabsListProps ) => {
+	const scrollerRef = useRef< HTMLDivElement >( null );
+	const [ edges, setEdges ] = useState< ScrollEdges >( { start: false, end: false } );
+
+	const updateEdges = useCallback( () => {
+		const node = scrollerRef.current;
+
+		if ( ! node ) {
+			return;
+		}
+
+		// `Math.abs` keeps this working under RTL, where `scrollLeft` counts down from 0.
+		// The fades themselves are still laid out left-to-right; RTL is not supported yet.
+		const offset = Math.abs( node.scrollLeft );
+		const maxScroll = node.scrollWidth - node.clientWidth;
+
+		setEdges( previous => {
+			const next = { start: offset > 1, end: offset < maxScroll - 1 };
+
+			// Bail out when nothing moved, otherwise the ResizeObserver below can loop.
+			return previous.start === next.start && previous.end === next.end ? previous : next;
+		} );
+	}, [] );
+
+	useEffect( () => {
+		const node = scrollerRef.current;
+
+		if ( ! node ) {
+			return;
+		}
+
+		updateEdges();
+		node.addEventListener( 'scroll', updateEdges, { passive: true } );
+
+		let observer: ResizeObserver | undefined;
+
+		if ( typeof ResizeObserver !== 'undefined' ) {
+			observer = new ResizeObserver( updateEdges );
+			observer.observe( node );
+
+			// Watch the list too, so relabelled or added triggers update the fades.
+			if ( node.firstElementChild ) {
+				observer.observe( node.firstElementChild );
+			}
+		}
+
+		return () => {
+			node.removeEventListener( 'scroll', updateEdges );
+			observer?.disconnect();
+		};
+	}, [ updateEdges ] );
+
+	useEffect( () => {
+		const node = scrollerRef.current;
+
+		if ( ! node ) {
+			return;
+		}
+
+		const reveal = ( behavior: ScrollBehavior ) => {
+			const active = node.querySelector< HTMLElement >( '[role="tab"][data-state="active"]' );
+
+			// `block: 'nearest'` keeps this from scrolling the page vertically.
+			active?.scrollIntoView?.( { behavior, block: 'nearest', inline: 'nearest' } );
+		};
+
+		reveal( 'auto' );
+
+		if ( typeof MutationObserver === 'undefined' ) {
+			return;
+		}
+
+		// Radix does not scroll a newly active tab into view, which matters when the
+		// active tab is set from outside (controlled `value`) rather than by a click.
+		const observer = new MutationObserver( () => {
+			const prefersReducedMotion = window.matchMedia?.(
+				'(prefers-reduced-motion: reduce)'
+			)?.matches;
+
+			reveal( prefersReducedMotion ? 'auto' : 'smooth' );
+		} );
+
+		observer.observe( node, {
+			subtree: true,
+			attributes: true,
+			attributeFilter: [ 'data-state' ],
+		} );
+
+		return () => observer.disconnect();
+	}, [] );
+
+	return (
+		<Box
+			ref={ scrollerRef }
+			className="vip-tabs-list-scroller"
+			data-scroll-start={ edges.start || undefined }
+			data-scroll-end={ edges.end || undefined }
+			sx={ {
+				overflowX: 'auto',
+				// Explicit, so the horizontal scroll does not coerce this to `auto` too.
+				overflowY: 'hidden',
+				// Room for the 3px focus halo on the triggers, which `overflow` would
+				// otherwise clip. The negative margin cancels it, leaving layout untouched.
+				py: '4px',
+				my: '-4px',
+				scrollbarWidth: 'none',
+				msOverflowStyle: 'none',
+				'&::-webkit-scrollbar': { display: 'none' },
+				...getFadeStyles( edges ),
+				// Never fade a focused trigger's outline (WCAG 2.4.11 Focus Not Obscured).
+				'&:focus-within': { maskImage: 'none', WebkitMaskImage: 'none' },
+			} }
+		>
+			<TabsPrimitive.List
+				ref={ ref }
+				aria-label={ title }
+				className={ classNames( 'vip-tabs-list', className ) }
+				sx={ {
+					display: 'flex',
+					width: 'max-content',
+					minWidth: '100%',
+					borderBottom: '1px solid',
+					borderColor: 'borders.2',
+					...sx,
+				} }
+				{ ...props }
+			>
+				{ children }
+			</TabsPrimitive.List>
+		</Box>
+	);
+};
+
+TabsList.displayName = 'TabsList';
 
 export { TabsList };

--- a/src/system/Tabs/TabsTrigger.tsx
+++ b/src/system/Tabs/TabsTrigger.tsx
@@ -36,11 +36,16 @@ const styles: ThemeUIStyleObject = {
 	cursor: 'pointer',
 	background: 'none',
 	mr: 3,
+	'&:last-of-type': { mr: 0 },
 	fontSize: 2,
 	px: 0,
 	pb: 3,
 	border: 'none',
 	color: 'heading',
+	// Keep every trigger at its natural width so a narrow TabsList overflows and
+	// scrolls sideways instead of squashing the labels onto two lines.
+	flexShrink: 0,
+	whiteSpace: 'nowrap',
 	'&[data-state="active"]': {
 		color: 'link',
 		fontWeight: 'regular',


### PR DESCRIPTION
## Description

https://linear.app/a8c/issue/PLTFRM-2753/fix-tab-navigation-on-smaller-screens

<img width="435" height="123" alt="image" src="https://github.com/user-attachments/assets/16266bda-0326-4913-b1d9-d8f85d8ef7db" />

This pull request enhances the `Tabs` component system by adding horizontal scrolling support to the `TabsList` when tab triggers overflow, improving accessibility and usability. It introduces a fade effect on the edges to visually indicate overflow, ensures the active tab is always scrolled into view, and adds comprehensive tests to verify these behaviors.

**Scrollable Tabs & Visual Feedback:**

- Added horizontal scrolling to `TabsList` with a fade effect on edges to indicate more tabs are available off-screen. The fade adapts to both light and dark themes without knowing the background color. (`src/system/Tabs/TabsList.tsx`, [src/system/Tabs/TabsList.tsxL7-R198](diffhunk://#diff-a7412fdcef920402654221f88518076cd982ae67262958441797189feaec1cb5L7-R198))
- Ensured each tab trigger stays at its natural width and uses `whiteSpace: 'nowrap'` and `flexShrink: 0` to prevent label wrapping and squashing, enabling smooth horizontal scrolling. (`src/system/Tabs/TabsTrigger.tsx`, [src/system/Tabs/TabsTrigger.tsxR39-R48](diffhunk://#diff-2ae865a81a22a17933181d9a5d9154a42403b65a725cce8de0ecd261d49c25cfR39-R48))

**Accessibility & Usability Improvements:**

- The active tab is automatically scrolled into view on mount and when changed, supporting both uncontrolled and controlled usage. (`src/system/Tabs/TabsList.tsx`, [src/system/Tabs/TabsList.tsxL7-R198](diffhunk://#diff-a7412fdcef920402654221f88518076cd982ae67262958441797189feaec1cb5L7-R198))
- The scroll container intentionally does not receive a tab stop, preserving accessible navigation via the tab triggers. (`src/system/Tabs/TabsList.tsx`, [src/system/Tabs/TabsList.tsxL7-R198](diffhunk://#diff-a7412fdcef920402654221f88518076cd982ae67262958441797189feaec1cb5L7-R198))

**Storybook & Testing:**

- Added a new `Scrollable` story to demonstrate tabs overflowing and scrolling, including a disabled tab and realistic tab labels. (`src/system/Tabs/Tabs.stories.jsx`, [[1]](diffhunk://#diff-a0a9805f7738d13dac5e7a403bd2f0fab85e7fcbe8534a0fa01ac6d7c3d35763R79-R111) [[2]](diffhunk://#diff-a0a9805f7738d13dac5e7a403bd2f0fab85e7fcbe8534a0fa01ac6d7c3d35763L11-R11)
- Introduced a comprehensive test suite for the `Tabs` component, covering accessibility, keyboard navigation, scroll edge detection, active tab scrolling, and custom styling. (`src/system/Tabs/Tabs.test.tsx`, [src/system/Tabs/Tabs.test.tsxR1-R213](diffhunk://#diff-5bbaee0c7d495dcf2f242fc713e69d6dbae091ecf51774b6985cb87b94a3f10bR1-R213))

## Checklist

- [ ] This PR has good automated test coverage
- [ ] The storybook for the component has been updated

## Steps to Test

Outline the steps to test and verify the PR here.

Example:

1. Pull down PR.
1. `npm run dev`.
1. Open Storybook.
1. Eat cookies.
1. Verify cookies are delicious.
