### PR TITLE
PLTFRM-2772 Fix FormAutocomplete reset on blur

### DIFF
--- a/src/system/NewForm/FormAutocomplete.test.jsx
+++ b/src/system/NewForm/FormAutocomplete.test.jsx
@@ -1,7 +1,8 @@
 /**
  * External dependencies
  */
-import { render, screen } from '@testing-library/react';
+import { act, fireEvent, render, screen } from '@testing-library/react';
+import userEvent from '@testing-library/user-event';
 import { axe } from 'jest-axe';
 
 /**
@@ -58,6 +59,77 @@ describe( '<FormAutocomplete />', () => {
 		expect( input ).toHaveAttribute(
 			'aria-describedby',
 			expect.stringContaining( 'dessert-help' )
+		);
+	} );
+
+	describe( 'resetOnBlur', () => {
+		// The blur event is dispatched on its own so the assertions cover this component's
+		// own blur listener rather than the vendor autocomplete's focusout handling.
+		const blur = async input => {
+			await act( async () => {
+				fireEvent.blur( input );
+			} );
+		};
+
+		const setup = async valueProps => {
+			const onChange = jest.fn();
+			const user = userEvent.setup();
+
+			render(
+				<FormAutocomplete
+					{ ...defaultProps }
+					forLabel="dessert"
+					resetOnBlur
+					showAllValues
+					onChange={ onChange }
+					{ ...valueProps }
+				/>
+			);
+
+			const input = screen.getByLabelText( defaultProps.label );
+
+			await user.click( input );
+			await user.click( await screen.findByRole( 'option', { name: 'Chocolate' } ) );
+
+			return { input, onChange, user };
+		};
+
+		const valueVariants = [
+			[ 'without a value prop', {} ],
+			[ 'with an undefined value', { value: undefined } ],
+			[ 'with an empty string value', { value: '' } ],
+		];
+
+		it.each( valueVariants )(
+			'keeps the confirmed selection across blurs %s',
+			async ( _case, valueProps ) => {
+				const { input, onChange, user } = await setup( valueProps );
+
+				await blur( input );
+
+				expect( input ).toHaveValue( 'Chocolate' );
+
+				await user.click( input );
+				await blur( input );
+
+				expect( input ).toHaveValue( 'Chocolate' );
+				expect( onChange ).toHaveBeenCalledTimes( 1 );
+				expect( onChange ).toHaveBeenLastCalledWith( options[ 0 ], 'Chocolate' );
+			}
+		);
+
+		it.each( valueVariants )(
+			'restores a partially typed query to the confirmed selection on blur %s',
+			async ( _case, valueProps ) => {
+				const { input, onChange, user } = await setup( valueProps );
+
+				await user.clear( input );
+				await user.keyboard( 'Vanil' );
+				await blur( input );
+
+				expect( input ).toHaveValue( 'Chocolate' );
+				expect( onChange ).toHaveBeenLastCalledWith( options[ 0 ], 'Chocolate' );
+			}
 		);
 	} );
 } );

--- a/src/system/NewForm/FormAutocomplete.tsx
+++ b/src/system/NewForm/FormAutocomplete.tsx
@@ -286,7 +286,7 @@ const FormAutocomplete = ( {
 				query: inputQuery && inputQuery !== '' ? selectedValue ?? '' : '', // selected value should not be null or the component will crash
 			} );
 		}
-	}, [ acRef ] );
+	}, [ acRef, resetOnBlur, inputQuery, selectedValue ] );
 	// sets the internal state variables and calls the onChange callback
 	const setAutocompleteState = useCallback(
 		( inputValue: string | null ) => {
@@ -424,7 +424,7 @@ const FormAutocomplete = ( {
 		input.addEventListener( 'keydown', onKeyDown );
 
 		return () => input.removeEventListener( 'keydown', onKeyDown );
-	}, [ inputId, resetOnBlur, setIsDirty ] );
+	}, [ inputId, resetOnBlur, setIsDirty, resetInputState ] );
 
 	// For accessibility, we need to add the error message to the aria-describedby attribute
 	useEffect( () => {
@@ -461,7 +461,7 @@ const FormAutocomplete = ( {
 		input.addEventListener( 'blur', onBlur );
 
 		return () => input.removeEventListener( 'blur', onBlur );
-	}, [ inputId ] );
+	}, [ inputId, resetInputState ] );
 	return (
 		<div className={ classNames( 'vip-form-autocomplete-component', className ) }>
 			{ label && ! isInline && <SelectLabel /> }


### PR DESCRIPTION
## Description

https://linear.app/a8c/issue/PLTFRM-2772/fix-state-reset-when-adding-app-notifications

This pull request adds comprehensive tests for the `resetOnBlur` behavior in the `FormAutocomplete` component and improves the component's effect dependencies to ensure correct behavior when relevant props or state change. The main focus is on ensuring that the confirmed selection is preserved or restored correctly on blur events, and that the component's internal state updates reliably.

**Testing improvements:**

* Added a new test suite for the `resetOnBlur` prop in `FormAutocomplete`, covering scenarios where the input is blurred with and without a value, and when the user partially types a query, ensuring the confirmed selection is restored on blur.
* Enhanced test utilities by importing `act`, `fireEvent`, and `userEvent` to simulate user interactions more accurately in the test file.

**Component effect dependency updates:**

* Updated the dependency array for the effect that sets the input query to include `resetOnBlur`, `inputQuery`, and `selectedValue`, ensuring the effect re-runs when any of these values change.
* Updated the dependency array for the effect that adds a `keydown` event listener to include `resetInputState`, ensuring the latest state is used in the handler.
* Updated the dependency array for the effect that adds a `blur` event listener to include `resetInputState`, ensuring the blur handler uses the latest state.