### PR TITLE
Add accessible ResultsSummary component

### DIFF
--- a/src/system/Form/InputWithCopyButton.tsx
+++ b/src/system/Form/InputWithCopyButton.tsx
@@ -64,9 +64,7 @@ const InputWithCopyButton = ( {
 	...props
 }: InputWithCopyButtonProps ) => {
 	const fallbackRef = useRef< HTMLInputElement >( null );
-	const inputRef = (
-		ref && typeof ref !== 'function' ? ref : fallbackRef
-	) as React.RefObject< HTMLInputElement >;
+	const inputRef = ref && typeof ref !== 'function' ? ref : fallbackRef;
 
 	const handleCopy = ( e: React.MouseEvent< HTMLButtonElement > ) => {
 		e.preventDefault();

--- a/src/system/ResultsSummary/ResultsSummary.stories.tsx
+++ b/src/system/ResultsSummary/ResultsSummary.stories.tsx
@@ -1,0 +1,76 @@
+/** @jsxImportSource theme-ui */
+
+/**
+ * External dependencies
+ */
+import { useState } from 'react';
+
+/**
+ * Internal dependencies
+ */
+import { ResultsSummary } from './ResultsSummary';
+import { Button } from '../Button';
+
+import type { Meta, StoryObj } from '@storybook/react-vite';
+
+const meta: Meta< typeof ResultsSummary > = {
+	title: 'Data display/ResultsSummary',
+	component: ResultsSummary,
+	parameters: {
+		docs: {
+			description: {
+				component: `
+Displays a compact result-set summary with consistent typography and a list icon. Changes are
+announced as a polite status update.
+
+Pass complete, localized copy as children. Consumers own range calculations, entity names,
+pluralization, and translations. Keep the component mounted while loading and update its children
+when results arrive so assistive technology can announce the change reliably.
+				`,
+			},
+		},
+	},
+};
+
+export default meta;
+
+type Story = StoryObj< typeof ResultsSummary >;
+
+export const Default: Story = {
+	args: {
+		children: 'Showing 1–10 of 37 sandboxes',
+	},
+};
+
+export const SingleResult: Story = {
+	args: {
+		children: '1 sandbox found',
+	},
+};
+
+const LoadingToResultsExample = () => {
+	const [ loading, setLoading ] = useState( true );
+
+	return (
+		<>
+			<ResultsSummary>
+				{ loading ? 'Loading results…' : 'Showing 1–10 of 37 sandboxes' }
+			</ResultsSummary>
+			<Button onClick={ () => setLoading( current => ! current ) } sx={ { mt: 3 } } type="button">
+				{ loading ? 'Show results' : 'Reset loading state' }
+			</Button>
+		</>
+	);
+};
+
+export const LoadingToResults: Story = {
+	render: () => <LoadingToResultsExample />,
+	parameters: {
+		docs: {
+			description: {
+				story:
+					'The same live-region element remains mounted while its content changes, allowing assistive technology to announce the result.',
+			},
+		},
+	},
+};

--- a/src/system/ResultsSummary/ResultsSummary.test.tsx
+++ b/src/system/ResultsSummary/ResultsSummary.test.tsx
@@ -1,0 +1,33 @@
+/**
+ * External dependencies
+ */
+import { render, screen } from '@testing-library/react';
+import { axe } from 'jest-axe';
+
+/**
+ * Internal dependencies
+ */
+import { ResultsSummary } from './ResultsSummary';
+
+describe( '<ResultsSummary />', () => {
+	it( 'updates a mounted polite live region', async () => {
+		const { container, rerender } = render( <ResultsSummary>Loading results…</ResultsSummary> );
+
+		const summary = screen.getByText( 'Loading results…' );
+
+		expect( summary ).toBeInstanceOf( HTMLParagraphElement );
+		expect( summary ).toHaveAttribute( 'aria-live', 'polite' );
+		expect( summary ).toHaveAttribute( 'aria-atomic', 'true' );
+
+		rerender( <ResultsSummary>Showing 1–10 of 37 sandboxes</ResultsSummary> );
+
+		expect( screen.getByText( 'Showing 1–10 of 37 sandboxes' ) ).toBe( summary );
+		expect( await axe( container ) ).toHaveNoViolations();
+	} );
+
+	it( 'preserves polymorphic heading semantics', () => {
+		render( <ResultsSummary as="h2">1 sandbox found</ResultsSummary> );
+
+		expect( screen.getByRole( 'heading', { level: 2 } ) ).toHaveAttribute( 'aria-live', 'polite' );
+	} );
+} );

--- a/src/system/ResultsSummary/ResultsSummary.tsx
+++ b/src/system/ResultsSummary/ResultsSummary.tsx
@@ -1,0 +1,91 @@
+/** @jsxImportSource theme-ui */
+
+/**
+ * External dependencies
+ */
+import classNames from 'classnames';
+import React from 'react';
+import { MdFormatListBulleted } from 'react-icons/md';
+
+/**
+ * Internal dependencies
+ */
+import { Box } from '../Box';
+import { Text } from '../Text/Text';
+
+import type { TextProps } from '../Text/Text';
+
+type ResultsSummaryElement = 'div' | 'h2' | 'h3' | 'h4' | 'h5' | 'h6' | 'p' | 'span';
+
+type ControlledResultsSummaryProps =
+	| 'aria-atomic'
+	| 'aria-live'
+	| 'as'
+	| 'children'
+	| 'ref'
+	| 'role';
+
+export type ResultsSummaryProps< E extends ResultsSummaryElement = 'p' > = Omit<
+	TextProps< E >,
+	ControlledResultsSummaryProps
+> & {
+	/** The complete, localized result summary. */
+	children: React.ReactNode;
+	/** The non-interactive text element used for the summary. */
+	as?: E;
+};
+
+type ResultsSummaryComponent = {
+	< E extends ResultsSummaryElement = 'p' >(
+		props: ResultsSummaryProps< E >
+	): React.ReactElement | null;
+	displayName?: string;
+};
+
+const TextComponent = Text as React.ElementType;
+
+/**
+ * Displays a localized summary of a result set and politely announces updates.
+ * Consumers remain responsible for count, range, entity, pluralization, and translation logic.
+ */
+const ResultsSummary = ( < E extends ResultsSummaryElement = 'p' >( {
+	children,
+	className,
+	sx,
+	...props
+}: ResultsSummaryProps< E > ) => (
+	<TextComponent
+		{ ...props }
+		aria-atomic="true"
+		aria-live="polite"
+		className={ classNames( 'vip-results-summary-component', className ) }
+		sx={ {
+			alignItems: 'center',
+			display: 'flex',
+			fontSize: 2,
+			fontWeight: 'bold',
+			mb: 0,
+			...sx,
+		} }
+	>
+		<Box
+			as="span"
+			aria-hidden="true"
+			sx={ {
+				alignItems: 'center',
+				display: 'inline-flex',
+				flexShrink: 0,
+				justifyContent: 'center',
+				lineHeight: 1,
+				mr: 2,
+			} }
+		>
+			<MdFormatListBulleted size={ 18 } />
+		</Box>
+		{ children }
+	</TextComponent>
+) ) as ResultsSummaryComponent;
+
+ResultsSummary.displayName = 'ResultsSummary';
+
+export { ResultsSummary };

--- a/src/system/ResultsSummary/ResultsSummary.tsx
+++ b/src/system/ResultsSummary/ResultsSummary.tsx
@@ -22,7 +22,6 @@ type ControlledResultsSummaryProps =
 	| 'aria-live'
 	| 'as'
 	| 'children'
-	| 'ref'
 	| 'role';
 
 export type ResultsSummaryProps< E extends ResultsSummaryElement = 'p' > = Omit<

--- a/src/system/ResultsSummary/ResultsSummary.tsx
+++ b/src/system/ResultsSummary/ResultsSummary.tsx
@@ -17,12 +17,7 @@ import type { TextProps } from '../Text/Text';
 
 type ResultsSummaryElement = 'div' | 'h2' | 'h3' | 'h4' | 'h5' | 'h6' | 'p' | 'span';
 
-type ControlledResultsSummaryProps =
-	| 'aria-atomic'
-	| 'aria-live'
-	| 'as'
-	| 'children'
-	| 'role';
+type ControlledResultsSummaryProps = 'aria-atomic' | 'aria-live' | 'as' | 'children' | 'role';
 
 export type ResultsSummaryProps< E extends ResultsSummaryElement = 'p' > = Omit<
 	TextProps< E >,

--- a/src/system/ResultsSummary/index.ts
+++ b/src/system/ResultsSummary/index.ts
@@ -1,0 +1,2 @@
+export { ResultsSummary } from './ResultsSummary';
+export type { ResultsSummaryProps } from './ResultsSummary';

--- a/src/system/index.ts
+++ b/src/system/index.ts
@@ -52,6 +52,7 @@ import { Notice } from './Notice';
 import { OptionRow } from './OptionRow';
 import { SimplePagination, Pagination } from './Pagination';
 import { Progress } from './Progress';
+import { ResultsSummary } from './ResultsSummary';
 import { ScreenReaderText } from './ScreenReaderText';
 import { ServiceHeader } from './ServiceHeader';
 import { Skeleton } from './Skeleton';
@@ -119,6 +120,7 @@ export {
 	RadioGroupChip,
 	Textarea,
 	Progress,
+	ResultsSummary,
 	Text,
 	Tabs,
 	Nav,
@@ -137,3 +139,5 @@ export {
 	WizardStep,
 	theme,
 };
+
+export type { ResultsSummaryProps } from './ResultsSummary';


### PR DESCRIPTION
## Description

Adds a reusable `ResultsSummary` component for consistent result-count and pagination summaries across VIP Dashboard and VIP Go Admin Console.

The component:

- uses VIP Design System typography, spacing, and a decorative list icon
- exposes `sx` and polymorphic non-interactive text elements for consumer layout needs
- keeps native paragraph or heading semantics while politely announcing updates
- leaves localization, pluralization, entity names, and range calculations to consumers
- includes mounted loading-to-results guidance and examples in Storybook

## Checklist

- [x] This PR has good automated test coverage
- [x] The storybook for the component has been updated

## Steps to Test

1. Run `npm install`.
2. Run `npm run dev`.
3. Open **Data display / ResultsSummary** in Storybook.
4. Verify the default and single-result examples.
5. Use the loading-to-results example and verify the same polite live region updates.
6. Run `npm run jest -- ResultsSummary.test.tsx --runInBand`.
7. Run `npm run check-types` and `npm run format:check`.
8. Run `npm run build-storybook`.