### PR TITLE
Toggle Group component

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -16,6 +16,7 @@
         "@radix-ui/react-navigation-menu": "^1.2.14",
         "@radix-ui/react-switch": "^1.2.6",
         "@radix-ui/react-tabs": "^1.1.13",
+        "@radix-ui/react-toggle-group": "^1.1.19",
         "@radix-ui/react-tooltip": "^1.2.8",
         "@theme-ui/match-media": "^0.17.0",
         "accessible-autocomplete": "^2.0.4",
@@ -5006,6 +5007,412 @@
         }
       }
     },
+    "node_modules/@radix-ui/react-toggle": {
+      "version": "1.1.18",
+      "resolved": "https://registry.npmjs.org/@radix-ui/react-toggle/-/react-toggle-1.1.18.tgz",
+      "integrity": "sha512-7lonPlKfSacd20GlOBx2ltuVKz9oqWYZz+oMQyOltw6t1y2nyftj2ZmwwUHYn49kqfDWcp8dNZm5NgV+5Z+mug==",
+      "license": "MIT",
+      "dependencies": {
+        "@radix-ui/primitive": "1.1.7",
+        "@radix-ui/react-primitive": "2.1.10",
+        "@radix-ui/react-use-controllable-state": "1.2.6"
+      },
+      "peerDependencies": {
+        "@types/react": "*",
+        "@types/react-dom": "*",
+        "react": "^16.8 || ^17.0 || ^18.0 || ^19.0 || ^19.0.0-rc",
+        "react-dom": "^16.8 || ^17.0 || ^18.0 || ^19.0 || ^19.0.0-rc"
+      },
+      "peerDependenciesMeta": {
+        "@types/react": {
+          "optional": true
+        },
+        "@types/react-dom": {
+          "optional": true
+        }
+      }
+    },
+    "node_modules/@radix-ui/react-toggle-group": {
+      "version": "1.1.19",
+      "resolved": "https://registry.npmjs.org/@radix-ui/react-toggle-group/-/react-toggle-group-1.1.19.tgz",
+      "integrity": "sha512-OtnwuSVjd1Ofi+AdnvhsjQdyuhCDwYs1w9RyB5BN/OavXOVQo42SYqQjwUnbPnaiPFBpQ9aX70dWeee+v2oBLA==",
+      "license": "MIT",
+      "dependencies": {
+        "@radix-ui/primitive": "1.1.7",
+        "@radix-ui/react-context": "1.2.2",
+        "@radix-ui/react-direction": "1.1.4",
+        "@radix-ui/react-primitive": "2.1.10",
+        "@radix-ui/react-roving-focus": "1.1.19",
+        "@radix-ui/react-toggle": "1.1.18",
+        "@radix-ui/react-use-controllable-state": "1.2.6"
+      },
+      "peerDependencies": {
+        "@types/react": "*",
+        "@types/react-dom": "*",
+        "react": "^16.8 || ^17.0 || ^18.0 || ^19.0 || ^19.0.0-rc",
+        "react-dom": "^16.8 || ^17.0 || ^18.0 || ^19.0 || ^19.0.0-rc"
+      },
+      "peerDependenciesMeta": {
+        "@types/react": {
+          "optional": true
+        },
+        "@types/react-dom": {
+          "optional": true
+        }
+      }
+    },
+    "node_modules/@radix-ui/react-toggle-group/node_modules/@radix-ui/primitive": {
+      "version": "1.1.7",
+      "resolved": "https://registry.npmjs.org/@radix-ui/primitive/-/primitive-1.1.7.tgz",
+      "integrity": "sha512-rqWnm76nYT8HoNNqEjpgJ7Pw/DrBj5iBTrmEPo6HTX5+VJyBNOqTdv4g89G63HuR5g0AaENoAcH7Is5fF2kZ8Q==",
+      "license": "MIT"
+    },
+    "node_modules/@radix-ui/react-toggle-group/node_modules/@radix-ui/react-collection": {
+      "version": "1.1.15",
+      "resolved": "https://registry.npmjs.org/@radix-ui/react-collection/-/react-collection-1.1.15.tgz",
+      "integrity": "sha512-9W+B9NPF0NaaPh/1NJd3+KqsnlLqU9H7T2rvww+fp+T/evVXdNAyYcnfRQZFOjkR1ajQp3yORlqnI8soawLvNA==",
+      "license": "MIT",
+      "dependencies": {
+        "@radix-ui/react-compose-refs": "1.1.5",
+        "@radix-ui/react-context": "1.2.2",
+        "@radix-ui/react-primitive": "2.1.10",
+        "@radix-ui/react-slot": "1.3.3"
+      },
+      "peerDependencies": {
+        "@types/react": "*",
+        "@types/react-dom": "*",
+        "react": "^16.8 || ^17.0 || ^18.0 || ^19.0 || ^19.0.0-rc",
+        "react-dom": "^16.8 || ^17.0 || ^18.0 || ^19.0 || ^19.0.0-rc"
+      },
+      "peerDependenciesMeta": {
+        "@types/react": {
+          "optional": true
+        },
+        "@types/react-dom": {
+          "optional": true
+        }
+      }
+    },
+    "node_modules/@radix-ui/react-toggle-group/node_modules/@radix-ui/react-compose-refs": {
+      "version": "1.1.5",
+      "resolved": "https://registry.npmjs.org/@radix-ui/react-compose-refs/-/react-compose-refs-1.1.5.tgz",
+      "integrity": "sha512-+48PbAAbq3didjJxa+OaWY2ZwgAKsNiRGyeHKszblZMQ+kcpd9pAaT11cMkGEie0vsOi3QdeTE6d5Fe3Gn61kA==",
+      "license": "MIT",
+      "peerDependencies": {
+        "@types/react": "*",
+        "react": "^16.8 || ^17.0 || ^18.0 || ^19.0 || ^19.0.0-rc"
+      },
+      "peerDependenciesMeta": {
+        "@types/react": {
+          "optional": true
+        }
+      }
+    },
+    "node_modules/@radix-ui/react-toggle-group/node_modules/@radix-ui/react-context": {
+      "version": "1.2.2",
+      "resolved": "https://registry.npmjs.org/@radix-ui/react-context/-/react-context-1.2.2.tgz",
+      "integrity": "sha512-RHCUGwKHDr0hDGg4X7ma4JG4/+12qxw8rkh5QKdDldlCvtja6nUx1Ef/8HVrJze81lEsgLQlqjzjGNHantgnQA==",
+      "license": "MIT",
+      "peerDependencies": {
+        "@types/react": "*",
+        "react": "^16.8 || ^17.0 || ^18.0 || ^19.0 || ^19.0.0-rc"
+      },
+      "peerDependenciesMeta": {
+        "@types/react": {
+          "optional": true
+        }
+      }
+    },
+    "node_modules/@radix-ui/react-toggle-group/node_modules/@radix-ui/react-direction": {
+      "version": "1.1.4",
+      "resolved": "https://registry.npmjs.org/@radix-ui/react-direction/-/react-direction-1.1.4.tgz",
+      "integrity": "sha512-5pzg4FGQNpExhnhT2zlrP1wZFaYCd1K0nYWoFAdcYoYK868IEigqMX3B3f8yIoRlAhAeDWciLI6ZdCKHF9P4Vg==",
+      "license": "MIT",
+      "peerDependencies": {
+        "@types/react": "*",
+        "react": "^16.8 || ^17.0 || ^18.0 || ^19.0 || ^19.0.0-rc"
+      },
+      "peerDependenciesMeta": {
+        "@types/react": {
+          "optional": true
+        }
+      }
+    },
+    "node_modules/@radix-ui/react-toggle-group/node_modules/@radix-ui/react-id": {
+      "version": "1.1.4",
+      "resolved": "https://registry.npmjs.org/@radix-ui/react-id/-/react-id-1.1.4.tgz",
+      "integrity": "sha512-TMQp2llA+RYn7JcjnrMnz7wN4pcVttPZnRZo52PLQsoLVKzNlVwUeHmfePgTgRluXFvlD3GD5g5MOVVTJCO0qA==",
+      "license": "MIT",
+      "dependencies": {
+        "@radix-ui/react-use-layout-effect": "1.1.4"
+      },
+      "peerDependencies": {
+        "@types/react": "*",
+        "react": "^16.8 || ^17.0 || ^18.0 || ^19.0 || ^19.0.0-rc"
+      },
+      "peerDependenciesMeta": {
+        "@types/react": {
+          "optional": true
+        }
+      }
+    },
+    "node_modules/@radix-ui/react-toggle-group/node_modules/@radix-ui/react-primitive": {
+      "version": "2.1.10",
+      "resolved": "https://registry.npmjs.org/@radix-ui/react-primitive/-/react-primitive-2.1.10.tgz",
+      "integrity": "sha512-MucOnzh6hR5mid6VpkbglRAMYMjKLqRnGBbjXkzjK52fuQDd1qbkx78a5P40mkcnVXJdEVxm26E9OPAiUq7nBg==",
+      "license": "MIT",
+      "dependencies": {
+        "@radix-ui/react-slot": "1.3.3"
+      },
+      "peerDependencies": {
+        "@types/react": "*",
+        "@types/react-dom": "*",
+        "react": "^16.8 || ^17.0 || ^18.0 || ^19.0 || ^19.0.0-rc",
+        "react-dom": "^16.8 || ^17.0 || ^18.0 || ^19.0 || ^19.0.0-rc"
+      },
+      "peerDependenciesMeta": {
+        "@types/react": {
+          "optional": true
+        },
+        "@types/react-dom": {
+          "optional": true
+        }
+      }
+    },
+    "node_modules/@radix-ui/react-toggle-group/node_modules/@radix-ui/react-roving-focus": {
+      "version": "1.1.19",
+      "resolved": "https://registry.npmjs.org/@radix-ui/react-roving-focus/-/react-roving-focus-1.1.19.tgz",
+      "integrity": "sha512-V9jI6hDjT7l3jsCQD9bLNvDLM3tH/gdbOTp7Tefp3hbbgCGQoK7tUvrWiRlcoBHIZ809ElXwNQwVo0B98LuTXQ==",
+      "license": "MIT",
+      "dependencies": {
+        "@radix-ui/primitive": "1.1.7",
+        "@radix-ui/react-collection": "1.1.15",
+        "@radix-ui/react-compose-refs": "1.1.5",
+        "@radix-ui/react-context": "1.2.2",
+        "@radix-ui/react-direction": "1.1.4",
+        "@radix-ui/react-id": "1.1.4",
+        "@radix-ui/react-primitive": "2.1.10",
+        "@radix-ui/react-use-callback-ref": "1.1.4",
+        "@radix-ui/react-use-controllable-state": "1.2.6",
+        "@radix-ui/react-use-is-hydrated": "0.1.3",
+        "@radix-ui/react-use-layout-effect": "1.1.4"
+      },
+      "peerDependencies": {
+        "@types/react": "*",
+        "@types/react-dom": "*",
+        "react": "^16.8 || ^17.0 || ^18.0 || ^19.0 || ^19.0.0-rc",
+        "react-dom": "^16.8 || ^17.0 || ^18.0 || ^19.0 || ^19.0.0-rc"
+      },
+      "peerDependenciesMeta": {
+        "@types/react": {
+          "optional": true
+        },
+        "@types/react-dom": {
+          "optional": true
+        }
+      }
+    },
+    "node_modules/@radix-ui/react-toggle-group/node_modules/@radix-ui/react-slot": {
+      "version": "1.3.3",
+      "resolved": "https://registry.npmjs.org/@radix-ui/react-slot/-/react-slot-1.3.3.tgz",
+      "integrity": "sha512-qx7oqnYbxnK9kYI9m317qmFmEgo6ywqWvbTogdj7cL9p3/yx4M48p7Rnw5z3H890cL/ow/EeWJsuTykeZVXP5Q==",
+      "license": "MIT",
+      "dependencies": {
+        "@radix-ui/react-compose-refs": "1.1.5"
+      },
+      "peerDependencies": {
+        "@types/react": "*",
+        "react": "^16.8 || ^17.0 || ^18.0 || ^19.0 || ^19.0.0-rc"
+      },
+      "peerDependenciesMeta": {
+        "@types/react": {
+          "optional": true
+        }
+      }
+    },
+    "node_modules/@radix-ui/react-toggle-group/node_modules/@radix-ui/react-use-callback-ref": {
+      "version": "1.1.4",
+      "resolved": "https://registry.npmjs.org/@radix-ui/react-use-callback-ref/-/react-use-callback-ref-1.1.4.tgz",
+      "integrity": "sha512-R6OUY2e2fA6Yn6s+VSx5KBV6Nx8LQEhu+cz7LCej18rQ1HLyg9PSC9jP/ZNx0o6FAIK9c0F1kHylzSxKsdlkrQ==",
+      "license": "MIT",
+      "peerDependencies": {
+        "@types/react": "*",
+        "react": "^16.8 || ^17.0 || ^18.0 || ^19.0 || ^19.0.0-rc"
+      },
+      "peerDependenciesMeta": {
+        "@types/react": {
+          "optional": true
+        }
+      }
+    },
+    "node_modules/@radix-ui/react-toggle-group/node_modules/@radix-ui/react-use-controllable-state": {
+      "version": "1.2.6",
+      "resolved": "https://registry.npmjs.org/@radix-ui/react-use-controllable-state/-/react-use-controllable-state-1.2.6.tgz",
+      "integrity": "sha512-uEQJGT97ZA/TgP/Hydw47lHu+/vQj6z/0jA+WeTbK1o9Rx45GImjpD0tc3W5ad3D6XTSR6e1yEO0FvGq6WQfVQ==",
+      "license": "MIT",
+      "dependencies": {
+        "@radix-ui/primitive": "1.1.7",
+        "@radix-ui/react-use-effect-event": "0.0.5",
+        "@radix-ui/react-use-layout-effect": "1.1.4"
+      },
+      "peerDependencies": {
+        "@types/react": "*",
+        "react": "^16.8 || ^17.0 || ^18.0 || ^19.0 || ^19.0.0-rc"
+      },
+      "peerDependenciesMeta": {
+        "@types/react": {
+          "optional": true
+        }
+      }
+    },
+    "node_modules/@radix-ui/react-toggle-group/node_modules/@radix-ui/react-use-effect-event": {
+      "version": "0.0.5",
+      "resolved": "https://registry.npmjs.org/@radix-ui/react-use-effect-event/-/react-use-effect-event-0.0.5.tgz",
+      "integrity": "sha512-7cshFL8HGS/7HEiHH+9kL9HBwp2sa9yX18Knwek6KYWmXwM7pegMgta2AXMQKI+rq3JnfSj9x8wYqFMTdG1Jgg==",
+      "license": "MIT",
+      "dependencies": {
+        "@radix-ui/react-use-layout-effect": "1.1.4"
+      },
+      "peerDependencies": {
+        "@types/react": "*",
+        "react": "^16.8 || ^17.0 || ^18.0 || ^19.0 || ^19.0.0-rc"
+      },
+      "peerDependenciesMeta": {
+        "@types/react": {
+          "optional": true
+        }
+      }
+    },
+    "node_modules/@radix-ui/react-toggle-group/node_modules/@radix-ui/react-use-layout-effect": {
+      "version": "1.1.4",
+      "resolved": "https://registry.npmjs.org/@radix-ui/react-use-layout-effect/-/react-use-layout-effect-1.1.4.tgz",
+      "integrity": "sha512-K20DkRkUwDnxEYMBPcg3Y6voLkEy5p5QQmszZgLngKKiC7dzBR/aEuK3w1qlx2JWDUNH6FluahYdgR3BP+QbYw==",
+      "license": "MIT",
+      "peerDependencies": {
+        "@types/react": "*",
+        "react": "^16.8 || ^17.0 || ^18.0 || ^19.0 || ^19.0.0-rc"
+      },
+      "peerDependenciesMeta": {
+        "@types/react": {
+          "optional": true
+        }
+      }
+    },
+    "node_modules/@radix-ui/react-toggle/node_modules/@radix-ui/primitive": {
+      "version": "1.1.7",
+      "resolved": "https://registry.npmjs.org/@radix-ui/primitive/-/primitive-1.1.7.tgz",
+      "integrity": "sha512-rqWnm76nYT8HoNNqEjpgJ7Pw/DrBj5iBTrmEPo6HTX5+VJyBNOqTdv4g89G63HuR5g0AaENoAcH7Is5fF2kZ8Q==",
+      "license": "MIT"
+    },
+    "node_modules/@radix-ui/react-toggle/node_modules/@radix-ui/react-compose-refs": {
+      "version": "1.1.5",
+      "resolved": "https://registry.npmjs.org/@radix-ui/react-compose-refs/-/react-compose-refs-1.1.5.tgz",
+      "integrity": "sha512-+48PbAAbq3didjJxa+OaWY2ZwgAKsNiRGyeHKszblZMQ+kcpd9pAaT11cMkGEie0vsOi3QdeTE6d5Fe3Gn61kA==",
+      "license": "MIT",
+      "peerDependencies": {
+        "@types/react": "*",
+        "react": "^16.8 || ^17.0 || ^18.0 || ^19.0 || ^19.0.0-rc"
+      },
+      "peerDependenciesMeta": {
+        "@types/react": {
+          "optional": true
+        }
+      }
+    },
+    "node_modules/@radix-ui/react-toggle/node_modules/@radix-ui/react-primitive": {
+      "version": "2.1.10",
+      "resolved": "https://registry.npmjs.org/@radix-ui/react-primitive/-/react-primitive-2.1.10.tgz",
+      "integrity": "sha512-MucOnzh6hR5mid6VpkbglRAMYMjKLqRnGBbjXkzjK52fuQDd1qbkx78a5P40mkcnVXJdEVxm26E9OPAiUq7nBg==",
+      "license": "MIT",
+      "dependencies": {
+        "@radix-ui/react-slot": "1.3.3"
+      },
+      "peerDependencies": {
+        "@types/react": "*",
+        "@types/react-dom": "*",
+        "react": "^16.8 || ^17.0 || ^18.0 || ^19.0 || ^19.0.0-rc",
+        "react-dom": "^16.8 || ^17.0 || ^18.0 || ^19.0 || ^19.0.0-rc"
+      },
+      "peerDependenciesMeta": {
+        "@types/react": {
+          "optional": true
+        },
+        "@types/react-dom": {
+          "optional": true
+        }
+      }
+    },
+    "node_modules/@radix-ui/react-toggle/node_modules/@radix-ui/react-slot": {
+      "version": "1.3.3",
+      "resolved": "https://registry.npmjs.org/@radix-ui/react-slot/-/react-slot-1.3.3.tgz",
+      "integrity": "sha512-qx7oqnYbxnK9kYI9m317qmFmEgo6ywqWvbTogdj7cL9p3/yx4M48p7Rnw5z3H890cL/ow/EeWJsuTykeZVXP5Q==",
+      "license": "MIT",
+      "dependencies": {
+        "@radix-ui/react-compose-refs": "1.1.5"
+      },
+      "peerDependencies": {
+        "@types/react": "*",
+        "react": "^16.8 || ^17.0 || ^18.0 || ^19.0 || ^19.0.0-rc"
+      },
+      "peerDependenciesMeta": {
+        "@types/react": {
+          "optional": true
+        }
+      }
+    },
+    "node_modules/@radix-ui/react-toggle/node_modules/@radix-ui/react-use-controllable-state": {
+      "version": "1.2.6",
+      "resolved": "https://registry.npmjs.org/@radix-ui/react-use-controllable-state/-/react-use-controllable-state-1.2.6.tgz",
+      "integrity": "sha512-uEQJGT97ZA/TgP/Hydw47lHu+/vQj6z/0jA+WeTbK1o9Rx45GImjpD0tc3W5ad3D6XTSR6e1yEO0FvGq6WQfVQ==",
+      "license": "MIT",
+      "dependencies": {
+        "@radix-ui/primitive": "1.1.7",
+        "@radix-ui/react-use-effect-event": "0.0.5",
+        "@radix-ui/react-use-layout-effect": "1.1.4"
+      },
+      "peerDependencies": {
+        "@types/react": "*",
+        "react": "^16.8 || ^17.0 || ^18.0 || ^19.0 || ^19.0.0-rc"
+      },
+      "peerDependenciesMeta": {
+        "@types/react": {
+          "optional": true
+        }
+      }
+    },
+    "node_modules/@radix-ui/react-toggle/node_modules/@radix-ui/react-use-effect-event": {
+      "version": "0.0.5",
+      "resolved": "https://registry.npmjs.org/@radix-ui/react-use-effect-event/-/react-use-effect-event-0.0.5.tgz",
+      "integrity": "sha512-7cshFL8HGS/7HEiHH+9kL9HBwp2sa9yX18Knwek6KYWmXwM7pegMgta2AXMQKI+rq3JnfSj9x8wYqFMTdG1Jgg==",
+      "license": "MIT",
+      "dependencies": {
+        "@radix-ui/react-use-layout-effect": "1.1.4"
+      },
+      "peerDependencies": {
+        "@types/react": "*",
+        "react": "^16.8 || ^17.0 || ^18.0 || ^19.0 || ^19.0.0-rc"
+      },
+      "peerDependenciesMeta": {
+        "@types/react": {
+          "optional": true
+        }
+      }
+    },
+    "node_modules/@radix-ui/react-toggle/node_modules/@radix-ui/react-use-layout-effect": {
+      "version": "1.1.4",
+      "resolved": "https://registry.npmjs.org/@radix-ui/react-use-layout-effect/-/react-use-layout-effect-1.1.4.tgz",
+      "integrity": "sha512-K20DkRkUwDnxEYMBPcg3Y6voLkEy5p5QQmszZgLngKKiC7dzBR/aEuK3w1qlx2JWDUNH6FluahYdgR3BP+QbYw==",
+      "license": "MIT",
+      "peerDependencies": {
+        "@types/react": "*",
+        "react": "^16.8 || ^17.0 || ^18.0 || ^19.0 || ^19.0.0-rc"
+      },
+      "peerDependenciesMeta": {
+        "@types/react": {
+          "optional": true
+        }
+      }
+    },
     "node_modules/@radix-ui/react-tooltip": {
       "version": "1.2.8",
       "resolved": "https://registry.npmjs.org/@radix-ui/react-tooltip/-/react-tooltip-1.2.8.tgz",
@@ -5100,6 +5507,21 @@
       "dependencies": {
         "@radix-ui/react-use-callback-ref": "1.1.1"
       },
+      "peerDependencies": {
+        "@types/react": "*",
+        "react": "^16.8 || ^17.0 || ^18.0 || ^19.0 || ^19.0.0-rc"
+      },
+      "peerDependenciesMeta": {
+        "@types/react": {
+          "optional": true
+        }
+      }
+    },
+    "node_modules/@radix-ui/react-use-is-hydrated": {
+      "version": "0.1.3",
+      "resolved": "https://registry.npmjs.org/@radix-ui/react-use-is-hydrated/-/react-use-is-hydrated-0.1.3.tgz",
+      "integrity": "sha512-umO/aJ+82CpOnhDZUTbILCQf7kU/g0iv+oGs/Q8jw7IkhWBzaEP4sA268PhFAJTFetbwp3ICc6ktpI4TqtxcIw==",
+      "license": "MIT",
       "peerDependencies": {
         "@types/react": "*",
         "react": "^16.8 || ^17.0 || ^18.0 || ^19.0 || ^19.0.0-rc"

--- a/package.json
+++ b/package.json
@@ -45,6 +45,7 @@
     "@radix-ui/react-navigation-menu": "^1.2.14",
     "@radix-ui/react-switch": "^1.2.6",
     "@radix-ui/react-tabs": "^1.1.13",
+    "@radix-ui/react-toggle-group": "^1.1.19",
     "@radix-ui/react-tooltip": "^1.2.8",
     "@theme-ui/match-media": "^0.17.0",
     "accessible-autocomplete": "^2.0.4",

--- a/src/system/ToggleGroup/ToggleGroup.stories.tsx
+++ b/src/system/ToggleGroup/ToggleGroup.stories.tsx
@@ -1,0 +1,235 @@
+/** @jsxImportSource theme-ui */
+
+/**
+ * External dependencies
+ */
+import { useState } from 'react';
+import { MdBlock, MdCheckCircle, MdPauseCircle } from 'react-icons/md';
+
+/**
+ * Internal dependencies
+ */
+import { ToggleGroup } from './ToggleGroup';
+import { Text } from '../Text/Text';
+
+import type { ToggleGroupOption } from './ToggleGroup';
+import type { Meta, StoryObj } from '@storybook/react-vite';
+
+const upperCaseOptions: ToggleGroupOption[] = [
+	{ value: 'enabled', label: 'ENABLED', variant: 'green' },
+	{ value: 'disabled', label: 'DISABLED', variant: 'gray' },
+	{ value: 'blocked', label: 'BLOCKED', variant: 'red' },
+];
+
+const sentenceCaseOptions: ToggleGroupOption[] = [
+	{ value: 'enabled', label: 'Enabled', variant: 'green' },
+	{ value: 'disabled', label: 'Disabled', variant: 'gray' },
+	{ value: 'blocked', label: 'Blocked', variant: 'red' },
+];
+
+const icons = {
+	enabled: <MdCheckCircle />,
+	disabled: <MdPauseCircle />,
+	blocked: <MdBlock />,
+};
+
+const iconOnlyOptions: ToggleGroupOption[] = sentenceCaseOptions.map( option => ( {
+	...option,
+	icon: icons[ option.value as keyof typeof icons ],
+	hideLabel: true,
+} ) );
+
+const iconWithLabelOptions: ToggleGroupOption[] = sentenceCaseOptions.map( option => ( {
+	...option,
+	icon: icons[ option.value as keyof typeof icons ],
+} ) );
+
+const Stack = ( { children }: { children: React.ReactNode } ) => (
+	<div sx={ { display: 'flex', flexDirection: 'column', gap: 3, alignItems: 'flex-start' } }>
+		{ children }
+	</div>
+);
+
+const meta: Meta< typeof ToggleGroup > = {
+	title: 'ToggleGroup',
+	component: ToggleGroup,
+	tags: [ 'new' ],
+	args: {
+		'aria-label': 'Site status',
+		options: upperCaseOptions,
+	},
+	parameters: {
+		docs: {
+			description: {
+				component: `
+A set of mutually exclusive options rendered as a single segmented control. Each option carries its
+own color while selected, so the control doubles as a status indicator.
+
+Give every option a \`variant\` drawn from the tag palette to match its meaning: \`green\` for a
+healthy state, \`red\` for a blocking one, \`gray\` for neutral.
+
+Every option needs a \`label\`, and that label is always its accessible name. Labels render exactly
+as authored, so pass the casing you want. An option can also take an \`icon\`; set \`hideLabel\` to
+show the icon alone and the label stays available to screen readers. \`hideLabel\` does not type
+check without an \`icon\`, so an option can never end up unnamed.
+
+The group starts empty unless you pass \`defaultValue\`. Once an option is selected the group always
+keeps exactly one active: clicking the active option again is a no-op rather than a way to clear it.
+				`,
+			},
+		},
+	},
+};
+
+export default meta;
+
+type Story = StoryObj< typeof ToggleGroup >;
+
+export const Default: Story = {
+	args: {
+		defaultValue: 'enabled',
+	},
+};
+
+export const SentenceCase: Story = {
+	args: {
+		defaultValue: 'enabled',
+		options: sentenceCaseOptions,
+	},
+	parameters: {
+		docs: {
+			description: {
+				story:
+					'Labels are rendered as authored. Nothing in the component forces uppercase, so sentence case works as-is.',
+			},
+		},
+	},
+};
+
+export const MixedLabelLengths: Story = {
+	args: {
+		defaultValue: 'needs-review',
+		options: [
+			{ value: 'ok', label: 'OK', variant: 'green' },
+			{ value: 'needs-review', label: 'Needs review', variant: 'yellow' },
+			{ value: 'quarantined', label: 'Quarantined by policy', variant: 'red' },
+		],
+	},
+	parameters: {
+		docs: {
+			description: {
+				story:
+					'Options size to their own label rather than sharing an equal width, so uneven labels stay readable.',
+			},
+		},
+	},
+};
+
+export const NoSelection: Story = {
+	parameters: {
+		docs: {
+			description: {
+				story:
+					'Without a `defaultValue` the group renders with nothing selected. It stays keyboard reachable: Tab moves into the group without selecting, and the arrow keys then pick an option.',
+			},
+		},
+	},
+};
+
+export const Variants: Story = {
+	render: args => (
+		<Stack>
+			{ upperCaseOptions.map( option => (
+				<ToggleGroup key={ option.value } { ...args } defaultValue={ option.value } />
+			) ) }
+		</Stack>
+	),
+	parameters: {
+		docs: {
+			description: {
+				story:
+					'The selected option determines the color, so the same group reads differently per status.',
+			},
+		},
+	},
+};
+
+export const IconOnly: Story = {
+	args: {
+		defaultValue: 'enabled',
+		options: iconOnlyOptions,
+	},
+	parameters: {
+		docs: {
+			description: {
+				story: `
+With \`hideLabel\`, the option shows only its icon and renders the \`label\` inside a visually hidden
+span. The accessible name therefore comes from real text in the accessibility tree rather than an
+\`aria-label\`, which keeps it available to browser translation and to assistive technology that
+falls back to content.
+
+Tab into the group and each option still announces "Enabled, radio button, 1 of 3".
+				`,
+			},
+		},
+	},
+};
+
+export const IconWithLabel: Story = {
+	args: {
+		defaultValue: 'blocked',
+		options: iconWithLabelOptions,
+	},
+	parameters: {
+		docs: {
+			description: {
+				story:
+					'Leave `hideLabel` off to show the icon and the label together. Icons inherit the option color, so they take the variant color once selected.',
+			},
+		},
+	},
+};
+
+export const DisabledOption: Story = {
+	args: {
+		defaultValue: 'enabled',
+		options: [
+			...sentenceCaseOptions.slice( 0, 2 ),
+			{ ...sentenceCaseOptions[ 2 ], disabled: true },
+		],
+	},
+};
+
+export const DisabledGroup: Story = {
+	args: {
+		defaultValue: 'disabled',
+		disabled: true,
+	},
+};
+
+const ControlledExample = () => {
+	const [ status, setStatus ] = useState( 'enabled' );
+
+	return (
+		<Stack>
+			<ToggleGroup
+				aria-label="Site status"
+				options={ sentenceCaseOptions }
+				value={ status }
+				onValueChange={ setStatus }
+			/>
+			<Text>Current status: { status }</Text>
+		</Stack>
+	);
+};
+
+export const Controlled: Story = {
+	render: () => <ControlledExample />,
+	parameters: {
+		docs: {
+			description: {
+				story: 'Pass `value` together with `onValueChange` to own the selection.',
+			},
+		},
+	},
+};

--- a/src/system/ToggleGroup/ToggleGroup.stories.tsx
+++ b/src/system/ToggleGroup/ToggleGroup.stories.tsx
@@ -4,7 +4,7 @@
  * External dependencies
  */
 import { useState } from 'react';
-import { MdBlock, MdCheckCircle, MdPauseCircle } from 'react-icons/md';
+import { MdBlock, MdCancel, MdCheckCircle } from 'react-icons/md';
 
 /**
  * Internal dependencies
@@ -29,7 +29,7 @@ const sentenceCaseOptions: ToggleGroupOption[] = [
 
 const icons = {
 	enabled: <MdCheckCircle />,
-	disabled: <MdPauseCircle />,
+	disabled: <MdCancel />,
 	blocked: <MdBlock />,
 };
 

--- a/src/system/ToggleGroup/ToggleGroup.test.tsx
+++ b/src/system/ToggleGroup/ToggleGroup.test.tsx
@@ -1,0 +1,222 @@
+/**
+ * External dependencies
+ */
+import { render, screen } from '@testing-library/react';
+import userEvent from '@testing-library/user-event';
+import { axe } from 'jest-axe';
+import { MdBlock, MdCheckCircle } from 'react-icons/md';
+import { Theme, ThemeUIProvider } from 'theme-ui';
+
+/**
+ * Internal dependencies
+ */
+import { ToggleGroup } from './ToggleGroup';
+import theme from '../theme';
+
+const statusOptions = [
+	{ value: 'enabled', label: 'Enabled', variant: 'green' as const },
+	{ value: 'disabled', label: 'Disabled', variant: 'gray' as const },
+	{ value: 'blocked', label: 'Blocked', variant: 'red' as const },
+];
+
+const renderToggleGroup = ( props = {} ) =>
+	render( <ToggleGroup aria-label="Site status" options={ statusOptions } { ...props } /> );
+
+describe( '<ToggleGroup />', () => {
+	it( 'renders every option unselected when no value is given', async () => {
+		const { container } = renderToggleGroup();
+
+		expect( screen.getByRole( 'radiogroup', { name: 'Site status' } ) ).toBeInTheDocument();
+
+		const options = screen.getAllByRole( 'radio' );
+
+		expect( options.map( option => option.textContent ) ).toEqual( [
+			'Enabled',
+			'Disabled',
+			'Blocked',
+		] );
+		options.forEach( option => expect( option ).toHaveAttribute( 'aria-checked', 'false' ) );
+
+		expect( await axe( container ) ).toHaveNoViolations();
+	} );
+
+	it( 'preselects defaultValue', () => {
+		renderToggleGroup( { defaultValue: 'blocked' } );
+
+		expect( screen.getByRole( 'radio', { name: 'Blocked' } ) ).toHaveAttribute(
+			'aria-checked',
+			'true'
+		);
+	} );
+
+	it( 'selects an option on click and reports the new value', async () => {
+		const onValueChange = jest.fn();
+		renderToggleGroup( { onValueChange } );
+
+		await userEvent.click( screen.getByRole( 'radio', { name: 'Enabled' } ) );
+
+		expect( onValueChange ).toHaveBeenCalledWith( 'enabled' );
+		expect( screen.getByRole( 'radio', { name: 'Enabled' } ) ).toHaveAttribute(
+			'aria-checked',
+			'true'
+		);
+	} );
+
+	it( 'keeps the selection when the active option is clicked again', async () => {
+		const onValueChange = jest.fn();
+		renderToggleGroup( { defaultValue: 'enabled', onValueChange } );
+
+		await userEvent.click( screen.getByRole( 'radio', { name: 'Enabled' } ) );
+
+		expect( onValueChange ).not.toHaveBeenCalled();
+		expect( screen.getByRole( 'radio', { name: 'Enabled' } ) ).toHaveAttribute(
+			'aria-checked',
+			'true'
+		);
+	} );
+
+	it( 'lets a controlled value override internal state', async () => {
+		const { rerender } = render(
+			<ToggleGroup aria-label="Site status" options={ statusOptions } value="enabled" />
+		);
+
+		await userEvent.click( screen.getByRole( 'radio', { name: 'Blocked' } ) );
+
+		expect( screen.getByRole( 'radio', { name: 'Enabled' } ) ).toHaveAttribute(
+			'aria-checked',
+			'true'
+		);
+
+		rerender( <ToggleGroup aria-label="Site status" options={ statusOptions } value="blocked" /> );
+
+		expect( screen.getByRole( 'radio', { name: 'Blocked' } ) ).toHaveAttribute(
+			'aria-checked',
+			'true'
+		);
+	} );
+
+	it( 'moves the selection with arrow keys from the empty state', async () => {
+		const onValueChange = jest.fn();
+		renderToggleGroup( { onValueChange } );
+
+		await userEvent.tab();
+
+		expect( screen.getByRole( 'radio', { name: 'Enabled' } ) ).toHaveFocus();
+		expect( onValueChange ).not.toHaveBeenCalled();
+
+		await userEvent.keyboard( '{ArrowRight}' );
+
+		expect( screen.getByRole( 'radio', { name: 'Disabled' } ) ).toHaveFocus();
+		expect( onValueChange ).toHaveBeenLastCalledWith( 'disabled' );
+	} );
+
+	it.each( [
+		[
+			'a single disabled option',
+			{ options: [ ...statusOptions.slice( 0, 2 ), { ...statusOptions[ 2 ], disabled: true } ] },
+		],
+		[ 'the whole group', { disabled: true } ],
+	] )( 'ignores clicks when %s is disabled', async ( _label, props ) => {
+		const onValueChange = jest.fn();
+		renderToggleGroup( { onValueChange, ...props } );
+
+		await userEvent.click( screen.getByRole( 'radio', { name: 'Blocked' } ) );
+
+		expect( onValueChange ).not.toHaveBeenCalled();
+		expect( screen.getByRole( 'radio', { name: 'Blocked' } ) ).toHaveAttribute(
+			'aria-checked',
+			'false'
+		);
+	} );
+
+	it( 'resolves every style value through the theme', () => {
+		render(
+			<ThemeUIProvider theme={ theme as Theme }>
+				<ToggleGroup aria-label="Site status" options={ statusOptions } defaultValue="enabled" />
+			</ThemeUIProvider>
+		);
+
+		// Emotion injects through the CSSOM, which jsdom's getComputedStyle ignores, so read the
+		// generated rules directly. Theme UI emits an unresolved lookup as its literal string
+		// rather than failing, which is how `fontFamily: 'body'` silently fell back to the UA font.
+		const emotionClasses = [
+			screen.getByRole( 'radiogroup', { name: 'Site status' } ),
+			...screen.getAllByRole( 'radio' ),
+		].flatMap( element =>
+			Array.from( element.classList ).filter( name => name.startsWith( 'css-' ) )
+		);
+		const rules = Array.from( document.styleSheets )
+			.flatMap( sheet => Array.from( sheet.cssRules ) )
+			.map( rule => rule.cssText )
+			.filter( text => emotionClasses.some( name => text.includes( name ) ) )
+			.join( '\n' );
+
+		expect( rules ).toContain( 'var(--theme-ui-colors-tag-green-background)' );
+		expect( rules ).toContain( 'var(--theme-ui-colors-layer-1)' );
+		expect( rules ).toContain( 'font-family: inherit' );
+		expect( rules ).not.toMatch( /: [a-z]+\.[a-z0-9.-]+;/ );
+		expect( theme.colors.tag.green.background ).toBe( '#d7efdf' );
+	} );
+
+	it( 'names an icon-only option from its visually hidden label', async () => {
+		const onValueChange = jest.fn();
+		const { container } = render(
+			<ToggleGroup
+				aria-label="Site status"
+				onValueChange={ onValueChange }
+				options={ [
+					{
+						value: 'enabled',
+						label: 'Enabled',
+						icon: <MdCheckCircle />,
+						hideLabel: true,
+						variant: 'green',
+					},
+					{
+						value: 'blocked',
+						label: 'Blocked',
+						icon: <MdBlock />,
+						hideLabel: true,
+						variant: 'red',
+					},
+				] }
+			/>
+		);
+
+		const blocked = screen.getByRole( 'radio', { name: 'Blocked' } );
+
+		expect( blocked.querySelector( '.screen-reader-text' ) ).toHaveTextContent( 'Blocked' );
+		expect( blocked.querySelector( 'svg' ) ).toBeInTheDocument();
+
+		await userEvent.click( blocked );
+
+		expect( onValueChange ).toHaveBeenCalledWith( 'blocked' );
+		expect( await axe( container ) ).toHaveNoViolations();
+	} );
+
+	it( 'shows an icon alongside a visible label', () => {
+		render(
+			<ToggleGroup
+				aria-label="Site status"
+				options={ [
+					{ value: 'enabled', label: 'Enabled', icon: <MdCheckCircle />, variant: 'green' },
+				] }
+			/>
+		);
+
+		const option = screen.getByRole( 'radio', { name: 'Enabled' } );
+
+		expect( option.querySelector( 'svg' ) ).toBeInTheDocument();
+		expect( option.querySelector( '.screen-reader-text' ) ).not.toBeInTheDocument();
+		expect( option ).toHaveTextContent( 'Enabled' );
+	} );
+
+	it( 'merges consumer sx and className with its own', () => {
+		renderToggleGroup( { className: 'custom-class', sx: { marginTop: '10px' } } );
+
+		const group = screen.getByRole( 'radiogroup', { name: 'Site status' } );
+
+		expect( group ).toHaveClass( 'vip-toggle-group-component', 'custom-class' );
+		expect( group ).toHaveStyle( 'margin-top: 10px' );
+	} );
+} );

--- a/src/system/ToggleGroup/ToggleGroup.tsx
+++ b/src/system/ToggleGroup/ToggleGroup.tsx
@@ -1,0 +1,233 @@
+/** @jsxImportSource theme-ui */
+
+/**
+ * External dependencies
+ */
+import * as ToggleGroupPrimitive from '@radix-ui/react-toggle-group';
+import classNames, { Argument } from 'classnames';
+import React, { useRef, useState } from 'react';
+import { Theme, ThemeUIStyleObject } from 'theme-ui';
+
+/**
+ * Internal dependencies
+ */
+import { ScreenReaderText } from '../ScreenReaderText/ScreenReaderText';
+
+interface ThemeProps extends Theme {
+	outline?: Record< string, string >;
+}
+
+export type ToggleGroupVariant =
+	| 'blue'
+	| 'gold'
+	| 'gray'
+	| 'green'
+	| 'orange'
+	| 'pink'
+	| 'red'
+	| 'salmon'
+	| 'yellow';
+
+interface ToggleGroupOptionBase {
+	/** Unique value reported through `onValueChange` when this option is selected. */
+	value: string;
+	/**
+	 * The option's text label. Always its accessible name, so it is required even when the
+	 * option shows only an icon.
+	 */
+	label: string;
+	/**
+	 * The color the option takes while it is selected.
+	 * @default 'gray'
+	 */
+	variant?: ToggleGroupVariant;
+	/**
+	 * Whether this option is disabled and cannot be selected.
+	 * @default false
+	 */
+	disabled?: boolean;
+}
+
+interface ToggleGroupLabelledOption extends ToggleGroupOptionBase {
+	/** An optional icon rendered before the label. */
+	icon?: React.ReactNode;
+	hideLabel?: false;
+}
+
+interface ToggleGroupIconOnlyOption extends ToggleGroupOptionBase {
+	/** The icon shown in place of the label. Required when `hideLabel` is set. */
+	icon: React.ReactNode;
+	/** Show only the icon, leaving `label` visually hidden but still read by screen readers. */
+	hideLabel: true;
+}
+
+/**
+ * A single option. `label` is always required and always the accessible name, so an option can
+ * never end up unnamed; hiding it visually requires an icon to take its place.
+ */
+export type ToggleGroupOption = ToggleGroupLabelledOption | ToggleGroupIconOnlyOption;
+
+export interface ToggleGroupProps {
+	/** The selectable options, rendered left to right. */
+	options: ToggleGroupOption[];
+	/** Accessible name for the group. Required, as the control has no visible label. */
+	'aria-label': string;
+	/** The option selected on first render. Omit to start with nothing selected. */
+	defaultValue?: string;
+	/** The controlled selected value. Use together with `onValueChange`. */
+	value?: string;
+	/** Callback invoked when the selection changes. Never fires with an empty value. */
+	onValueChange?: ( value: string ) => void;
+	/**
+	 * Whether the whole group is disabled.
+	 * @default false
+	 */
+	disabled?: boolean;
+	/** Additional CSS class name(s) to apply to the root element. */
+	className?: Argument;
+	/** Theme UI style overrides for the root element. */
+	sx?: ThemeUIStyleObject;
+	/** Forwarded ref to the underlying root element. */
+	ref?: React.Ref< HTMLDivElement >;
+}
+
+const rootStyles: ThemeUIStyleObject = {
+	display: 'inline-flex',
+	alignItems: 'center',
+	padding: '2px',
+	backgroundColor: 'layer.1',
+	border: '1px solid',
+	borderColor: 'border',
+	borderRadius: 4,
+};
+
+const itemStyles = ( variant: ToggleGroupVariant ): ThemeUIStyleObject => ( {
+	appearance: 'none',
+	border: 'none',
+	cursor: 'pointer',
+	fontFamily: 'inherit',
+	fontSize: 0,
+	fontWeight: 'medium',
+	letterSpacing: '0.01em',
+	lineHeight: 1,
+	px: 3,
+	py: 2,
+	borderRadius: 4,
+	backgroundColor: 'transparent',
+	color: 'texts.secondary',
+	whiteSpace: 'nowrap',
+	display: 'inline-flex',
+	alignItems: 'center',
+	justifyContent: 'center',
+	gap: 2,
+	svg: {
+		display: 'block',
+		fill: 'currentColor',
+		width: '1rem',
+		height: '1rem',
+	},
+	transition: 'background-color 0.1s ease-in-out, color 0.1s ease-in-out',
+	'&[data-state="on"]': {
+		backgroundColor: `tag.${ variant }.background`,
+		color: `tag.${ variant }.text`,
+	},
+	'&:hover:not(:disabled):not([data-state="on"])': {
+		backgroundColor: 'hover',
+		color: 'heading',
+	},
+	'&:disabled': {
+		cursor: 'not-allowed',
+		color: 'muted',
+	},
+	'&:focus-visible': ( theme: ThemeProps ) => theme.outline,
+} );
+
+/**
+ * ToggleGroup — A set of mutually exclusive options rendered as a single segmented control.
+ * Each option carries its own color while selected, so the control can double as a status
+ * indicator. Once an option is selected the group always keeps exactly one active.
+ */
+export const ToggleGroup = ( {
+	options,
+	defaultValue = undefined,
+	value = undefined,
+	onValueChange = undefined,
+	disabled = false,
+	className = null,
+	sx,
+	ref,
+	...props
+}: ToggleGroupProps ) => {
+	const [ internalValue, setInternalValue ] = useState( defaultValue );
+	const selectedValue = value ?? internalValue;
+	const isArrowNavigating = useRef( false );
+
+	const handleValueChange = ( nextValue: string ) => {
+		// Radix clears the selection when the active option is clicked again. The group is
+		// sticky once chosen, so an empty value is dropped rather than reported.
+		if ( ! nextValue ) {
+			return;
+		}
+
+		setInternalValue( nextValue );
+		onValueChange?.( nextValue );
+	};
+
+	// Radix moves focus on arrow keys without selecting, but it renders the options as
+	// `role="radio"`, where the radio group pattern expects selection to follow focus.
+	// Tabbing in must not select, so only a focus that an arrow key caused counts.
+	const handleItemKeyDown = ( event: React.KeyboardEvent ) => {
+		isArrowNavigating.current = event.key.startsWith( 'Arrow' );
+	};
+
+	const handleItemFocus = ( optionValue: string ) => () => {
+		if ( ! isArrowNavigating.current ) {
+			return;
+		}
+
+		isArrowNavigating.current = false;
+		handleValueChange( optionValue );
+	};
+
+	return (
+		<ToggleGroupPrimitive.Root
+			type="single"
+			value={ selectedValue ?? '' }
+			onValueChange={ handleValueChange }
+			disabled={ disabled }
+			className={ classNames( 'vip-toggle-group-component', className ) }
+			sx={ { ...rootStyles, ...sx } }
+			ref={ ref }
+			{ ...props }
+		>
+			{ options.map(
+				( {
+					value: optionValue,
+					label,
+					icon,
+					hideLabel,
+					variant = 'gray',
+					disabled: optionDisabled = false,
+				} ) => (
+					<ToggleGroupPrimitive.Item
+						key={ optionValue }
+						value={ optionValue }
+						disabled={ optionDisabled }
+						onKeyDown={ handleItemKeyDown }
+						onFocus={ handleItemFocus( optionValue ) }
+						className={ classNames(
+							'vip-toggle-group-item',
+							`vip-toggle-group-item-${ optionValue }`
+						) }
+						sx={ itemStyles( variant ) }
+					>
+						{ icon }
+						{ hideLabel ? <ScreenReaderText>{ label }</ScreenReaderText> : label }
+					</ToggleGroupPrimitive.Item>
+				)
+			) }
+		</ToggleGroupPrimitive.Root>
+	);
+};
+
+ToggleGroup.displayName = 'ToggleGroup';

--- a/src/system/ToggleGroup/index.ts
+++ b/src/system/ToggleGroup/index.ts
@@ -1,0 +1,2 @@
+export { ToggleGroup } from './ToggleGroup';
+export type { ToggleGroupProps, ToggleGroupOption, ToggleGroupVariant } from './ToggleGroup';

--- a/src/system/index.ts
+++ b/src/system/index.ts
@@ -61,6 +61,7 @@ import { Spinner } from './Spinner';
 import { Table, TableRow, TableCell } from './Table';
 import { Tabs, TabsList, TabsContent, TabsTrigger } from './Tabs';
 import { Text } from './Text';
+import { ToggleGroup } from './ToggleGroup';
 import { Toolbar } from './Toolbar';
 import { Tooltip } from './Tooltip';
 import { Wizard, WizardStep } from './Wizard';
@@ -130,6 +131,7 @@ export {
 	TabsContent,
 	TabsList,
 	Toggle,
+	ToggleGroup,
 	ToggleRow,
 	Toolbar,
 	Snackbar,
@@ -141,3 +143,4 @@ export {
 };
 
 export type { ResultsSummaryProps } from './ResultsSummary';
+export type { ToggleGroupProps, ToggleGroupOption, ToggleGroupVariant } from './ToggleGroup';


### PR DESCRIPTION
## Description

<img width="315" height="73" alt="image" src="https://github.com/user-attachments/assets/90aa94d8-0061-4836-8413-677778799d9a" />

<img width="251" height="78" alt="image" src="https://github.com/user-attachments/assets/d150c82c-1d06-432c-abca-200bc99fc86b" />

<img width="175" height="73" alt="image" src="https://github.com/user-attachments/assets/9a0bb9ed-9c46-48f1-a2bc-f695b72b23dc" />


This pull request introduces a new `ToggleGroup` component to the system UI library, providing a segmented control for mutually exclusive options with color and accessibility support. The implementation includes the component itself, Storybook stories for documentation and demonstration, a comprehensive test suite, and the necessary exports and dependency updates for integration.

**Component Implementation:**

- Added the `ToggleGroup` component, supporting colored, accessible, and optionally icon-only options, with both controlled and uncontrolled selection modes.

**Documentation and Testing:**

- Added Storybook stories in `ToggleGroup.stories.tsx` to demonstrate usage, customization, and accessibility features of the `ToggleGroup` component.
- Added a test suite in `ToggleGroup.test.tsx` covering rendering, selection logic, accessibility, keyboard navigation, icon handling, and theming.

**Exports and Integration:**

- Exported `ToggleGroup` and its types from the component and system index files, making them available for use throughout the codebase. [[1]](diffhunk://#diff-6ef0480dcf05d22b4c88277d05659661149d0fb1d2247038766c1554b4b94c75R1-R2) [[2]](diffhunk://#diff-07a0c24db0eb95bfebacb9256a34e191bf4e627e88003bba0cd3e0740ac373f7R64) [[3]](diffhunk://#diff-07a0c24db0eb95bfebacb9256a34e191bf4e627e88003bba0cd3e0740ac373f7R134) [[4]](diffhunk://#diff-07a0c24db0eb95bfebacb9256a34e191bf4e627e88003bba0cd3e0740ac373f7R146)

**Dependencies:**

- Added `@radix-ui/react-toggle-group` as a new dependency to support the segmented control behavior.